### PR TITLE
fix(advisory): read goal filter from source; add starts_with predicate

### DIFF
--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -334,15 +334,20 @@ def _fetch_goal_actual(gc, goal: dict) -> tuple[float | None, str]:
     if ci is None:
         return None, f"column {column_name!r} not in header"
     data = rows[1:]
-    filt = goal.get("filter") or None
+    filt = src.get("filter") or None
     if filt:
         fcol = (filt.get("column") or "").strip()
         predicate = (filt.get("predicate") or "").strip()
+        value = str(filt.get("value") or "").strip()
         fci = cmap.get(_norm_header_cell(fcol)) if fcol else None
         if fci is None:
             return None, f"filter column {fcol!r} not in header"
         if predicate == "us_region":
             data = [r for r in data if fci < len(r) and _us_region_match(r[fci])]
+        elif predicate == "starts_with":
+            if not value:
+                return None, "filter predicate 'starts_with' requires a value"
+            data = [r for r in data if fci < len(r) and str(r[fci] or "").strip().startswith(value)]
         else:
             return None, f"unsupported predicate: {predicate!r}"
     values = [r[ci] if ci < len(r) else "" for r in data]


### PR DESCRIPTION
## Summary
Two fixes to `_fetch_goal_actual` in `generate_advisory_snapshot.py`:

1. **Filter lookup bug** — was reading \`goal.get(\"filter\")\`, but the documented JSON schema (and every existing goal in \`GROWTH_GOALS.json\`) nests the filter under \`source\`. As a result the \`us_region\` filter for USA Partners was silently not being applied — the count included Brazilian and Swiss partners too. Before: 36 (unfiltered). After: 26 (US only).

2. **New \`starts_with\` predicate** — lets calendar-year filters be expressed via JSON so the sales goal can sum \`Monthly Sales Volume (USD)\` for rows where \`Year-Month\` starts with \`2026\` (instead of reading the since-inception cumulative cell which overstated progress).

## Companion PR
TrueSightDAO/agentic_ai_context PR \`fix/growth-goals-2026-sales-ytd\` updates GROWTH_GOALS.json to use the new predicate.

## Before
| Goal | Actual |
|------|--------|
| QR Sales (cumulative since inception) | \$13,995 / \$40K (35%) |
| USA Partners (filter not applied) | 36 / 100 (36%) |

## After
| Goal | Actual |
|------|--------|
| 2026 QR Sales | \$1,646 / \$40K (4%) — **behind** pace |
| USA Partners | 26 / 100 (26%) — on track |

🤖 Generated with [Claude Code](https://claude.com/claude-code)