### PR TITLE
ci: publish Agroverse inventory snapshots to agroverse-inventory

### DIFF
--- a/.github/workflows/publish-agroverse-inventory-snapshot.yml
+++ b/.github/workflows/publish-agroverse-inventory-snapshot.yml
@@ -1,0 +1,73 @@
+# Regenerates public JSON snapshots in TrueSightDAO/agroverse-inventory from the
+# main ledger (Google Sheets). Uses market_research/scripts/sync_agroverse_store_inventory.py.
+#
+# Required repository secrets (go_to_market / market_research clone):
+#   GOOGLE_CREDENTIALS_JSON   — service account JSON with Sheets + Drive read (same as other workflows here).
+#   AGROVERSE_INVENTORY_PUSH_TOKEN — fine-grained PAT with **Contents: Read and write** on TrueSightDAO/agroverse-inventory
+#     (classic PAT with `repo` scope also works). Needed because GITHUB_TOKEN cannot push to another repo by default.
+#
+# Outputs: store-inventory.json, partners-inventory.json on agroverse-inventory default branch (main).
+
+name: Publish Agroverse inventory snapshots
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 06:15 UTC daily — offset from top-of-hour to reduce Sheets API burst collisions.
+    - cron: "15 6 * * *"
+
+concurrency:
+  group: agroverse-inventory-snapshot
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout market_research (this repo)
+        uses: actions/checkout@v4
+
+      - name: Checkout agroverse-inventory (target)
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/agroverse-inventory
+          path: agroverse-inventory
+          token: ${{ secrets.AGROVERSE_INVENTORY_PUSH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "gspread>=5.12" "google-auth>=2.23"
+
+      - name: Write Google credentials
+        run: |
+          echo '${{ secrets.GOOGLE_CREDENTIALS_JSON }}' > google_credentials.json
+
+      - name: Sync from Sheets and write JSON files
+        run: |
+          python3 scripts/sync_agroverse_store_inventory.py --execute \
+            --json-out agroverse-inventory/store-inventory.json \
+            --partner-json-out agroverse-inventory/partners-inventory.json
+
+      - name: Commit and push agroverse-inventory if changed
+        working-directory: agroverse-inventory
+        env:
+          TARGET_TOKEN: ${{ secrets.AGROVERSE_INVENTORY_PUSH_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${TARGET_TOKEN}@github.com/TrueSightDAO/agroverse-inventory.git"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add store-inventory.json partners-inventory.json
+          if git diff --staged --quiet; then
+            echo "No changes to inventory JSON; skipping commit."
+          else
+            git commit -m "chore: refresh store and partner inventory snapshots [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/scripts/generate_beer_hall_preview.py
+++ b/scripts/generate_beer_hall_preview.py
@@ -7,6 +7,7 @@ Follows the same evidence steps as **`agentic_ai_context/OPENCLAW_WHATSAPP.md`**
   - **§ Gathering what merged** — `git fetch` + `git log` on `origin/<default>` for each clone
   - **Merged PRs** — `gh pr list -R TrueSightDAO/<repo> --state merged` (optional if `gh` missing)
   - **§ Gathering Telegram Chat Logs** — `list_recent_telegram_chat_logs_for_digest.py`
+  - **§ DApp Remarks (Hit List)** — `list_recent_dapp_remarks_for_digest.py` (offline / field human notes)
 
 Output is Markdown (for reading in Cursor / Git). Paste into WhatsApp manually if desired;
 use WhatsApp formatting rules from **`OPENCLAW_WHATSAPP.md`** (no `**bold**` in the bubble).
@@ -14,6 +15,7 @@ use WhatsApp formatting rules from **`OPENCLAW_WHATSAPP.md`** (no `**bold**` in 
 Usage (from `market_research/`):
   python3 scripts/generate_beer_hall_preview.py
   python3 scripts/generate_beer_hall_preview.py --since-days 3 --telegram-hours 48
+  python3 scripts/generate_beer_hall_preview.py --dapp-include-automation
   python3 scripts/generate_beer_hall_preview.py --output /path/to/preview.md
 
 Default output: **`agentic_ai_context/previews/beer_hall_preview_latest.md`** when that
@@ -151,10 +153,28 @@ def _telegram_block(hours: int) -> str:
     return "```\n" + out.strip() + "\n```\n"
 
 
+def _dapp_remarks_block(hours: int, *, include_automation: bool) -> str:
+    script = _REPO / "scripts" / "list_recent_dapp_remarks_for_digest.py"
+    if not script.is_file():
+        return "_(DApp Remarks helper script missing)_\n"
+    cmd = [sys.executable, str(script), "--hours", str(float(hours))]
+    if include_automation:
+        cmd.append("--include-automation")
+    code, out = _run(cmd, cwd=_REPO)
+    if code != 0:
+        return f"_(DApp Remarks helper exit {code})_\n```\n{out[:4000]}\n```\n"
+    return "```\n" + out.strip() + "\n```\n"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Beer Hall digest preview (no WhatsApp send).")
     ap.add_argument("--since-days", type=int, default=7, help="Look-back for git log / gh (calendar days).")
     ap.add_argument("--telegram-hours", type=int, default=48, help="Passed to list_recent_telegram_chat_logs_for_digest.py.")
+    ap.add_argument(
+        "--dapp-include-automation",
+        action="store_true",
+        help="Pass --include-automation to list_recent_dapp_remarks_for_digest.py (default: human-oriented rows only).",
+    )
     ap.add_argument("--output", type=Path, default=None, help="Markdown output path.")
     ap.add_argument(
         "--no-stdout",
@@ -174,7 +194,11 @@ def main() -> int:
     parts.append(f"# Beer Hall digest — **PREVIEW** (no OpenClaw send)\n")
     parts.append(f"- Generated: **{dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}**\n")
     parts.append(f"- Git window: `{since_iso}` → `{until_iso}` (local clone `origin` default branch)\n")
-    parts.append(f"- Telegram helper look-back: **{args.telegram_hours}h**\n")
+    parts.append(
+        f"- Telegram + DApp Remarks helper look-back: **{args.telegram_hours}h** "
+        f"(same window for both; DApp default excludes script submitters unless "
+        f"`--dapp-include-automation`)\n"
+    )
     parts.append("\n---\n\n## Message 1 (TLDR only — WhatsApp paste)\n\n")
     parts.append(
         "_Draft manually from the evidence below. No GitHub URLs in Message 1. "
@@ -186,7 +210,7 @@ def main() -> int:
     parts.append("\n---\n\n## Message 2 (Shipped + links — WhatsApp paste)\n\n")
     parts.append(
         "_Use `*Shipped*` then bullets. **Only** `https://github.com/TrueSightDAO/...` for GitHub. "
-        "Optional: **Community (Telegram log):** after bullets._\n\n"
+        "Optional: **Community (Telegram log):** and/or **Community (DApp Remarks / field):** after bullets._\n\n"
         "*Shipped*\n\n"
         "- …\n"
     )
@@ -228,6 +252,9 @@ def main() -> int:
 
     parts.append("---\n\n## Evidence — Telegram Chat Logs helper output\n\n")
     parts.append(_telegram_block(args.telegram_hours))
+
+    parts.append("---\n\n## Evidence — DApp Remarks (Hit List) helper output\n\n")
+    parts.append(_dapp_remarks_block(args.telegram_hours, include_automation=args.dapp_include_automation))
 
     parts.append(
         "\n---\n\n## Operator checklist before a real Beer Hall send\n\n"

--- a/scripts/list_recent_dapp_remarks_for_digest.py
+++ b/scripts/list_recent_dapp_remarks_for_digest.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Print recent rows from tab **DApp Remarks** on the Hit List workbook — for drafting **Beer Hall**
+digests (field / partner **offline** turn-by-turn notes that do not appear in Git or Telegram logs).
+
+Uses **Submitted At** when parseable. Filters to the last **--hours** (default 48). By default
+**--humans-only** drops rows whose **Submitted By** looks like known automation (Hit List scripts,
+batch jobs); pass **--include-automation** to show everything for auditing.
+
+Spreadsheet: https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit
+Tab: **DApp Remarks** (often first tab / `gid=0`)
+
+Usage (from market_research/):
+  python3 scripts/list_recent_dapp_remarks_for_digest.py
+  python3 scripts/list_recent_dapp_remarks_for_digest.py --hours 72
+  python3 scripts/list_recent_dapp_remarks_for_digest.py --include-automation
+
+Requires: google_credentials.json; spreadsheet shared with the service account (Editor).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import gspread
+from google.oauth2.service_account import Credentials as SACredentials
+
+_REPO = Path(__file__).resolve().parent.parent
+_SA_CREDS = _REPO / "google_credentials.json"
+SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
+DAPP_REMARKS_WS = "DApp Remarks"
+
+SHEETS_SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+]
+
+# Substrings (normalized) in Submitted By → treat as automation unless --include-automation
+_AUTOMATION_MARKERS = (
+    "hit_list_",
+    "field_agent",
+    "enrich_contact",
+    "photo_review",
+    "suggest_manager",
+    "places_pull",
+    "process_dapp",
+    "append_",
+    "google_apps_script",
+    "gmail_oauth",
+    "workflow_dispatch",
+    "github actions",
+)
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "").strip().lower())
+
+
+def _parse_sheet_date(raw: str) -> datetime | None:
+    t = (raw or "").strip()
+    if not t:
+        return None
+    if re.fullmatch(r"\d{8}", t):
+        try:
+            return datetime.strptime(t, "%Y%m%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%m/%d/%Y"):
+        try:
+            dt = datetime.strptime(t[:19] if len(t) > 10 else t, fmt)
+            return dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    try:
+        if "T" in t:
+            return datetime.fromisoformat(t.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+    return None
+
+
+def _col_map(header: list[str]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for j, cell in enumerate(header):
+        key = _norm(cell)
+        if not key:
+            continue
+        out[key] = j
+    return out
+
+
+def _find_col(m: dict[str, int], *names: str) -> int | None:
+    for want in names:
+        w = _norm(want)
+        for k, j in m.items():
+            if k == w or k.replace(" ", "_") == w or w in k:
+                return j
+    return None
+
+
+def _is_automation_submitter(submitted_by: str) -> bool:
+    s = _norm(submitted_by)
+    if not s:
+        return True
+    return any(m in s for m in _AUTOMATION_MARKERS)
+
+
+def _meaningful_remark(remarks: str) -> bool:
+    r = (remarks or "").strip()
+    if len(r) < 8:
+        return False
+    if _norm(r) in ("n/a", "-", "none"):
+        return False
+    return True
+
+
+def get_client():
+    if not _SA_CREDS.is_file():
+        sys.stderr.write(f"Missing {_SA_CREDS}\n")
+        sys.exit(1)
+    creds = SACredentials.from_service_account_file(str(_SA_CREDS), scopes=SHEETS_SCOPES)
+    return gspread.authorize(creds)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--hours", type=float, default=48.0, help="Look-back window from Submitted At (default 48)")
+    p.add_argument(
+        "--max-rows",
+        type=int,
+        default=800,
+        help="Max data rows to scan from the bottom of the sheet (default 800)",
+    )
+    p.add_argument("--sheet", default=DAPP_REMARKS_WS, help="Worksheet title")
+    p.add_argument(
+        "--include-automation",
+        action="store_true",
+        help="Include script/system Submitted By rows (default: humans-oriented filter on)",
+    )
+    args = p.parse_args()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.hours)
+
+    gc = get_client()
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    try:
+        ws = sh.worksheet(args.sheet)
+    except gspread.WorksheetNotFound:
+        sys.stderr.write(
+            f"Worksheet {args.sheet!r} not found. Check tab name matches exactly.\n"
+        )
+        sys.exit(1)
+
+    all_vals = ws.get_all_values()
+    if not all_vals:
+        print("(empty worksheet)")
+        return
+
+    header = all_vals[0]
+    cmap = _col_map(header)
+    i_sub_at = _find_col(cmap, "Submitted At", "submitted_at")
+    i_remarks = _find_col(cmap, "Remarks", "remark")
+    i_shop = _find_col(cmap, "Shop Name", "shop name")
+    i_status = _find_col(cmap, "Status")
+    i_by = _find_col(cmap, "Submitted By", "submitted_by")
+    i_proc = _find_col(cmap, "Processed")
+
+    if i_remarks is None:
+        sys.stderr.write(
+            "Could not find Remarks column. Headers: " + ", ".join(h for h in header if h)[:500] + "\n"
+        )
+        sys.exit(1)
+    if i_sub_at is None:
+        sys.stderr.write(
+            "Could not find Submitted At column. Headers: " + ", ".join(h for h in header if h)[:500] + "\n"
+        )
+        sys.exit(1)
+
+    data_rows = all_vals[1:]
+    if args.max_rows > 0 and len(data_rows) > args.max_rows:
+        data_rows = data_rows[-args.max_rows :]
+
+    max_i = max(i for i in (i_sub_at, i_remarks, i_shop, i_status, i_by, i_proc) if i is not None)
+
+    candidates: list[tuple[datetime | None, str]] = []
+    for row in data_rows:
+        while len(row) <= max_i:
+            row.append("")
+        raw_at = row[i_sub_at] if i_sub_at < len(row) else ""
+        dt = _parse_sheet_date(raw_at)
+        remarks = row[i_remarks] if i_remarks < len(row) else ""
+        shop = row[i_shop] if i_shop is not None and i_shop < len(row) else ""
+        status = row[i_status] if i_status is not None and i_status < len(row) else ""
+        by = row[i_by] if i_by is not None and i_by < len(row) else ""
+        proc = row[i_proc] if i_proc is not None and i_proc < len(row) else ""
+
+        if not _meaningful_remark(remarks):
+            continue
+        if not args.include_automation and _is_automation_submitter(by):
+            continue
+        if dt is not None and dt < cutoff:
+            continue
+        if dt is None:
+            continue
+
+        snippet = re.sub(r"\s+", " ", remarks).strip()
+        if len(snippet) > 260:
+            snippet = snippet[:257] + "…"
+        shop_bit = f"{shop.strip()} — " if shop and shop.strip() else ""
+        who = (by or "").strip() or "Unknown"
+        st = (status or "").strip()
+        st_bit = f" [status: {st[:72]}]" if st else ""
+        proc_bit = ""
+        if proc and _norm(proc) not in ("", "no", "n"):
+            proc_bit = " _(processed)_"
+        line = f"- {shop_bit}{snippet} _(by {who})_{st_bit}{proc_bit}"
+        candidates.append((dt, line))
+
+    candidates.sort(key=lambda x: (x[0] or datetime.min.replace(tzinfo=timezone.utc)), reverse=True)
+
+    filter_note = "all submitters" if args.include_automation else "human-oriented (automation Submitted By filtered out)"
+    print(
+        f"# DApp Remarks — rows with Submitted At on/after {cutoff.isoformat()} UTC "
+        f"(~{args.hours}h look-back; {filter_note})\n"
+        f"# Sheet: https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit#gid=0\n"
+        f"# Tab: {args.sheet!r}\n"
+        "# Use under Community in Beer Hall Message 2 (offline / field narrative). "
+        "Dedup vs Git bullets and Telegram log lines.\n"
+    )
+    if not candidates:
+        print(
+            "(no qualifying rows — widen --hours, try --include-automation, "
+            "or confirm Submitted At parses as ISO / YYYY-MM-DD)"
+        )
+        return
+    for _, line in candidates:
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_agroverse_store_inventory.py
+++ b/scripts/sync_agroverse_store_inventory.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""
+Port of `agroverse_shop/google-app-script/update_store_inventory.gs` (Python).
+
+1. Reads store managers, currency→SKU mapping, main-ledger inventory, and managed-ledger balances.
+2. Writes computed totals to **Agroverse SKUs** column **I** (Store inventory).
+3. Writes `store-inventory.json` for the public GitHub snapshot (same shape as today).
+
+Requires `market_research/google_credentials.json` with access to:
+- Main workbook `1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU`
+- Every managed-ledger spreadsheet linked from **Shipment Ledger Listing** column **AB**
+
+Usage:
+  python3 scripts/sync_agroverse_store_inventory.py --dry-run
+  python3 scripts/sync_agroverse_store_inventory.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import gspread
+from gspread.exceptions import APIError
+from google.oauth2.service_account import Credentials as SACredentials
+
+REPO = Path(__file__).resolve().parents[1]
+SA_CREDS = REPO / "google_credentials.json"
+
+MAIN_SPREADSHEET_ID = "1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU"
+
+SKUS_SHEET_NAME = "Agroverse SKUs"
+CURRENCIES_SHEET_NAME = "Currencies"
+CONTRIBUTORS_SHEET_NAME = "Contributors contact information"
+PARTNERS_SHEET_NAME = "Agroverse Partners"
+OFFCHAIN_ASSET_LOCATION_SHEET_NAME = "offchain asset location"
+SHIPMENT_LEDGER_SHEET_NAME = "Shipment Ledger Listing"
+BALANCE_SHEET_NAME = "Balance"
+
+SHEETS_SCOPES = (
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive.readonly",
+)
+
+_SPREADSHEET_ID_RE = re.compile(r"/d/([a-zA-Z0-9-_]+)")
+
+
+def _truthy_store_manager(val: object) -> bool:
+    if val is True:
+        return True
+    s = str(val).strip().lower()
+    return s in ("true", "1", "yes")
+
+
+def _to_float(val: object) -> float:
+    if val is None or val == "":
+        return 0.0
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _extract_spreadsheet_id(url: str) -> str | None:
+    m = _SPREADSHEET_ID_RE.search(url or "")
+    return m.group(1) if m else None
+
+
+def _client() -> gspread.Client:
+    creds = SACredentials.from_service_account_file(str(SA_CREDS), scopes=SHEETS_SCOPES)
+    return gspread.authorize(creds)
+
+
+def _gspread_retry(fn, *, max_attempts: int = 6) -> object:
+    delay = 10.0
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except APIError as e:
+            msg = str(e)
+            if ("429" in msg or "Quota" in msg) and attempt < max_attempts - 1:
+                time.sleep(delay)
+                delay = min(delay * 1.5, 120.0)
+                continue
+            raise
+
+
+def get_store_managers(sh: gspread.Spreadsheet) -> list[str]:
+    ws = sh.worksheet(CONTRIBUTORS_SHEET_NAME)
+    rows = _gspread_retry(lambda: ws.get_values("A2:T"))
+    managers: list[str] = []
+    for row in rows:
+        if len(row) < 20:
+            continue
+        name = row[0].strip() if row[0] else ""
+        if name and _truthy_store_manager(row[19]):
+            managers.append(name)
+    return managers
+
+
+def get_currency_to_sku_mapping(sh: gspread.Spreadsheet) -> dict[str, str]:
+    ws = sh.worksheet(CURRENCIES_SHEET_NAME)
+    rows = _gspread_retry(lambda: ws.get_values("A2:M"))
+    mapping: dict[str, str] = {}
+    for row in rows:
+        if len(row) < 13:
+            continue
+        currency = row[0].strip() if row[0] else ""
+        sku = row[12].strip() if row[12] else ""
+        if currency and sku:
+            mapping[currency] = sku
+    return mapping
+
+
+def _last_filled_row_in_col_a(ws: gspread.Worksheet) -> int:
+    """Approximate Sheets `getLastRow()` for column A."""
+    vals = ws.col_values(1)
+    return len(vals)
+
+
+def get_main_ledger_inventory(sh: gspread.Spreadsheet, store_managers: set[str]) -> dict[str, dict[str, float]]:
+    ws = sh.worksheet(OFFCHAIN_ASSET_LOCATION_SHEET_NAME)
+    last_row = _last_filled_row_in_col_a(ws)
+    if last_row < 5:
+        return {}
+    # Match Apps Script behavior: rows 5 .. (lastRow - 4), inclusive end row.
+    end_row = max(4, last_row - 4)
+    if end_row < 5:
+        return {}
+    rng = f"A5:C{end_row}"
+    rows = _gspread_retry(lambda: ws.get_values(rng))
+    inv: dict[str, dict[str, float]] = {}
+    for row in rows:
+        if len(row) < 3:
+            continue
+        currency = row[0].strip() if row[0] else ""
+        location = row[1].strip() if row[1] else ""
+        amount = _to_float(row[2])
+        if not currency or not location or location not in store_managers or amount <= 0:
+            continue
+        inv.setdefault(currency, {})
+        inv[currency][location] = inv[currency].get(location, 0.0) + amount
+    return inv
+
+
+def get_managed_ledger_urls(sh: gspread.Spreadsheet) -> list[str]:
+    ws = sh.worksheet(SHIPMENT_LEDGER_SHEET_NAME)
+    rows = _gspread_retry(lambda: ws.get_values("A2:AB"))
+    seen: set[str] = set()
+    urls: list[str] = []
+    for row in rows:
+        if len(row) < 28:
+            continue
+        url = row[27].strip() if row[27] else ""
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def get_managed_ledger_inventory(
+    gc: gspread.Client, ledger_url: str, store_managers: set[str]
+) -> dict[str, dict[str, float]]:
+    sid = _extract_spreadsheet_id(ledger_url)
+    if not sid:
+        return {}
+    inv: dict[str, dict[str, float]] = {}
+    try:
+        msh = _gspread_retry(lambda: gc.open_by_key(sid))
+    except Exception as e:  # noqa: BLE001
+        print(f"  [skip] Could not open managed ledger {ledger_url!r}: {e}")
+        return inv
+    try:
+        mws = msh.worksheet(BALANCE_SHEET_NAME)
+    except Exception as e:  # noqa: BLE001
+        print(f"  [skip] No Balance tab in {ledger_url!r}: {e}")
+        return inv
+    # One read for H:J (avoid extra `col_values` quota).
+    rows = _gspread_retry(lambda: mws.get_values("H2:J"))
+    while rows and not any(str(c).strip() for c in rows[-1]):
+        rows.pop()
+    for row in rows:
+        if len(row) < 3:
+            continue
+        location = row[0].strip() if row[0] else ""
+        amount = _to_float(row[1])
+        currency = row[2].strip() if row[2] else ""
+        if not currency or not location or location not in store_managers or amount <= 0:
+            continue
+        inv.setdefault(currency, {})
+        inv[currency][location] = inv[currency].get(location, 0.0) + amount
+    return inv
+
+
+def calculate_sku_inventory(
+    gc: gspread.Client, sh: gspread.Spreadsheet, *, managers: list[str] | None = None
+) -> dict[str, float]:
+    if managers is None:
+        managers = get_store_managers(sh)
+    if not managers:
+        raise RuntimeError("No store managers found (Contributors contact information column T).")
+    ms = set(managers)
+    cur_to_sku = get_currency_to_sku_mapping(sh)
+    if not cur_to_sku:
+        raise RuntimeError("No currency→SKU mappings found (Currencies columns A and M).")
+
+    sku_totals: dict[str, float] = {}
+
+    main = get_main_ledger_inventory(sh, ms)
+    for currency, by_mgr in main.items():
+        sku = cur_to_sku.get(currency)
+        if not sku:
+            continue
+        sku_totals[sku] = sku_totals.get(sku, 0.0) + sum(by_mgr.values())
+
+    for url in get_managed_ledger_urls(sh):
+        led = get_managed_ledger_inventory(gc, url, ms)
+        for currency, by_mgr in led.items():
+            sku = cur_to_sku.get(currency)
+            if not sku:
+                continue
+            sku_totals[sku] = sku_totals.get(sku, 0.0) + sum(by_mgr.values())
+
+    return sku_totals
+
+
+def read_partners_by_contributor(sh: gspread.Spreadsheet) -> dict[str, list[str]]:
+    """Map contributor_contact_id -> [partner_id, ...] from Agroverse Partners."""
+    try:
+        ws = sh.worksheet(PARTNERS_SHEET_NAME)
+    except Exception:
+        return {}
+    rows = _gspread_retry(lambda: ws.get_all_values())
+    if not rows:
+        return {}
+    header = [c.strip().lower() for c in rows[0]]
+
+    def _idx(name: str, fallback: int) -> int:
+        try:
+            return header.index(name)
+        except ValueError:
+            return fallback
+
+    partner_idx = _idx("partner_id", 0)
+    contributor_idx = _idx("contributor_contact_id", 4)
+    status_idx = _idx("status", 3)
+
+    out: dict[str, list[str]] = {}
+    for row in rows[1:]:
+        if not row:
+            continue
+        partner_id = row[partner_idx].strip() if len(row) > partner_idx and row[partner_idx] else ""
+        contributor = (
+            row[contributor_idx].strip() if len(row) > contributor_idx and row[contributor_idx] else ""
+        )
+        status = row[status_idx].strip().lower() if len(row) > status_idx and row[status_idx] else "active"
+        if not partner_id or not contributor or status == "inactive":
+            continue
+        out.setdefault(contributor, [])
+        if partner_id not in out[contributor]:
+            out[contributor].append(partner_id)
+    return out
+
+
+def read_sku_metadata(sh: gspread.Spreadsheet) -> dict[str, dict[str, str]]:
+    """Read key SKU fields used for partner product snippets."""
+    ws = sh.worksheet(SKUS_SHEET_NAME)
+    rows = _gspread_retry(lambda: ws.get_all_values())
+    if not rows:
+        return {}
+    header = [c.strip().lower() for c in rows[0]]
+
+    def _idx(name: str, fallback: int) -> int:
+        try:
+            return header.index(name)
+        except ValueError:
+            return fallback
+
+    id_idx = _idx("product id", 0)
+    name_idx = _idx("product name", 1)
+    price_idx = _idx("price (usd)", 2)
+    category_idx = _idx("category", 4)
+    shipment_idx = _idx("shipment", 5)
+    farm_idx = _idx("farm", 6)
+    image_idx = _idx("image path", 7)
+    gtin_idx = _idx("gtin", 9)
+
+    out: dict[str, dict[str, str]] = {}
+    for row in rows[1:]:
+        if not row:
+            continue
+        pid = row[id_idx].strip() if len(row) > id_idx and row[id_idx] else ""
+        if not pid:
+            continue
+        out[pid] = {
+            "productId": pid,
+            "productName": row[name_idx].strip() if len(row) > name_idx and row[name_idx] else "",
+            "priceUsd": row[price_idx].strip() if len(row) > price_idx and row[price_idx] else "",
+            "category": row[category_idx].strip() if len(row) > category_idx and row[category_idx] else "",
+            "shipment": row[shipment_idx].strip() if len(row) > shipment_idx and row[shipment_idx] else "",
+            "farm": row[farm_idx].strip() if len(row) > farm_idx and row[farm_idx] else "",
+            "imagePath": row[image_idx].strip() if len(row) > image_idx and row[image_idx] else "",
+            "gtin": row[gtin_idx].strip() if len(row) > gtin_idx and row[gtin_idx] else "",
+        }
+    return out
+
+
+def calculate_partner_sku_inventory(
+    gc: gspread.Client, sh: gspread.Spreadsheet, *, managers: list[str] | None = None
+) -> dict[str, dict[str, float]]:
+    """Aggregate inventory by partner_id and sku using contributor mappings."""
+    if managers is None:
+        managers = get_store_managers(sh)
+    ms = set(managers)
+    if not ms:
+        return {}
+
+    contributor_to_partners = read_partners_by_contributor(sh)
+    if not contributor_to_partners:
+        return {}
+
+    cur_to_sku = get_currency_to_sku_mapping(sh)
+    if not cur_to_sku:
+        return {}
+
+    partner_totals: dict[str, dict[str, float]] = {}
+
+    def accumulate(currency_map: dict[str, dict[str, float]]) -> None:
+        for currency, by_mgr in currency_map.items():
+            sku = cur_to_sku.get(currency)
+            if not sku:
+                continue
+            for manager, qty in by_mgr.items():
+                if manager not in ms:
+                    continue
+                partner_ids = contributor_to_partners.get(manager, [])
+                for partner_id in partner_ids:
+                    partner_totals.setdefault(partner_id, {})
+                    partner_totals[partner_id][sku] = partner_totals[partner_id].get(sku, 0.0) + qty
+
+    accumulate(get_main_ledger_inventory(sh, ms))
+    for url in get_managed_ledger_urls(sh):
+        accumulate(get_managed_ledger_inventory(gc, url, ms))
+
+    return partner_totals
+
+
+def read_sku_product_ids(sh: gspread.Spreadsheet) -> list[str]:
+    ws = sh.worksheet(SKUS_SHEET_NAME)
+    last = _last_filled_row_in_col_a(ws)
+    if last < 2:
+        return []
+    col = _gspread_retry(lambda: ws.get_values(f"A2:A{last}"))
+    out: list[str] = []
+    for r in col:
+        if not r:
+            continue
+        pid = r[0].strip() if r[0] else ""
+        if pid:
+            out.append(pid)
+    return out
+
+
+def read_current_inventory_column(sh: gspread.Spreadsheet) -> dict[str, float]:
+    ws = sh.worksheet(SKUS_SHEET_NAME)
+    last = _last_filled_row_in_col_a(ws)
+    if last < 2:
+        return {}
+    rows = _gspread_retry(lambda: ws.get_values(f"A2:I{last}"))
+    cur: dict[str, float] = {}
+    for row in rows:
+        if not row:
+            continue
+        pid = row[0].strip() if row[0] else ""
+        if not pid:
+            continue
+        inv = _to_float(row[8]) if len(row) > 8 else 0.0
+        cur[pid] = inv
+    return cur
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write Agroverse SKUs column I and store-inventory.json (default is dry-run).",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=REPO.parent / "agroverse-inventory" / "store-inventory.json",
+        help="Path to store-inventory.json",
+    )
+    parser.add_argument(
+        "--partner-json-out",
+        type=Path,
+        default=REPO.parent / "agroverse-inventory" / "partners-inventory.json",
+        help="Path to partner inventory JSON payload.",
+    )
+    args = parser.parse_args()
+    dry_run = not args.execute
+
+    if not SA_CREDS.exists():
+        raise SystemExit(f"Missing {SA_CREDS}")
+
+    gc = _client()
+    sh = _gspread_retry(lambda: gc.open_by_key(MAIN_SPREADSHEET_ID))
+
+    managers = get_store_managers(sh)
+    sku_totals = calculate_sku_inventory(gc, sh, managers=managers)
+    partner_totals = calculate_partner_sku_inventory(gc, sh, managers=managers)
+    sku_meta = read_sku_metadata(sh)
+    product_ids = read_sku_product_ids(sh)
+    if not product_ids:
+        raise SystemExit("No product IDs found in Agroverse SKUs column A.")
+
+    # Full snapshot: every SKU row gets a value (0 if not present in ledger-derived totals).
+    snapshot: dict[str, int] = {}
+    updates: list[list[int]] = []
+    for pid in product_ids:
+        qty = int(round(sku_totals.get(pid, 0.0)))
+        snapshot[pid] = qty
+        updates.append([qty])
+
+    current = read_current_inventory_column(sh)
+    changed = [pid for pid in product_ids if int(round(current.get(pid, 0.0))) != snapshot[pid]]
+
+    print(f"Store managers: {len(managers)}")
+    print(f"SKUs on sheet: {len(product_ids)}")
+    print(f"Ledger-derived SKUs with >0 qty: {sum(1 for k, v in snapshot.items() if v > 0)}")
+    if changed:
+        print(f"Column I changes vs sheet: {len(changed)}")
+        for pid in sorted(changed)[:30]:
+            print(f"  {pid}: {int(round(current.get(pid, 0.0)))} -> {snapshot[pid]}")
+        if len(changed) > 30:
+            print(f"  ... and {len(changed) - 30} more")
+    else:
+        print("Column I already matches calculated inventory for all listed SKUs.")
+
+    payload = {
+        "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        "source": "sync_agroverse_store_inventory",
+        "inventory": snapshot,
+    }
+
+    partner_payload = {
+        "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        "source": "sync_agroverse_store_inventory",
+        "partners": {},
+    }
+    for partner_id, sku_map in sorted(partner_totals.items()):
+        items = []
+        for sku, qty in sorted(sku_map.items()):
+            q_int = int(round(qty))
+            if q_int <= 0:
+                continue
+            online_qty = int(round(snapshot.get(sku, 0.0)))
+            item = {
+                "productId": sku,
+                "inventory": q_int,
+                "venueInventory": q_int,
+                "onlineInventory": online_qty,
+                "availableOnline": online_qty > 0,
+            }
+            meta = sku_meta.get(sku, {})
+            item.update({k: v for k, v in meta.items() if k != "productId" and v})
+            items.append(item)
+        if items:
+            partner_payload["partners"][partner_id] = {"items": items}
+
+    if dry_run:
+        print("\nDry run: no sheet or JSON writes. Re-run with --execute to apply.")
+        print(
+            f"Partner inventory payload (partners with items): "
+            f"{len(partner_payload['partners'])}"
+        )
+        return
+
+    ws = sh.worksheet(SKUS_SHEET_NAME)
+    n = len(updates)
+    ws.update(values=updates, range_name=f"I2:I{1 + n}", value_input_option="USER_ENTERED")
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    args.partner_json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.partner_json_out.write_text(json.dumps(partner_payload, indent=2) + "\n", encoding="utf-8")
+
+    print(f"\nWrote Agroverse SKUs column I (rows 2..{1 + n}).")
+    print(f"Wrote JSON: {args.json_out}")
+    print(f"Wrote partner JSON: {args.partner_json_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a scheduled and manual GitHub Action that runs `scripts/sync_agroverse_store_inventory.py --execute` and commits `store-inventory.json` and `partners-inventory.json` to `TrueSightDAO/agroverse-inventory` on `main`.

**New repository secrets required** (repo: `go_to_market`):
- `GOOGLE_CREDENTIALS_JSON` — already used by other workflows; same Sheets access.
- `AGROVERSE_INVENTORY_PUSH_TOKEN` — PAT with write access to `TrueSightDAO/agroverse-inventory` (fine-grained **Contents: Read and write** on that repo, or classic `repo` scope).

Until both secrets are set, the workflow will fail at checkout or Sheets. Use **Actions → Publish Agroverse inventory snapshots → Run workflow** to test after adding secrets.

Made with [Cursor](https://cursor.com)