### PR TITLE
Warmup email: Grok prompt and template (rainforest, QR, flexible paths)

### DIFF
--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -6,8 +6,9 @@ Gmail **drafts** for Hit List rows with Status = **AI: Warm up prospect** and Em
   while the Gmail draft exists; next draft only after **Email Agent Follow Up** shows a prior
   **sent** at least ``--min-days-since-sent`` ago (default **7**). Run **sync_email_agent_followup.py** first.
 - **Attachment:** ``retail_price_list/agroverse_wholesale_price_list_2026.pdf`` on each draft.
-- **Grok** (optional ``--use-grok``): first-touch intro; no in-person visit assumption; consignment + bulk paths;
-  style reference in ``templates/warmup_outreach_reference.md``.
+- **Grok** (optional ``--use-grok``): first-touch intro; no in-person visit assumption; flexible consignment or bulk;
+  lead with Amazon rainforest restoration (tree per bag, QR traceability); style reference in
+  ``templates/warmup_outreach_reference.md``.
 - **Reply promotion:** By default, before drafting, promotes rows to **AI: Prospect replied** when Gmail shows
   an **inbound** message **from** the prospect **after** the latest logged **sent_at** for that address in
   **Email Agent Follow Up**.
@@ -241,8 +242,16 @@ def grok_warmup_system_prompt() -> str:
         "- No markdown fences, no preamble.\n"
         "- **Do not** assume Gary is **in their city** or will **visit their shop**. No “stopping by,” "
         "**in-person meetings**, or return-visit framing. Prefer **email reply** or a **short call** they schedule.\n"
-        "- Acknowledge retailers differ: some prefer **consignment**, others prefer **bulk / wholesale purchase**. "
-        "Offer both paths briefly and neutrally.\n"
+        "- **Lead with mission impact:** purchases support **restoration of the Amazon rainforest**; **each bag "
+        "plants a new tree**, **directly traceable** via the **unique QR code on that bag** (keep this accurate "
+        "and prominent — at least one clear sentence early in the body).\n"
+        "- **Commercial fit:** say Agroverse is **flexible** and happy with **either** a **consignment-friendly** "
+        "retail path **or** **wholesale / bulk** — present them as **parallel options**, not as a contrast "
+        "(avoid lines like “while others choose wholesale for margins” or any implication that bulk is mainly "
+        "about beating other retailers’ choices).\n"
+        "- **Do not** assume, imply, or acknowledge that the shop **already carries cacao**, has their **own "
+        "cacao supplier**, or needs an “alongside what you stock” angle. Do not invite them to compare against "
+        "an existing cacao line you do not know they have.\n"
         "- State clearly that a **wholesale price list PDF is attached** (do not paste prices in the body unless "
         "already in context notes).\n"
         "- Salutation: use a natural greeting for the **shop** or a generic “Hi —” if no contact name is known.\n"
@@ -356,19 +365,21 @@ def build_message_raw_with_pdf(
 
 def warmup_subject_template(shop_name: str) -> str:
     s = (shop_name or "Intro").strip()
-    return f"Ceremonial cacao for {s} — wholesale options (PDF attached)"
+    return f"Ceremonial cacao for {s} — each bag plants a tree (PDF attached)"
 
 
 def warmup_body_template(shop_name: str) -> str:
     shop = shop_name or "your shop"
     return (
         f"Hi —\n\n"
-        f"I’m Gary with Agroverse (farm-linked ceremonial cacao). I’m reaching out to {shop} because "
-        f"I think your customers may appreciate a transparent, craft cacao option alongside what you already carry.\n\n"
-        f"Some retailers start with **consignment-friendly** terms; others prefer a **straight bulk order** when they "
-        f"know their velocity. I’ve attached our **wholesale price list PDF** so you can skim SKUs and tiers — "
-        f"no need to meet in person on my side; happy to answer by email or on a quick call if that’s easier.\n\n"
-        f"If you tell me which path fits you better (consignment vs bulk), I can point you to the lightest next step.\n\n"
+        f"I’m Gary with Agroverse (farm-linked ceremonial cacao). I’m reaching out to {shop} because our model ties "
+        f"every sale to **Amazon rainforest restoration**: **each bag plants a new tree**, and the **unique QR code "
+        f"on that bag** links to **direct traceability** for that planting.\n\n"
+        f"We’re **flexible on structure** — **either** **consignment-friendly** retail **or** **wholesale / bulk** "
+        f"works on our side; I’ve attached our **wholesale price list PDF** so you can skim SKUs and tiers. "
+        f"No need to meet in person on my side; happy to answer by email or on a quick call if that’s easier.\n\n"
+        f"If you tell me which path you’d rather explore first (consignment vs bulk), I can point you to the lightest "
+        f"next step.\n\n"
         f"Thanks,\n"
         f"Gary\n"
         f"Agroverse | ceremonial cacao for retail\n"

--- a/templates/warmup_outreach_reference.md
+++ b/templates/warmup_outreach_reference.md
@@ -6,18 +6,20 @@ Use as **style guide only** for AI-generated intros — do not copy sentences ve
 
 - **Retailer:** Independent metaphysical / spiritual shop (Santa Cruz area).
 - **Opening moves:** Manager asked about **consignment vs bulk purchase**; space on the floor; how Agroverse works with small retailers.
-- **Tone:** Warm, specific, **not** assuming the sender is local or will “stop by.” Everything actionable **by email** (or call if they offer a number). Offer both **consignment-friendly framing** and **straight bulk buy** with pricing clarity.
+- **Tone:** Warm, specific, **not** assuming the sender is local or will “stop by.” Everything actionable **by email** (or call if they offer a number). Say Agroverse is **flexible** with **either** consignment-friendly retail **or** wholesale/bulk — neutral parallel options, not “others buy bulk for margins.”
 - **Materials:** A **wholesale / price overview PDF** was offered or attached so they could compare unit economics without a meeting.
 - **Outcome:** Successful onboarding as a retailer — relationship built on clear options (consignment vs bulk) and respectful follow-through.
 
 ## Dos
 
-- Lead with **ceremonial cacao + farm / traceability** in one line.
-- Acknowledge their **shelf / risk** reality (consignment vs buying inventory).
-- Invite **reply by email** with what they prefer (consignment conversation vs bulk order path).
+- Lead with **support for Amazon rainforest restoration**: **each bag plants a new tree**, **traceable** via the **unique QR code on that bag**, plus **ceremonial cacao / farm link** in the same opening beat.
+- State clearly that Agroverse is **flexible** — **either** consignment-friendly terms **or** wholesale/bulk — without contrasting retailers or implying bulk is mainly for margin vs peers.
+- Invite **reply by email** with which path they want to explore first (consignment vs bulk).
 - Reference **attached wholesale price list** (PDF) as the place for SKUs and tiers.
 
 ## Don’ts
 
 - Don’t assume an **in-person visit**, “swinging by,” or that you’re **in their city**.
 - Don’t pressure for a **meeting at their shop** as the primary CTA.
+- Don’t assume they **already carry cacao** or have an existing cacao line; no “alongside what you already stock” unless factual context explicitly says so.
+- Don’t frame **wholesale vs consignment** as what “other shops” do for **margins** or competitive advantage.


### PR DESCRIPTION
Updates the Hit List warmup flow for `suggest_warmup_prospect_drafts.py` and `templates/warmup_outreach_reference.md`.

- Grok system prompt: lead with Amazon rainforest restoration, one tree per bag, traceability via the bag QR code; present consignment vs wholesale as parallel flexible options; explicitly avoid assuming the shop already carries cacao or framing bulk as a margins-vs-peers choice.
- Fallback subject/body template aligned with the same positioning.
- Style reference markdown updated to match.

Made with [Cursor](https://cursor.com)