### PR TITLE
ci: field agent Places pull every hour

### DIFF
--- a/.github/workflows/field_agent_location_places_pull.yml
+++ b/.github/workflows/field_agent_location_places_pull.yml
@@ -17,8 +17,8 @@ on:
         required: false
         default: "false"
   schedule:
-    # Every 3 hours at :20 UTC (staggered from other Hit List jobs)
-    - cron: "20 */3 * * *"
+    # Every hour at :20 UTC (staggered from on-the-hour Hit List jobs)
+    - cron: "20 * * * *"
 
 concurrency:
   group: field-agent-location-places-pull


### PR DESCRIPTION
Runs **Field agent location Places pull** hourly at :20 UTC (was every 3 hours).

Workflow: `.github/workflows/field_agent_location_places_pull.yml`

Made with [Cursor](https://cursor.com)