### PR TITLE
feat(advisory): render Purpose & Mission north-star block at top of snapshot

### DIFF
--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -1023,6 +1023,16 @@ def _build_markdown(
     parts.append("# ADVISORY_SNAPSHOT\n\n")
     parts.append("Machine-oriented digest of **recent evidence** for LLM advisors. ")
     parts.append("Git lines are **proxies** for shipped work, not verified outcomes.\n\n")
+
+    # North star: purpose + mission. Placed FIRST so every LLM reading the
+    # snapshot sees the guiding frame before any goals, metrics, or evidence.
+    # Advisors should trace every suggestion back to this.
+    parts.append(_read_operator_block(
+        ctx_root / "PURPOSE_AND_MISSION.md",
+        "## Purpose & Mission (north star)",
+        "The guiding star: why we exist and the measurable mission every suggestion should serve.",
+    ))
+
     parts.append("---\n\n## Meta\n\n")
     parts.append(f"- Generated (UTC): `{now.strftime('%Y-%m-%dT%H:%M:%SZ')}`\n")
     parts.append(f"- Look-back: **{since_days}** calendar days (`{since_d.isoformat()}` → today UTC)\n")


### PR DESCRIPTION
## Summary
- Read \`agentic_ai_context/PURPOSE_AND_MISSION.md\` and insert a \`## Purpose & Mission (north star)\` section above Meta / Growth goals / evidence in ADVISORY_SNAPSHOT.md
- LLM advisors now read the guiding frame before any tactical data
- Reuses the existing \`_read_operator_block\` helper (same pattern as CONSTRAINTS.md / METRICS_WEEKLY.md)

## No GAS change needed
\`iching_oracle/gas/oracle_advisory_bridge.gs\` already fetches the advisory snapshot from raw GitHub. Once the next snapshot refresh publishes, the north star lands at the top of every Grok hexagram-reading prompt automatically.

## Companion PR
TrueSightDAO/agentic_ai_context PR \`feat/purpose-mission-and-beer-hall-audience-filter\` adds the PURPOSE_AND_MISSION.md file itself and a Beer Hall audience filter in OPENCLAW_WHATSAPP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)