### PR TITLE
fix(ci): quote hit_list_enrich_contact workflow_dispatch description

### DIFF
--- a/.github/workflows/hit_list_enrich_contact.yml
+++ b/.github/workflows/hit_list_enrich_contact.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: Max rows to process (Status AI: Enrich with contact only)
+        description: 'Max rows to process (Status AI: Enrich with contact only)'
         required: true
         default: "10"
       dry_run:


### PR DESCRIPTION
Fixes invalid workflow YAML: the `limit` input `description` contained unquoted `AI:`, which YAML parsed as a mapping.

**Change:** Quote the description string.

Validation: GitHub no longer reports a syntax error on line 14.

Made with [Cursor](https://cursor.com)