### PR TITLE
fix(hit-list): avoid Google Sheets read quota on batch status promote

### DIFF
--- a/scripts/hit_list_dapp_remarks_sheet.py
+++ b/scripts/hit_list_dapp_remarks_sheet.py
@@ -8,11 +8,54 @@ and mark the remark **Processed** (same pattern as hit_list_research_photo_revie
 
 from __future__ import annotations
 
+import random
+import re
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 import gspread
+from gspread.exceptions import APIError
 from gspread.utils import rowcol_to_a1
+
+_APPEND_RANGE_ROW = re.compile(r"!A(\d+)(?::[A-Z]+(\d+))?", re.IGNORECASE)
+
+
+def _parse_row_from_append_response(res: dict) -> int | None:
+    """Parse Google Sheets values.append response for the first row of the appended range."""
+    if not res:
+        return None
+    upd = res.get("updates") or {}
+    r = upd.get("updatedRange") or res.get("updatedRange")
+    if not r:
+        return None
+    m = _APPEND_RANGE_ROW.search(str(r))
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _gspread_call_with_retry(fn, *, max_attempts: int = 5) -> object:
+    """Retry on Sheets 429 read/write quota (Read requests per minute per user)."""
+    delay = 2.0
+    # jitter so concurrent CI jobs don't stampede the same retry instant
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except APIError as e:
+            err = getattr(e, "response", None)
+            http = getattr(err, "status_code", None) if err is not None else None
+            # Google Sheets returns HTTP 429; error body may also include code 429.
+            if (http == 429 or getattr(e, "code", None) == 429) and attempt < max_attempts - 1:
+                time.sleep(delay + random.uniform(0, 1.5))
+                delay = min(delay * 1.8, 75.0)
+                continue
+            raise
+    raise RuntimeError("unreachable _gspread_call_with_retry")
+
+
+# Public alias for scripts that batch-read sheets (same backoff as DApp remark apply path).
+gspread_retry = _gspread_call_with_retry
 
 
 def append_sales_note(existing: str, note_line: str) -> str:
@@ -44,9 +87,17 @@ def apply_remark_to_hit_list(
     remarks: str,
     submitted_by: str,
     submitted_at: str,
+    *,
+    hit_headers: list[str] | None = None,
+    remark_row: int | None = None,
+    remark_headers: list[str] | None = None,
 ) -> None:
-    hit_vals = hit_ws.get_all_values()
-    headers = hit_vals[0]
+    # Prefer caller-supplied headers (one row read) or a single header row — never full-sheet
+    # get_all_values() here; batch promote runs hit the 60 reads/min quota otherwise.
+    if hit_headers is not None:
+        headers = hit_headers
+    else:
+        headers = _gspread_call_with_retry(lambda: hit_ws.row_values(1))
     hidx = {h: i for i, h in enumerate(headers)}
     for col in ("Status", "Sales Process Notes", "Status Updated By", "Status Updated Date"):
         if col not in hidx:
@@ -55,11 +106,13 @@ def apply_remark_to_hit_list(
     now_iso = datetime.now(timezone.utc).isoformat()
     note_prefix = f"[{submitted_at} | {submitted_by}]" if submitted_at else f"[{now_iso} | {submitted_by}]"
     note_line = f"{note_prefix} {remarks}"
-    existing_notes = hit_ws.cell(hit_row, hidx["Sales Process Notes"] + 1).value or ""
+    c_notes = hidx["Sales Process Notes"] + 1
+    existing_notes = _gspread_call_with_retry(
+        lambda: hit_ws.cell(hit_row, c_notes).value
+    ) or ""
     new_notes = append_sales_note(str(existing_notes), note_line)
 
     c_status = hidx["Status"] + 1
-    c_notes = hidx["Sales Process Notes"] + 1
     c_by = hidx["Status Updated By"] + 1
     c_dt = hidx["Status Updated Date"] + 1
 
@@ -73,10 +126,15 @@ def apply_remark_to_hit_list(
         value_input_option="USER_ENTERED",
     )
 
-    ridx_row = find_remark_row_by_submission(remark_ws, submission_id)
+    ridx_row = remark_row
+    if not ridx_row:
+        ridx_row = find_remark_row_by_submission(remark_ws, submission_id)
     if not ridx_row:
         raise RuntimeError(f"Could not find DApp Remarks row for submission {submission_id}")
-    r_headers = remark_ws.row_values(1)
+    if remark_headers is not None:
+        r_headers = remark_headers
+    else:
+        r_headers = _gspread_call_with_retry(lambda: remark_ws.row_values(1))
     ridx = {h: i for i, h in enumerate(r_headers)}
     remark_ws.batch_update(
         [
@@ -97,9 +155,14 @@ def append_dapp_remark_and_apply(
     submitted_by: str,
     submitted_at: str,
     submission_id: str,
+    *,
+    hit_headers: list[str] | None = None,
+    remark_headers: list[str] | None = None,
 ) -> None:
     """Append one DApp Remarks row and sync Status / Sales Process Notes on Hit List."""
-    r_headers = remark_ws.row_values(1)
+    r_headers = remark_headers if remark_headers is not None else _gspread_call_with_retry(
+        lambda: remark_ws.row_values(1)
+    )
     row_out: list[str] = []
     for h in r_headers:
         if h == "Submission ID":
@@ -120,7 +183,11 @@ def append_dapp_remark_and_apply(
             row_out.append("")
         else:
             row_out.append("")
-    remark_ws.append_row(row_out, value_input_option="USER_ENTERED")
+    append_res = _gspread_call_with_retry(
+        lambda: remark_ws.append_row(row_out, value_input_option="USER_ENTERED")
+    )
+    ar_dict: dict = dict(append_res) if isinstance(append_res, Mapping) else {}
+    remark_row = _parse_row_from_append_response(ar_dict)
     time.sleep(1.5)
     apply_remark_to_hit_list(
         hit_ws,
@@ -132,4 +199,7 @@ def append_dapp_remark_and_apply(
         remarks,
         submitted_by,
         submitted_at,
+        hit_headers=hit_headers,
+        remark_row=remark_row,
+        remark_headers=r_headers,
     )

--- a/scripts/hit_list_promote_status.py
+++ b/scripts/hit_list_promote_status.py
@@ -37,7 +37,7 @@ from pathlib import Path
 import gspread
 from google.oauth2.service_account import Credentials
 
-from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply
+from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply, gspread_retry
 
 REPO = Path(__file__).resolve().parents[1]
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
@@ -122,6 +122,8 @@ def run_shortlisted_to_enrich(
     ws: gspread.Worksheet,
     remark_ws: gspread.Worksheet,
     header: list[str],
+    rows: list[list[str]],
+    remark_headers: list[str],
     limit: int,
     dry_run: bool,
     require_website: bool,
@@ -132,7 +134,6 @@ def run_shortlisted_to_enrich(
     i_notes = col_idx(header, "Notes")
     i_website = col_idx(header, "Website")
     width = len(header)
-    rows = ws.get_all_values()
     if len(rows) < 2:
         print("No data rows.")
         return
@@ -193,6 +194,8 @@ def run_shortlisted_to_enrich(
             SUBMITTED_BY,
             submitted_at,
             str(uuid.uuid4()),
+            hit_headers=header,
+            remark_headers=remark_headers,
         )
         time.sleep(1.0)
 
@@ -203,6 +206,8 @@ def run_email_to_warmup(
     ws: gspread.Worksheet,
     remark_ws: gspread.Worksheet,
     header: list[str],
+    rows: list[list[str]],
+    remark_headers: list[str],
     limit: int,
     dry_run: bool,
     shop_filter: str | None,
@@ -211,7 +216,6 @@ def run_email_to_warmup(
     i_shop = col_idx(header, "Shop Name")
     i_email = col_idx(header, "Email")
     width = len(header)
-    rows = ws.get_all_values()
     if len(rows) < 2:
         print("No data rows.")
         return
@@ -277,6 +281,8 @@ def run_email_to_warmup(
             SUBMITTED_BY,
             submitted_at,
             str(uuid.uuid4()),
+            hit_headers=header,
+            remark_headers=remark_headers,
         )
         time.sleep(1.0)
 
@@ -325,11 +331,12 @@ def main() -> None:
     sh = gc.open_by_key(SPREADSHEET_ID)
     ws = sh.worksheet(HIT_LIST_WS)
     remark_ws = sh.worksheet(DAPP_REMARKS_WS)
-    rows = ws.get_all_values()
+    rows = gspread_retry(lambda: ws.get_all_values())
     if len(rows) < 2:
         print("No Hit List header/data.")
         sys.exit(0)
     header = rows[0]
+    remark_headers = gspread_retry(lambda: remark_ws.row_values(1))
 
     shop_filter = (args.shop or "").strip() or None
 
@@ -338,6 +345,8 @@ def main() -> None:
             ws,
             remark_ws,
             header,
+            rows,
+            remark_headers,
             args.limit,
             args.dry_run,
             args.require_website,
@@ -348,6 +357,8 @@ def main() -> None:
             ws,
             remark_ws,
             header,
+            rows,
+            remark_headers,
             args.limit,
             args.dry_run,
             shop_filter,


### PR DESCRIPTION
Fixes CI failures with `RESOURCE_EXHAUSTED` / 429 (Read requests per minute) when promoting many rows.

**Changes**
- `apply_remark_to_hit_list`: use a single header row (or caller-supplied headers) instead of `get_all_values()` on the full Hit List each time; after `append_row`, parse `updates.updatedRange` so we do not scan the entire DApp Remarks sheet to find the new row.
- `hit_list_promote_status.py`: pass cached Hit List `rows` and one `remark_headers` read from `main`; remove duplicate `get_all_values()` in the run functions.
- `gspread_retry`: backoff + jitter on HTTP 429 for Sheets calls.

Made with [Cursor](https://cursor.com)