### PR TITLE
Hit List: Google listing, Places backfills, GAS mirror sync

### DIFF
--- a/physical_stores/find_nearby_stores.gs
+++ b/physical_stores/find_nearby_stores.gs
@@ -28,6 +28,19 @@
  *   shop_type=<string>    : Filter by shop type (optional)
  *                           Valid values: "Metaphysical/Spiritual", "Wellness Center", "Health Food Store", etc.
  *                           Use empty string "" or omit parameter to show all shop types
+ *   save_location=true    : When present with a valid lat/lng search, append one row to the
+ *                           "Recent Field Agent Location" tab (Status=pending) for Python automation.
+ *                           Requires digital_signature (or submitted_by) when save_location is enabled.
+ *                           Response may include field_agent_location: { saved, location_id?, reason? }.
+ *   open_now=true         : When present, only return stores that appear open at the viewer's
+ *                           local wall-clock time in time zone ``tz`` (IANA), e.g. America/Los_Angeles.
+ *                           Requires ``tz`` when ``open_now`` is enabled. Rows missing hour cells for
+ *                           that weekday are excluded. Hours use columns Monday Open … Sunday Close
+ *                           (24h HH:MM as written by Places automation / the DApp). Rows whose
+ *                           **Google listing** cell is **Closed** (permanently closed on Google) are
+ *                           always excluded when ``open_now`` is enabled.
+ *   tz=<IANA>             : Time zone for open_now (e.g. America/Los_Angeles). Defaults to script
+ *                           time zone when open_now is set but tz is omitted.
  * 
  * Query parameters (for status update):
  *   action=update_status     : Action to update store status
@@ -96,6 +109,149 @@
 const SPREADSHEET_ID = '1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc';
 const SHEET_NAME = 'Hit List';
 const DAPP_REMARKS_SHEET = 'DApp Remarks';
+/** Tab for DApp “field agent was here” pings (Python automation reads Status). */
+const RECENT_FIELD_AGENT_SHEET = 'Recent Field Agent Location';
+const FIELD_AGENT_STATUS_PENDING = 'pending';
+
+/** Hit List weekday hour columns (Monday … Sunday; open/close pairs, 24h HH:MM). */
+const HIT_LIST_OPENING_HOUR_HEADERS = [
+  'Monday Open', 'Monday Close',
+  'Tuesday Open', 'Tuesday Close',
+  'Wednesday Open', 'Wednesday Close',
+  'Thursday Open', 'Thursday Close',
+  'Friday Open', 'Friday Close',
+  'Saturday Open', 'Saturday Close',
+  'Sunday Open', 'Sunday Close'
+];
+
+/** Hit List column: Google ``business_status`` as sheet text (e.g. **Closed** = permanently closed). */
+const GOOGLE_LISTING_HEADER = 'Google listing';
+
+/**
+ * Sheets often returns times as Date (1899-12-30 wall clock) or as a day-fraction number.
+ * Open-now parsing expects "HH:mm" text; this normalizes before parseHmToMinutes_.
+ * @param {*} raw Cell value from getValues()
+ * @param {string} sheetTz Spreadsheet time zone from spreadsheet.getSpreadsheetTimeZone()
+ * @return {string}
+ */
+function normalizeHourCellToHmString_(raw, sheetTz) {
+  if (raw === null || raw === undefined || raw === '') {
+    return '';
+  }
+  var tz = sheetTz || Session.getScriptTimeZone();
+  if (Object.prototype.toString.call(raw) === '[object Date]') {
+    var d = /** @type {Date} */ (raw);
+    if (isNaN(d.getTime())) {
+      return '';
+    }
+    return Utilities.formatDate(d, tz, 'HH:mm');
+  }
+  if (typeof raw === 'number' && isFinite(raw)) {
+    var frac = raw;
+    if (frac < 0) {
+      return '';
+    }
+    if (frac >= 1) {
+      frac = frac - Math.floor(frac);
+    }
+    var totalMinutes = Math.round(frac * 24 * 60);
+    if (totalMinutes >= 24 * 60) {
+      totalMinutes = totalMinutes % (24 * 60);
+    }
+    if (totalMinutes < 0) {
+      totalMinutes = 0;
+    }
+    var hh = Math.floor(totalMinutes / 60);
+    var mm = totalMinutes % 60;
+    return (hh < 10 ? '0' : '') + hh + ':' + (mm < 10 ? '0' : '') + mm;
+  }
+  return String(raw).trim();
+}
+
+/**
+ * @param {string} s
+ * @return {number|null} minutes since midnight
+ */
+function parseHmToMinutes_(s) {
+  var t = String(s || '').trim();
+  if (!t) {
+    return null;
+  }
+  var m = t.match(/^([01]?\d|2[0-3]):([0-5]\d)$/);
+  if (!m) {
+    return null;
+  }
+  return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+}
+
+/**
+ * ISO weekday in time zone: 1=Monday … 7=Sunday (Java ``u`` pattern).
+ * @param {string} timeZone
+ * @return {{u:number, minutes:number}}
+ */
+function localWallClockFromTz_(timeZone) {
+  var now = new Date();
+  var u = parseInt(Utilities.formatDate(now, timeZone, 'u'), 10);
+  var hm = Utilities.formatDate(now, timeZone, 'HH:mm');
+  var parts = hm.split(':');
+  var minutes = parseInt(parts[0], 10) * 60 + parseInt(parts[1], 10);
+  return { u: u, minutes: minutes };
+}
+
+/**
+ * @param {Array} row
+ * @param {Object} headerIndex map header -> 0-based column index
+ * @param {string} viewerTimeZone IANA time zone for "now" (e.g. America/Los_Angeles)
+ * @param {string} sheetTz Spreadsheet time zone for interpreting time-typed cells
+ * @return {boolean}
+ */
+function isHitListRowOpenNow_(row, headerIndex, viewerTimeZone, sheetTz) {
+  var ctx = localWallClockFromTz_(viewerTimeZone);
+  var u = ctx.u;
+  var nowM = ctx.minutes;
+  // u: 1 Mon .. 6 Sat, 7 Sun -> pair start index in HIT_LIST_OPENING_HOUR_HEADERS
+  var pairStart = (u === 7) ? 12 : (u - 1) * 2;
+  var openH = HIT_LIST_OPENING_HOUR_HEADERS[pairStart];
+  var closeH = HIT_LIST_OPENING_HOUR_HEADERS[pairStart + 1];
+  var oi = headerIndex[openH];
+  var ci = headerIndex[closeH];
+  var oRaw = (oi >= 0 && oi < row.length) ? row[oi] : '';
+  var cRaw = (ci >= 0 && ci < row.length) ? row[ci] : '';
+  var oS = normalizeHourCellToHmString_(oRaw, sheetTz);
+  var cS = normalizeHourCellToHmString_(cRaw, sheetTz);
+  if (!oS) {
+    return false;
+  }
+  var openM = parseHmToMinutes_(oS);
+  if (openM === null) {
+    return false;
+  }
+  if (!cS) {
+    return nowM >= openM;
+  }
+  var closeM = parseHmToMinutes_(cS);
+  if (closeM === null) {
+    return nowM >= openM;
+  }
+  if (closeM < openM) {
+    return nowM >= openM || nowM <= closeM;
+  }
+  return nowM >= openM && nowM <= closeM;
+}
+
+/**
+ * @param {Array} row
+ * @param {Object} headerIndex map header -> 0-based column index
+ * @return {boolean} True when the sheet marks this row as permanently closed on Google.
+ */
+function isHitListRowPermanentlyClosed_(row, headerIndex) {
+  var hi = headerIndex[GOOGLE_LISTING_HEADER];
+  if (hi === undefined || hi === null || hi < 0) {
+    return false;
+  }
+  var v = String((row[hi] || '')).trim().toLowerCase();
+  return v === 'closed';
+}
 
 /**
  * Calculate distance between two points using Haversine formula
@@ -193,9 +349,10 @@ function isWithinBounds(lat, lng, neLat, neLng, swLat, swLng) {
  * @param {Array<string>|null} statusFilters - Filter by store status(es) (default: ["Contacted"]). Use null or empty array to show all statuses
  * @param {Object|null} bounds - Optional bounds object with neLat, neLng, swLat, swLng to filter stores by visible area
  * @param {Array<string>|null} shopTypeFilters - Filter by shop type(s) (optional). Use null or empty array to show all shop types
+ * @param {{enabled:boolean,timeZone:string}|null} openNowFilter When enabled, only rows open at local wall time in timeZone.
  * @return {Array} Array of store objects with distance
  */
-function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTypeFilters) {
+function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTypeFilters, openNowFilter) {
   // If statusFilters is null, undefined, or empty array, it means show all statuses
   if (statusFilters === undefined || statusFilters === null) {
     statusFilters = null; // Show all
@@ -214,6 +371,9 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
   } else if (!Array.isArray(shopTypeFilters)) {
     shopTypeFilters = [shopTypeFilters];
   }
+  if (openNowFilter === undefined) {
+    openNowFilter = null;
+  }
   try {
     // Open the spreadsheet
     const spreadsheet = SpreadsheetApp.openById(SPREADSHEET_ID);
@@ -222,6 +382,11 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
     if (!sheet) {
       throw new Error(`Sheet "${SHEET_NAME}" not found`);
     }
+
+    ensureHitListOpeningHourColumns_(sheet);
+    ensureHitListGoogleListingColumn_(sheet);
+
+    const sheetTz = spreadsheet.getSpreadsheetTimeZone();
     
     // Get all data
     const data = sheet.getDataRange().getValues();
@@ -231,6 +396,10 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
     
     // Find column indices
     const headers = data[0];
+    const headerIndex = {};
+    headers.forEach(function (h, idx) {
+      headerIndex[String(h || '').trim()] = idx;
+    });
     const shopNameIdx = headers.indexOf("Shop Name");
     const statusIdx = headers.indexOf("Status");
     const latIdx = headers.indexOf("Latitude");
@@ -339,6 +508,15 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
       
       // Calculate distance
       const distance = calculateDistance(userLat, userLng, storeLat, storeLng);
+
+      if (openNowFilter && openNowFilter.enabled && openNowFilter.timeZone) {
+        if (isHitListRowPermanentlyClosed_(row, headerIndex)) {
+          continue;
+        }
+        if (!isHitListRowOpenNow_(row, headerIndex, openNowFilter.timeZone, sheetTz)) {
+          continue;
+        }
+      }
       
       // Build store object with all available fields
       const store = {
@@ -366,10 +544,26 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
         visit_date: visitDateIdx >= 0 ? (row[visitDateIdx] || "") : "",
         outcome: outcomeIdx >= 0 ? (row[outcomeIdx] || "") : "",
         sales_process_notes: salesNotesIdx >= 0 ? (row[salesNotesIdx] || "") : "",
+        google_listing: (function () {
+          var gli = headerIndex.hasOwnProperty(GOOGLE_LISTING_HEADER) ? headerIndex[GOOGLE_LISTING_HEADER] : -1;
+          if (gli < 0 || gli >= row.length) {
+            return '';
+          }
+          return String(row[gli] || '').trim();
+        })(),
         latitude: storeLat,
         longitude: storeLng,
         distance: Math.round(distance * 10) / 10 // Round to 1 decimal place
       };
+
+      HIT_LIST_OPENING_HOUR_HEADERS.forEach(function (hh) {
+        var di = headerIndex[hh];
+        var key = String(hh || '').trim().toLowerCase().replace(/\s+/g, '_');
+        if (key) {
+          var rawCell = di >= 0 && di < row.length ? row[di] : '';
+          store[key] = normalizeHourCellToHmString_(rawCell, sheetTz);
+        }
+      });
       
       stores.push(store);
     }
@@ -384,6 +578,83 @@ function findNearbyStores(userLat, userLng, limit, statusFilters, bounds, shopTy
     Logger.log("Error in findNearbyStores: " + error.toString());
     throw error;
   }
+}
+
+/**
+ * Ensure “Recent Field Agent Location” exists with expected headers.
+ * @param {GoogleAppsScript.Spreadsheet.Spreadsheet} spreadsheet
+ * @return {GoogleAppsScript.Spreadsheet.Sheet}
+ */
+function ensureRecentFieldAgentLocationSheet_(spreadsheet) {
+  let sheet = spreadsheet.getSheetByName(RECENT_FIELD_AGENT_SHEET);
+  const headers = [
+    'Logged At',
+    'Latitude',
+    'Longitude',
+    'Digital Signature',
+    'Location ID',
+    'Status'
+  ];
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(RECENT_FIELD_AGENT_SHEET);
+    sheet.appendRow(headers);
+    return sheet;
+  }
+
+  const lastRow = sheet.getLastRow();
+  const lastCol = Math.max(sheet.getLastColumn(), headers.length);
+  const firstRow = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  const row1Blank = firstRow.every(function (cell) {
+    return String(cell || '').trim() === '';
+  });
+
+  // Tab exists but has no header row yet (completely empty sheet is common).
+  if (lastRow === 0 || row1Blank) {
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    return sheet;
+  }
+
+  const matches = headers.every(function (h, i) {
+    return String(firstRow[i] || '').trim() === h;
+  });
+  if (matches) {
+    return sheet;
+  }
+
+  // Row 1 has text but not our canonical headers (e.g. placeholders or different labels).
+  // Safe to overwrite only when there is no data in row 2+.
+  if (lastRow <= 1) {
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    return sheet;
+  }
+
+  throw new Error(
+    'Sheet "' + RECENT_FIELD_AGENT_SHEET + '" row 1 must be exactly: ' + headers.join(', ') +
+      '. Fix row 1 in the spreadsheet, or move existing rows down so row 1 can be the header row.'
+  );
+}
+
+/**
+ * Append one field-agent location row (Status pending for downstream Python).
+ * @param {number} lat
+ * @param {number} lng
+ * @param {string} digitalSignature
+ * @return {string} Location ID (UUID)
+ */
+function appendFieldAgentLocation_(lat, lng, digitalSignature) {
+  const spreadsheet = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ensureRecentFieldAgentLocationSheet_(spreadsheet);
+  const locationId = Utilities.getUuid();
+  const now = new Date();
+  sheet.appendRow([
+    now,
+    lat,
+    lng,
+    digitalSignature || '',
+    locationId,
+    FIELD_AGENT_STATUS_PENDING
+  ]);
+  return locationId;
 }
 
 function ensureDappRemarksSheet_(spreadsheet) {
@@ -630,6 +901,39 @@ function updateStoreStatus(shopName, newStatus, digitalSignature, remarks, submi
   }
 }
 
+function ensureHitListOpeningHourColumns_(sheet) {
+  var lastCol = sheet.getLastColumn();
+  var headers = sheet.getRange(1, 1, 1, Math.max(lastCol, 1)).getValues()[0];
+  var missing = [];
+  HIT_LIST_OPENING_HOUR_HEADERS.forEach(function (h) {
+    if (headers.indexOf(h) === -1) {
+      missing.push(h);
+    }
+  });
+  if (!missing.length) {
+    return;
+  }
+  var nextCol = sheet.getLastColumn() + 1;
+  sheet.getRange(1, nextCol, 1, nextCol + missing.length - 1).setValues([missing]);
+}
+
+/**
+ * Ensure **Google listing** column exists (Place business status summary for the DApp).
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ */
+function ensureHitListGoogleListingColumn_(sheet) {
+  var lastCol = sheet.getLastColumn();
+  var headers = sheet.getRange(1, 1, 1, Math.max(lastCol, 1)).getValues()[0];
+  var trimmed = headers.map(function (h) {
+    return String(h || '').trim();
+  });
+  if (trimmed.indexOf(GOOGLE_LISTING_HEADER) !== -1) {
+    return;
+  }
+  var nextCol = sheet.getLastColumn() + 1;
+  sheet.getRange(1, nextCol).setValue(GOOGLE_LISTING_HEADER);
+}
+
 function addNewStore(storeData) {
   const spreadsheet = SpreadsheetApp.openById(SPREADSHEET_ID);
   const sheet = spreadsheet.getSheetByName(SHEET_NAME);
@@ -648,6 +952,11 @@ function addNewStore(storeData) {
     data = sheet.getDataRange().getValues();
     headers = data[0];
   }
+
+  ensureHitListOpeningHourColumns_(sheet);
+  ensureHitListGoogleListingColumn_(sheet);
+  data = sheet.getDataRange().getValues();
+  headers = data[0];
 
   const headerIndex = {};
   headers.forEach((header, idx) => {
@@ -747,6 +1056,17 @@ function addNewStore(storeData) {
   setValue('Status Updated Date', now);
   setValue('Store Key', storeKey);
 
+  HIT_LIST_OPENING_HOUR_HEADERS.forEach(function (h) {
+    var k = String(h || '').trim().toLowerCase().replace(/\s+/g, '_');
+    if (k && storeData[k]) {
+      setValue(h, storeData[k]);
+    }
+  });
+
+  if (storeData.google_listing) {
+    setValue(GOOGLE_LISTING_HEADER, storeData.google_listing);
+  }
+
   sheet.appendRow(row);
 
   const submissionId = logDappSubmission_(spreadsheet, storeData.shopName, storeData.status, storeData.remarks, submittedBy, true);
@@ -792,6 +1112,15 @@ function doGet(e) {
         longitude: (e.parameter.longitude || '').trim(),
         submittedBy: (e.parameter.submitted_by || e.parameter.digital_signature || '').trim()
       };
+
+      HIT_LIST_OPENING_HOUR_HEADERS.forEach(function (h) {
+        var k = String(h || '').trim().toLowerCase().replace(/\s+/g, '_');
+        if (k) {
+          storeData[k] = (e.parameter[k] || '').trim();
+        }
+      });
+
+      storeData.google_listing = (e.parameter.google_listing || '').trim();
 
       let salesNotes = '';
       if (storeData.remarks) {
@@ -878,7 +1207,7 @@ function doGet(e) {
     const statusRegex = /[&?]status=([^&]*)/g;
     let match;
     while ((match = statusRegex.exec(queryString)) !== null) {
-      const value = decodeURIComponent(match[1].replace(/\+/g, ' ')).trim();
+      const value = decodeURIComponent(match[1].replace(/\+/g, ' '));
       if (value && value !== "" && value !== "All") {
         statusMatches.push(value);
       }
@@ -973,20 +1302,53 @@ function doGet(e) {
         }))
         .setMimeType(ContentService.MimeType.JSON);
     }
+
+    /** Optional: log signed contributor location for automation (see Recent Field Agent Location). */
+    let fieldAgentLocation = undefined;
+    const saveLocRaw = String(e.parameter.save_location || '').toLowerCase();
+    if (saveLocRaw === 'true' || saveLocRaw === '1') {
+      const ds = (e.parameter.digital_signature || e.parameter.submitted_by || '').trim();
+      if (!ds) {
+        fieldAgentLocation = { saved: false, reason: 'missing digital_signature' };
+      } else {
+        try {
+          const locationId = appendFieldAgentLocation_(lat, lng, ds);
+          fieldAgentLocation = { saved: true, location_id: locationId };
+        } catch (locErr) {
+          Logger.log('appendFieldAgentLocation_: ' + locErr.toString());
+          fieldAgentLocation = { saved: false, reason: String(locErr) };
+        }
+      }
+    }
     
+    const openNowRaw = String(e.parameter.open_now || '').toLowerCase();
+    const openNowEnabled = openNowRaw === 'true' || openNowRaw === '1';
+    const openNowTz = (e.parameter.tz || e.parameter.time_zone || Session.getScriptTimeZone() || 'Etc/UTC').trim();
+    let openNowFilter = null;
+    if (openNowEnabled) {
+      openNowFilter = { enabled: true, timeZone: openNowTz };
+    }
+
     // Find nearby stores
-    const stores = findNearbyStores(lat, lng, limit, statusFilters, bounds, shopTypeFilters);
-    
+    const stores = findNearbyStores(lat, lng, limit, statusFilters, bounds, shopTypeFilters, openNowFilter);
+
+    const payload = {
+      success: true,
+      location: { latitude: lat, longitude: lng },
+      status_filters: statusFilters || [],
+      shop_type_filters: shopTypeFilters || [],
+      open_now: !!openNowFilter,
+      open_now_tz: openNowFilter ? openNowTz : '',
+      count: stores.length,
+      stores: stores
+    };
+    if (fieldAgentLocation !== undefined) {
+      payload.field_agent_location = fieldAgentLocation;
+    }
+
     // Return JSON response
     return ContentService
-      .createTextOutput(JSON.stringify({
-        success: true,
-        location: { latitude: lat, longitude: lng },
-        status_filters: statusFilters || [],
-        shop_type_filters: shopTypeFilters || [],
-        count: stores.length,
-        stores: stores
-      }))
+      .createTextOutput(JSON.stringify(payload))
       .setMimeType(ContentService.MimeType.JSON);
       
   } catch (error) {
@@ -1053,7 +1415,7 @@ function testFindNearbyStores() {
     Logger.log("");
   
     try {
-      const stores = findNearbyStores(lat, lng, limit, testCase.status);
+      const stores = findNearbyStores(lat, lng, limit, testCase.status, null, null, null);
     
       Logger.log("✅ Test successful!");
       Logger.log("Found " + stores.length + " stores");

--- a/scripts/backfill_hit_list_google_listing.py
+++ b/scripts/backfill_hit_list_google_listing.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Backfill the Hit List **Google listing** column from Google Place Details ``business_status``.
+
+- **Closed** → ``CLOSED_PERMANENTLY``
+- **Temporarily closed** → ``CLOSED_TEMPORARILY``
+- Empty → operational or unknown
+
+Requires ``place_id`` in **Notes** (same convention as other Hit List scripts), unless
+``--resolve-missing-place-id`` is used (shares Find Place logic with opening-hours backfill).
+
+Usage:
+  cd market_research
+  python3 scripts/backfill_hit_list_google_listing.py --dry-run --limit 50
+  python3 scripts/backfill_hit_list_google_listing.py --limit 500 --sleep-write 1.2
+  python3 scripts/backfill_hit_list_google_listing.py --resolve-missing-place-id --limit 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+from gspread.utils import rowcol_to_a1
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import backfill_hit_list_opening_hours as bl  # noqa: E402
+import discover_apothecaries_la_hit_list as dl  # noqa: E402
+
+PID_RE = re.compile(r"(?i)place[_\s-]*id\s*:\s*([A-Za-z0-9_-]{12,})")
+
+
+def col_index(header: list[str], name: str) -> int:
+    try:
+        return header.index(name)
+    except ValueError:
+        return -1
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Backfill Hit List Google listing from Places business_status.")
+    p.add_argument("--limit", type=int, default=500, help="Max rows updated this run.")
+    p.add_argument("--sleep-details", type=float, default=0.08, help="Seconds between Place Details calls.")
+    p.add_argument(
+        "--sleep-write",
+        type=float,
+        default=1.2,
+        help="Seconds after each sheet write (reduces 429s). Default 1.2.",
+    )
+    p.add_argument("--force", action="store_true", help="Overwrite non-empty Google listing cells.")
+    p.add_argument(
+        "--resolve-missing-place-id",
+        action="store_true",
+        help="Use Find Place from Text when Notes has no place_id.",
+    )
+    p.add_argument("--find-radius-m", type=float, default=50000.0, help="Find Place locationbias radius (m).")
+    p.add_argument("--dry-run", action="store_true", help="Do not write the sheet.")
+    args = p.parse_args()
+
+    key = dl.maps_api_key()
+    gc = dl.gspread_client()
+    ws = gc.open_by_key(dl.SPREADSHEET_ID).worksheet(dl.HIT_LIST_WS)
+    rows = ws.get_all_values()
+    if len(rows) < 2:
+        print("Hit List has no data rows.", flush=True)
+        return
+
+    header = [str(x or "").strip() for x in rows[0]]
+    if dl.GOOGLE_LISTING_COL not in header:
+        c = len(header) + 1
+        if not args.dry_run:
+            if ws.col_count < c:
+                ws.add_cols(c - ws.col_count)
+            ws.update_cell(1, c, dl.GOOGLE_LISTING_COL)
+            time.sleep(max(0.0, args.sleep_write))
+        header.append(dl.GOOGLE_LISTING_COL)
+        print(f"Added header {dl.GOOGLE_LISTING_COL!r} at column {c}.", flush=True)
+
+    idx_notes = col_index(header, "Notes")
+    idx_gl = col_index(header, dl.GOOGLE_LISTING_COL)
+    if idx_notes < 0 or idx_gl < 0:
+        raise SystemExit("Hit List must have Notes and Google listing columns.")
+
+    updated = 0
+    skipped = 0
+    notes_appended = 0
+
+    for r_idx, row in enumerate(rows[1:], start=2):
+        if updated >= args.limit:
+            break
+
+        notes = row[idx_notes] if idx_notes < len(row) else ""
+        cur = (row[idx_gl] if idx_gl < len(row) else "").strip()
+        if cur and not args.force:
+            skipped += 1
+            continue
+
+        m = PID_RE.search(notes or "")
+        pid: str | None = m.group(1).strip() if m else None
+
+        if not pid and args.resolve_missing_place_id:
+            q = bl.build_find_query(row, header)
+            if not q:
+                skipped += 1
+                continue
+            pid, reason = bl.resolve_place_id(key, row, header, radius_m=args.find_radius_m)
+            time.sleep(max(0.0, args.sleep_details))
+            if not pid:
+                print(f"Row {r_idx}: could not resolve place_id ({reason}) query={q!r}", flush=True)
+                skipped += 1
+                continue
+            new_notes = bl.append_place_id_to_notes(notes, pid)
+            if new_notes != (notes or "") and not args.dry_run:
+                ncell = rowcol_to_a1(r_idx, idx_notes + 1)
+                ws.update(range_name=ncell, values=[[new_notes]], value_input_option="USER_ENTERED")
+                notes = new_notes
+                notes_appended += 1
+                print(f"Row {r_idx}: appended place_id to Notes ({pid})", flush=True)
+                time.sleep(max(0.0, args.sleep_write))
+            elif new_notes != (notes or "") and args.dry_run:
+                print(f"Row {r_idx}: dry-run would append place_id ({pid})", flush=True)
+        elif not pid:
+            skipped += 1
+            continue
+
+        det = dl.place_details(key, pid)
+        time.sleep(max(0.0, args.sleep_details))
+        if det.get("status") != "OK":
+            print(f"Row {r_idx}: Details not OK for place_id={pid!r}", flush=True)
+            skipped += 1
+            continue
+
+        res = det.get("result") or {}
+        label = dl.google_listing_from_business_status(res.get("business_status"))
+
+        if args.dry_run:
+            print(f"Row {r_idx}: dry-run would set Google listing={label!r} ({pid})", flush=True)
+            updated += 1
+            continue
+
+        cell = rowcol_to_a1(r_idx, idx_gl + 1)
+        ws.update(range_name=cell, values=[[label]], value_input_option="USER_ENTERED")
+        print(f"Row {r_idx}: Google listing={label!r} ({pid})", flush=True)
+        updated += 1
+        time.sleep(max(0.0, args.sleep_write))
+
+    print(
+        f"Done. rows_updated={updated} notes_place_id_appended={notes_appended} "
+        f"skipped={skipped} dry_run={args.dry_run}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_hit_list_opening_hours.py
+++ b/scripts/backfill_hit_list_opening_hours.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Backfill **Monday Open … Sunday Close** on the Hit List from Google Place Details.
+
+1) **Notes contain ``place_id: …``** (discovery convention): Details + hour columns.
+
+2) With **``--resolve-missing-place-id``**: rows **without** that token use **Find Place from Text**
+   (shop name + address + city + state), biased by row **Latitude/Longitude** when present, to obtain
+   a ``place_id``. The script appends ``place_id: …`` to **Notes**, then writes hours when Google
+   returns ``opening_hours``.
+
+Requires:
+  - ``market_research/.env`` with ``GOOGLE_MAPS_API_KEY`` or ``GOOGLE_PLACES_API_KEY``
+  - ``market_research/google_credentials.json`` (Editor on the Hit List workbook)
+
+Usage:
+  cd market_research
+  python3 scripts/backfill_hit_list_opening_hours.py --dry-run --limit 20
+  python3 scripts/backfill_hit_list_opening_hours.py --limit 200
+  python3 scripts/backfill_hit_list_opening_hours.py --resolve-missing-place-id --dry-run --limit 15
+  python3 scripts/backfill_hit_list_opening_hours.py --resolve-missing-place-id --limit 30 --find-radius-m 25000
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+from gspread.utils import rowcol_to_a1
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import discover_apothecaries_la_hit_list as dl  # noqa: E402
+
+PID_RE = re.compile(r"(?i)place[_\s-]*id\s*:\s*([A-Za-z0-9_-]{12,})")
+
+
+def col_index(header: list[str], name: str) -> int:
+    try:
+        return header.index(name)
+    except ValueError:
+        return -1
+
+
+def cell_at(row: list[str], idx: int) -> str:
+    if idx < 0 or idx >= len(row):
+        return ""
+    return str(row[idx] or "").strip()
+
+
+def row_lat_lng(row: list[str], header: list[str]) -> tuple[float | None, float | None]:
+    li = col_index(header, "Latitude")
+    gi = col_index(header, "Longitude")
+    if li < 0 or gi < 0:
+        return None, None
+    ls, gs = cell_at(row, li), cell_at(row, gi)
+    if not ls or not gs:
+        return None, None
+    try:
+        return float(ls), float(gs)
+    except ValueError:
+        return None, None
+
+
+def build_find_query(row: list[str], header: list[str]) -> str | None:
+    name = cell_at(row, col_index(header, "Shop Name"))
+    if not name:
+        return None
+    addr = cell_at(row, col_index(header, "Address"))
+    city = cell_at(row, col_index(header, "City"))
+    state = cell_at(row, col_index(header, "State"))
+    parts = [name]
+    if addr:
+        parts.append(addr)
+    if city:
+        parts.append(city)
+    if state:
+        parts.append(state)
+    if len(parts) == 1 and not city and not state and not addr:
+        return name
+    return ", ".join(parts)
+
+
+def append_place_id_to_notes(notes: str, pid: str) -> str:
+    """Append a dedupe-friendly ``place_id:`` line without removing existing text."""
+    raw = notes or ""
+    if PID_RE.search(raw):
+        return raw
+    tag = f"place_id: {pid}"
+    tail = f"{tag} (auto-resolved from shop name/address)."
+    stripped = raw.rstrip()
+    if not stripped:
+        return tail
+    return f"{stripped}\n{tail}"
+
+
+def resolve_place_id(
+    key: str,
+    row: list[str],
+    header: list[str],
+    *,
+    radius_m: float,
+) -> tuple[str | None, str]:
+    q = build_find_query(row, header)
+    if not q:
+        return None, "missing_query"
+    lat, lng = row_lat_lng(row, header)
+    try:
+        data = dl.find_place_from_text(key, q, lat, lng, radius_m=radius_m)
+    except Exception as exc:
+        return None, f"find_place_error:{exc}"
+    st = data.get("status") or ""
+    if st != "OK":
+        return None, f"find_place_{st}"
+    cands = data.get("candidates") or []
+    if not cands:
+        return None, "zero_results"
+    pid = (cands[0].get("place_id") or "").strip()
+    if not pid:
+        return None, "empty_place_id"
+    return pid, "ok"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Backfill Hit List opening hour columns from Places.")
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max Hit List rows that receive an opening-hours write (or dry-run preview) this run. "
+        "Note-only appends from --resolve-missing-place-id do not count toward this cap.",
+    )
+    p.add_argument("--sleep-details", type=float, default=0.08, help="Seconds between Places API calls.")
+    p.add_argument(
+        "--sleep-write",
+        type=float,
+        default=1.2,
+        help="Seconds after each sheet write batch (reduces Sheets write 429s). Default 1.2.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Update hour columns even if some weekday cells are already non-empty.",
+    )
+    p.add_argument(
+        "--resolve-missing-place-id",
+        action="store_true",
+        help="Use Find Place from Text when Notes has no place_id (needs Shop Name + some location text).",
+    )
+    p.add_argument(
+        "--find-radius-m",
+        type=float,
+        default=50000.0,
+        help="locationbias circle radius in meters when row has lat/lng (default 50000).",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print actions only; do not write the sheet.")
+    args = p.parse_args()
+
+    key = dl.maps_api_key()
+    gc = dl.gspread_client()
+    ws = gc.open_by_key(dl.SPREADSHEET_ID).worksheet(dl.HIT_LIST_WS)
+    rows = ws.get_all_values()
+    if len(rows) < 2:
+        print("Hit List has no data rows.", flush=True)
+        return
+    header = [str(x or "").strip() for x in rows[0]]
+
+    missing_any_header = [h for h in dl.HIT_LIST_OPENING_HOUR_COLS if h not in header]
+    if missing_any_header:
+        raise SystemExit(
+            "Hit List row 1 is missing hour column(s): "
+            + ", ".join(missing_any_header)
+            + ". Add these headers on row 1 (after Contact Form URL), then re-run."
+        )
+
+    idx_notes = col_index(header, "Notes")
+    if idx_notes < 0:
+        raise SystemExit('Hit List must have a "Notes" column.')
+
+    hour_indices = [col_index(header, h) for h in dl.HIT_LIST_OPENING_HOUR_COLS]
+    if any(i < 0 for i in hour_indices):
+        raise SystemExit("Could not resolve all hour column indices from row 1.")
+
+    hour_rows_updated = 0
+    skipped = 0
+    resolved_notes = 0
+
+    for r_idx, row in enumerate(rows[1:], start=2):
+        if hour_rows_updated >= args.limit:
+            break
+        notes = row[idx_notes] if idx_notes < len(row) else ""
+
+        def cell(ci: int) -> str:
+            return (row[ci] if ci < len(row) else "").strip()
+
+        has_any_hours = any(cell(ci) for ci in hour_indices)
+        if has_any_hours and not args.force:
+            skipped += 1
+            continue
+
+        m = PID_RE.search(notes or "")
+        pid: str | None = m.group(1).strip() if m else None
+        resolve_reason = ""
+
+        if not pid and args.resolve_missing_place_id:
+            q = build_find_query(row, header)
+            if not q:
+                skipped += 1
+                continue
+            pid, resolve_reason = resolve_place_id(key, row, header, radius_m=args.find_radius_m)
+            time.sleep(max(0.0, args.sleep_details))
+            if not pid:
+                print(f"Row {r_idx}: could not resolve place_id ({resolve_reason}) query={q!r}", flush=True)
+                skipped += 1
+                continue
+            new_notes = append_place_id_to_notes(notes, pid)
+            if new_notes != (notes or "") and not args.dry_run:
+                ncell = rowcol_to_a1(r_idx, idx_notes + 1)
+                ws.update(range_name=ncell, values=[[new_notes]], value_input_option="USER_ENTERED")
+                notes = new_notes
+                resolved_notes += 1
+                print(f"Row {r_idx}: appended place_id to Notes ({pid})", flush=True)
+                time.sleep(max(0.0, args.sleep_write))
+            elif new_notes != (notes or "") and args.dry_run:
+                print(f"Row {r_idx}: dry-run would append place_id to Notes ({pid}) query={q!r}", flush=True)
+        elif not pid:
+            skipped += 1
+            continue
+
+        assert pid is not None
+
+        det = dl.place_details(key, pid)
+        time.sleep(max(0.0, args.sleep_details))
+        if det.get("status") != "OK":
+            print(f"Row {r_idx}: Details not OK for place_id={pid!r}", flush=True)
+            skipped += 1
+            continue
+        res = det.get("result") or {}
+        grid = dl.opening_hours_week_grid_from_place_result(res)
+        if not any((grid.get(h) or "").strip() for h in dl.HIT_LIST_OPENING_HOUR_COLS):
+            print(f"Row {r_idx}: no opening_hours for place_id={pid!r}", flush=True)
+            skipped += 1
+            continue
+
+        if args.dry_run:
+            name = cell_at(row, col_index(header, "Shop Name"))
+            print(f"Row {r_idx}: dry-run would update hours for {name!r} ({pid})", flush=True)
+            hour_rows_updated += 1
+            continue
+
+        ci0 = hour_indices[0]
+        contiguous = hour_indices == list(range(ci0, ci0 + len(hour_indices)))
+        vals = [[(grid.get(h) or "").strip() for h in dl.HIT_LIST_OPENING_HOUR_COLS]]
+        if contiguous:
+            rng = f"{rowcol_to_a1(r_idx, ci0 + 1)}:{rowcol_to_a1(r_idx, hour_indices[-1] + 1)}"
+            ws.update(range_name=rng, values=vals, value_input_option="USER_ENTERED")
+        else:
+            for h in dl.HIT_LIST_OPENING_HOUR_COLS:
+                ci = col_index(header, h)
+                val = (grid.get(h) or "").strip()
+                cell_a1 = rowcol_to_a1(r_idx, ci + 1)
+                ws.update(range_name=cell_a1, values=[[val]], value_input_option="USER_ENTERED")
+
+        print(f"Row {r_idx}: updated hours for place_id={pid}", flush=True)
+        hour_rows_updated += 1
+        time.sleep(max(0.0, args.sleep_write))
+
+    print(
+        f"Done. hour_rows_updated={hour_rows_updated} notes_place_id_appended={resolved_notes} "
+        f"skipped={skipped} dry_run={args.dry_run} resolve={bool(args.resolve_missing_place_id)}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discover_apothecaries_la_hit_list.py
+++ b/scripts/discover_apothecaries_la_hit_list.py
@@ -31,6 +31,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -48,6 +49,36 @@ SCOPES = [
 ]
 
 # Column order must match Hit List tab (see HIT_LIST_CREDENTIALS.md, append_to_hit_list.py)
+HIT_LIST_OPENING_HOUR_COLS: tuple[str, ...] = (
+    "Monday Open",
+    "Monday Close",
+    "Tuesday Open",
+    "Tuesday Close",
+    "Wednesday Open",
+    "Wednesday Close",
+    "Thursday Open",
+    "Thursday Close",
+    "Friday Open",
+    "Friday Close",
+    "Saturday Open",
+    "Saturday Close",
+    "Sunday Open",
+    "Sunday Close",
+)
+
+# Google Place Details ``business_status`` → Hit List cell (empty = operational / unknown).
+GOOGLE_LISTING_COL = "Google listing"
+
+
+def google_listing_from_business_status(status: str | None) -> str:
+    s = (status or "").strip().upper()
+    if s == "CLOSED_PERMANENTLY":
+        return "Closed"
+    if s == "CLOSED_TEMPORARILY":
+        return "Temporarily closed"
+    return ""
+
+
 HIT_LIST_COLS = [
     "Shop Name",
     "Status",
@@ -80,10 +111,37 @@ HIT_LIST_COLS = [
     "Instagram Follow Count",
     "Store Key",
     "Contact Form URL",
+    *HIT_LIST_OPENING_HOUR_COLS,
+    GOOGLE_LISTING_COL,
 ]
 
 NEARBY_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json"
 DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
+FIND_PLACE_URL = "https://maps.googleapis.com/maps/api/place/findplacefromtext/json"
+
+
+def find_place_from_text(
+    key: str,
+    query: str,
+    lat: float | None,
+    lng: float | None,
+    radius_m: float = 50000.0,
+) -> dict[str, Any]:
+    """
+    Find Place from Text (legacy Places API). Prefer ``locationbias`` when lat/lng are known.
+    Returns the full JSON (status, candidates, …).
+    """
+    params: dict[str, Any] = {
+        "input": (query or "").strip(),
+        "inputtype": "textquery",
+        "fields": "place_id,name,formatted_address,business_status",
+        "key": key,
+    }
+    if lat is not None and lng is not None:
+        params["locationbias"] = f"circle:{int(radius_m)}@{lat},{lng}"
+    r = requests.get(FIND_PLACE_URL, params=params, timeout=45)
+    r.raise_for_status()
+    return r.json()
 
 
 @dataclass(frozen=True)
@@ -571,7 +629,7 @@ def collect_nearby_for_center(
 def place_details(key: str, place_id: str) -> dict[str, Any]:
     fields = (
         "place_id,name,formatted_address,formatted_phone_number,website,geometry,"
-        "types,address_component,business_status,url"
+        "types,address_component,business_status,url,opening_hours"
     )
     r = requests.get(
         DETAILS_URL,
@@ -580,6 +638,88 @@ def place_details(key: str, place_id: str) -> dict[str, Any]:
     )
     r.raise_for_status()
     return r.json()
+
+
+# Google weekday on periods: 0 = Sunday .. 6 = Saturday.
+_GOOGLE_DAY_TO_PAIR_START: dict[int, int] = {
+    0: 12,
+    1: 0,
+    2: 2,
+    3: 4,
+    4: 6,
+    5: 8,
+    6: 10,
+}
+
+
+def opening_hours_week_grid_from_place_result(res: dict[str, Any]) -> dict[str, str]:
+    """
+    Build the 14 Hit List hour cells from legacy Place Details ``opening_hours.periods``.
+    Multiple same-day segments: earliest open and latest close (lunch gaps not modeled).
+    """
+    out: dict[str, str] = {c: "" for c in HIT_LIST_OPENING_HOUR_COLS}
+    oh = res.get("opening_hours") or {}
+    periods = oh.get("periods") or []
+    if not periods:
+        return out
+
+    # Per Google day index: list of (open_min, close_min) where close may be >1440 if overnight.
+    intervals: dict[int, list[tuple[int, int]]] = {d: [] for d in range(7)}
+
+    def parse_day_time(day: Any, tim: str | None) -> tuple[int, int] | None:
+        try:
+            d = int(day)
+        except (TypeError, ValueError):
+            return None
+        if d < 0 or d > 6:
+            return None
+        s = (tim or "").strip()
+        if not s.isdigit():
+            return None
+        if len(s) == 3:
+            s = s.zfill(4)
+        if len(s) != 4:
+            return None
+        mins = int(s[:2]) * 60 + int(s[2:])
+        return d, mins
+
+    for p in periods:
+        o = p.get("open") or {}
+        c = p.get("close") or {}
+        op = parse_day_time(o.get("day"), o.get("time"))
+        if not op:
+            continue
+        open_day, open_m = op
+        cp = parse_day_time(c.get("day"), c.get("time"))
+        if not cp:
+            # Open 24h (no close) — treat as full day for that weekday.
+            intervals[open_day].append((0, 24 * 60))
+            continue
+        close_day, close_m = cp
+        if close_day == open_day:
+            end_m = close_m if close_m > open_m else close_m + 24 * 60
+            intervals[open_day].append((open_m, end_m))
+        else:
+            # Overnight (e.g. Mon 22:00 → Tue 02:00): measure from open day's midnight.
+            span = (24 * 60 - open_m) + close_m
+            end_m = open_m + span
+            intervals[open_day].append((open_m, end_m))
+
+    for d, segs in intervals.items():
+        if not segs:
+            continue
+        start = min(s for s, _ in segs)
+        end = max(e for _, e in segs)
+        pair0 = _GOOGLE_DAY_TO_PAIR_START.get(d)
+        if pair0 is None:
+            continue
+        open_col = HIT_LIST_OPENING_HOUR_COLS[pair0]
+        close_col = HIT_LIST_OPENING_HOUR_COLS[pair0 + 1]
+        out[open_col] = f"{start // 60:02d}:{start % 60:02d}"
+        end_norm = end % (24 * 60)
+        out[close_col] = f"{end_norm // 60:02d}:{end_norm % 60:02d}"
+
+    return out
 
 
 def parse_address_components(comps: list[dict[str, Any]]) -> dict[str, str]:
@@ -690,13 +830,15 @@ def row_dict_for_append(
     shop_type: str,
     place_id: str,
     region_notes_label: str,
+    opening_hours_row: Mapping[str, str] | None = None,
+    google_listing: str = "",
 ) -> dict[str, str]:
     notes = (
         f"Auto-discovered (Google Places Nearby, {region_notes_label}). place_id: {place_id}. "
         "Pre-filtered pharmacies/cannabis chains; confirm shop type before outreach."
     )
     sk = compute_store_key(name, street, city, state)
-    return {
+    rd: dict[str, str] = {
         "Shop Name": name,
         "Status": "Research",
         "Priority": "Low",
@@ -729,6 +871,15 @@ def row_dict_for_append(
         "Store Key": sk,
         "Contact Form URL": "",
     }
+    for c in HIT_LIST_OPENING_HOUR_COLS:
+        rd[c] = ""
+    if opening_hours_row:
+        for c in HIT_LIST_OPENING_HOUR_COLS:
+            v = (opening_hours_row.get(c) or "").strip()
+            if v:
+                rd[c] = v
+    rd[GOOGLE_LISTING_COL] = (google_listing or "").strip()
+    return rd
 
 
 def main() -> None:
@@ -910,6 +1061,7 @@ def main() -> None:
         phone = (res.get("formatted_phone_number") or "").strip()
         website = (res.get("website") or "").strip()
 
+        hours = opening_hours_week_grid_from_place_result(res)
         rd = row_dict_for_append(
             name=name,
             street=street,
@@ -922,6 +1074,8 @@ def main() -> None:
             shop_type=args.shop_type,
             place_id=pid,
             region_notes_label=region.notes_label,
+            opening_hours_row=hours,
+            google_listing=google_listing_from_business_status(res.get("business_status")),
         )
         sk = rd["Store Key"]
         sk_legacy = compute_store_key_legacy(name, street, city, state)
@@ -965,6 +1119,20 @@ def main() -> None:
         return
 
     ws = gc.open_by_key(SPREADSHEET_ID).worksheet(HIT_LIST_WS)
+    hdr = [str(x or "").strip() for x in ws.row_values(1)]
+    missing_h = [c for c in HIT_LIST_OPENING_HOUR_COLS if c not in hdr]
+    if missing_h:
+        raise SystemExit(
+            "Hit List row 1 is missing opening-hour column(s): "
+            + ", ".join(missing_h)
+            + ". Add them (after Contact Form URL) to match scripts/discover_apothecaries_la_hit_list.py, then re-run."
+        )
+    if GOOGLE_LISTING_COL not in hdr:
+        next_col = len(hdr) + 1
+        if ws.col_count < next_col:
+            ws.add_cols(next_col - ws.col_count)
+        ws.update_cell(1, next_col, GOOGLE_LISTING_COL)
+        hdr.append(GOOGLE_LISTING_COL)
     ws.append_rows(to_append, value_input_option="USER_ENTERED")
     print(f"Appended {len(to_append)} rows to {HIT_LIST_WS!r}.")
 


### PR DESCRIPTION
## Goal
Ship Hit List tooling and GAS-aligned script for Google business status (permanently closed), opening-hour backfills, and Find Place resolution.

## Changes
- `scripts/discover_apothecaries_la_hit_list.py` — `Google listing` column, `google_listing_from_business_status`, append-time header + column expand.
- `scripts/backfill_hit_list_google_listing.py` — backfill listing from Place Details (optional resolve missing place_id).
- `scripts/backfill_hit_list_opening_hours.py` — opening-hour backfill (included in branch).
- `physical_stores/find_nearby_stores.gs` — synced with deployed web app behavior (hours, open_now, permanently closed).

## Testing
- `python3 -m py_compile` on the touched Python scripts.

## Rollout / follow-ups
- Apps Script: deploy / version bump if not already on HEAD after `clasp push`.
- Sheet: run backfill scripts from `market_research/` with credentials as documented.

Made with [Cursor](https://cursor.com)