### PR TITLE
Automate advisory snapshot refresh + weekly Beer Hall digest

### DIFF
--- a/.github/workflows/advisory-snapshot-refresh.yml
+++ b/.github/workflows/advisory-snapshot-refresh.yml
@@ -1,0 +1,139 @@
+# Regenerates ADVISORY_SNAPSHOT.md (oracle.truesight.me Grok context) from recent DAO
+# activity. Publishes to both TrueSightDAO/agentic_ai_context and
+# TrueSightDAO/ecosystem_change_logs via the Contents API (no cross-repo git push).
+#
+# Required repository secrets (go_to_market / market_research clone):
+#   ORACLE_ADVISORY_PUSH_TOKEN — fine-grained PAT with **Contents: Read and write** on
+#     TrueSightDAO/agentic_ai_context and TrueSightDAO/ecosystem_change_logs.
+#     (Classic PAT with `repo` scope also works.)
+#
+# Script: scripts/generate_advisory_snapshot.py --github-api-publish
+# (no --with-rem in CI — macOS rem CLI not available on Linux runners)
+#
+# Sibling DAO repos are checked out shallowly so `git log` evidence in the snapshot
+# reflects the last ~7 days of merges per repo.
+
+name: Advisory snapshot refresh
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 6 hours, offset from top-of-hour to avoid burst collisions with other workflows.
+    - cron: "27 */6 * * *"
+
+concurrency:
+  group: advisory-snapshot-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout market_research
+        uses: actions/checkout@v4
+        with:
+          path: repos/market_research
+
+      # --- sibling DAO repos for git-log evidence (read-only; shallow) ---
+
+      - name: Checkout truesight_me_beta
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/truesight_me_beta
+          path: repos/truesight_me
+          fetch-depth: 100
+
+      - name: Checkout agentic_ai_context
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/agentic_ai_context
+          path: repos/agentic_ai_context
+          fetch-depth: 100
+
+      - name: Checkout tokenomics
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/tokenomics
+          path: repos/tokenomics
+          fetch-depth: 100
+
+      - name: Checkout dapp
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/dapp
+          path: repos/dapp
+          fetch-depth: 100
+
+      - name: Checkout TrueChain
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/TrueChain
+          path: repos/TrueChain
+          fetch-depth: 100
+
+      - name: Checkout qr_codes
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/qr_codes
+          path: repos/qr_codes
+          fetch-depth: 100
+
+      - name: Checkout proposals
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/proposals
+          path: repos/proposals
+          fetch-depth: 100
+
+      - name: Checkout agroverse-inventory
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/agroverse-inventory
+          path: repos/agroverse-inventory
+          fetch-depth: 100
+
+      - name: Checkout agroverse_shop_beta
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/agroverse_shop_beta
+          path: repos/agroverse_shop
+          fetch-depth: 100
+
+      - name: Checkout oracle (iching_oracle)
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/oracle
+          path: repos/iching_oracle
+          fetch-depth: 100
+
+      - name: Checkout Cypher-Defense
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/Cypher-Defense
+          path: repos/Cypher-Defense
+          fetch-depth: 100
+          token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+
+      - name: Checkout ecosystem_change_logs (for BASE.md + archives + reminders)
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/ecosystem_change_logs
+          path: repos/ecosystem_change_logs
+          fetch-depth: 100
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install --upgrade pip
+
+      - name: Refresh snapshot and publish via GitHub Contents API
+        working-directory: repos/market_research
+        env:
+          TRUESIGHT_DAO_ORACLE_ADVISORY_PAT: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+        run: |
+          python3 scripts/generate_advisory_snapshot.py --github-api-publish

--- a/.github/workflows/beer-hall-digest-weekly.yml
+++ b/.github/workflows/beer-hall-digest-weekly.yml
@@ -1,0 +1,209 @@
+# Weekly Beer Hall digest — generates the preview, drafts Message 1 + Message 2 via
+# Claude, archives to TrueSightDAO/ecosystem_change_logs, refreshes the advisory snapshot,
+# and opens PRs on ecosystem_change_logs + agentic_ai_context for human review.
+#
+# NOTE: WhatsApp send via OpenClaw has been retired. This workflow does NOT post to WhatsApp.
+#
+# Required repository secrets (go_to_market / market_research clone):
+#   ANTHROPIC_API_KEY           — Anthropic API key for Claude (Sonnet 4.6 by default).
+#   GOOGLE_CREDENTIALS_JSON     — service account JSON (Sheets read — for telegram/DApp evidence blocks).
+#   ORACLE_ADVISORY_PUSH_TOKEN  — fine-grained PAT with Contents: Read+Write AND
+#                                 Pull requests: Read+Write on
+#                                 TrueSightDAO/ecosystem_change_logs and
+#                                 TrueSightDAO/agentic_ai_context.
+#
+# PRs are opened — NOT auto-merged — so you can review before the archive lands.
+
+name: Beer Hall digest (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Sundays 02:00 UTC (Saturday evening PT). Weekly cadence per operator decision.
+    - cron: "0 2 * * 0"
+
+concurrency:
+  group: beer-hall-digest-weekly
+  cancel-in-progress: false
+
+jobs:
+  draft-and-archive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      DATE_UTC: ""
+
+    steps:
+      - name: Checkout market_research
+        uses: actions/checkout@v4
+        with:
+          path: repos/market_research
+
+      # --- sibling DAO repos for git-log evidence (read-only; shallow) ---
+
+      - name: Checkout truesight_me_beta
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/truesight_me_beta, path: repos/truesight_me, fetch-depth: 100 }
+      - name: Checkout tokenomics
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/tokenomics, path: repos/tokenomics, fetch-depth: 100 }
+      - name: Checkout dapp
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/dapp, path: repos/dapp, fetch-depth: 100 }
+      - name: Checkout TrueChain
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/TrueChain, path: repos/TrueChain, fetch-depth: 100 }
+      - name: Checkout qr_codes
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/qr_codes, path: repos/qr_codes, fetch-depth: 100 }
+      - name: Checkout proposals
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/proposals, path: repos/proposals, fetch-depth: 100 }
+      - name: Checkout agroverse-inventory
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/agroverse-inventory, path: repos/agroverse-inventory, fetch-depth: 100 }
+      - name: Checkout agroverse_shop_beta
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/agroverse_shop_beta, path: repos/agroverse_shop, fetch-depth: 100 }
+      - name: Checkout oracle (iching_oracle)
+        uses: actions/checkout@v4
+        with: { repository: TrueSightDAO/oracle, path: repos/iching_oracle, fetch-depth: 100 }
+      - name: Checkout Cypher-Defense
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/Cypher-Defense
+          path: repos/Cypher-Defense
+          fetch-depth: 100
+          token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+
+      # --- target repos (writable; need PAT so we can push branches) ---
+
+      - name: Checkout ecosystem_change_logs (target)
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/ecosystem_change_logs
+          path: repos/ecosystem_change_logs
+          fetch-depth: 100
+          token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+
+      - name: Checkout agentic_ai_context (target — advisory mirror)
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/agentic_ai_context
+          path: repos/agentic_ai_context
+          fetch-depth: 100
+          token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "anthropic>=0.34" "gspread>=5.12" "google-auth>=2.23"
+
+      - name: Write Google credentials (for telegram/DApp evidence helpers)
+        run: |
+          echo '${{ secrets.GOOGLE_CREDENTIALS_JSON }}' > repos/market_research/google_credentials.json
+
+      - name: Compute UTC date
+        run: echo "DATE_UTC=$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
+
+      - name: Generate Beer Hall preview
+        working-directory: repos/market_research
+        run: |
+          python3 scripts/generate_beer_hall_preview.py --no-stdout --output /tmp/beer_hall_preview.md
+          ls -la /tmp/beer_hall_preview.md
+
+      - name: Draft Message 1 + Message 2 via Claude
+        working-directory: repos/market_research
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python3 scripts/draft_beer_hall_digest.py \
+            --preview /tmp/beer_hall_preview.md \
+            --out-msg1 /tmp/msg1.txt \
+            --out-msg2 /tmp/msg2.txt \
+            --out-slug /tmp/slug.txt
+          echo "--- Drafted slug: $(cat /tmp/slug.txt) ---"
+          echo "--- Message 1 (first 40 lines) ---"
+          head -40 /tmp/msg1.txt || true
+          echo "--- Message 2 (first 40 lines) ---"
+          head -40 /tmp/msg2.txt || true
+
+      - name: Archive digest to ecosystem_change_logs (local commit on feature branch)
+        working-directory: repos/ecosystem_change_logs
+        run: |
+          SLUG=$(cat /tmp/slug.txt | tr -d '\n' | tr -c 'a-z0-9-' '-' | sed 's/--*/-/g; s/^-//; s/-$//')
+          BRANCH="auto/beer-hall-${DATE_UTC}-${SLUG}"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          python3 scripts/archive_beer_hall_changelog.py \
+            --slug "$SLUG" \
+            --tldr-file /tmp/msg1.txt \
+            --message2-file /tmp/msg2.txt \
+            --notes "Drafted automatically by .github/workflows/beer-hall-digest-weekly.yml"
+          echo "BEERHALL_BRANCH=$BRANCH" >> $GITHUB_ENV
+          echo "SLUG=$SLUG" >> $GITHUB_ENV
+
+      - name: Refresh advisory snapshot (commits to both target clones on their branches)
+        working-directory: repos/market_research
+        run: |
+          # Ensure the agentic_ai_context target is also on a feature branch so ADVISORY_SNAPSHOT.md
+          # commits land on a branch we can push and PR.
+          (cd ../agentic_ai_context && \
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com" && \
+            git config user.name "github-actions[bot]" && \
+            git checkout -b "auto/advisory-refresh-${DATE_UTC}")
+          python3 scripts/generate_advisory_snapshot.py --git-commit
+
+      - name: Push ecosystem_change_logs branch
+        working-directory: repos/ecosystem_change_logs
+        env:
+          TARGET_TOKEN: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${TARGET_TOKEN}@github.com/TrueSightDAO/ecosystem_change_logs.git"
+          git push -u origin "$BEERHALL_BRANCH"
+
+      - name: Push agentic_ai_context branch
+        working-directory: repos/agentic_ai_context
+        env:
+          TARGET_TOKEN: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${TARGET_TOKEN}@github.com/TrueSightDAO/agentic_ai_context.git"
+          git push -u origin "auto/advisory-refresh-${DATE_UTC}"
+
+      - name: Open PR on ecosystem_change_logs
+        working-directory: repos/ecosystem_change_logs
+        env:
+          GH_TOKEN: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+        run: |
+          gh pr create \
+            --repo TrueSightDAO/ecosystem_change_logs \
+            --head "$BEERHALL_BRANCH" \
+            --base main \
+            --title "Beer Hall ${DATE_UTC}: ${SLUG}" \
+            --body "Auto-drafted by \`.github/workflows/beer-hall-digest-weekly.yml\` on market_research. Human review required before merge.
+
+          WhatsApp send is retired — this is an archive-only digest that feeds the static Beer Hall feed and the advisory snapshot (oracle.truesight.me Grok context).
+
+          Companion PR on \`agentic_ai_context\` refreshes the ADVISORY_SNAPSHOT mirror.
+
+          🤖 Generated with [Claude Sonnet 4.6](https://www.anthropic.com/)"
+
+      - name: Open PR on agentic_ai_context
+        working-directory: repos/agentic_ai_context
+        env:
+          GH_TOKEN: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
+        run: |
+          gh pr create \
+            --repo TrueSightDAO/agentic_ai_context \
+            --head "auto/advisory-refresh-${DATE_UTC}" \
+            --base main \
+            --title "chore(advisory): refresh ADVISORY_SNAPSHOT (${DATE_UTC})" \
+            --body "Companion to TrueSightDAO/ecosystem_change_logs Beer Hall PR (same date).
+
+          Auto-generated by \`market_research/.github/workflows/beer-hall-digest-weekly.yml\`."

--- a/scripts/draft_beer_hall_digest.py
+++ b/scripts/draft_beer_hall_digest.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Draft Beer Hall **Message 1** (TLDR) and **Message 2** (Shipped + Community) by feeding
+the output of ``generate_beer_hall_preview.py`` to **Anthropic Claude**.
+
+The Beer Hall WhatsApp send has been retired — digests are **archive-only** artifacts
+that feed the static ``beer_hall/feed/`` (read by truesight.me) and ``ADVISORY_SNAPSHOT.md``
+(read by the oracle at oracle.truesight.me). This drafter replaces the manual/LLM-in-IDE
+summarisation step so the weekly GitHub Action can run end-to-end.
+
+Writes three files:
+
+* ``--out-msg1``      — Message 1 (TLDR; no URLs)
+* ``--out-msg2``      — Message 2 (``Shipped`` bullets with GitHub URLs + optional Community section)
+* ``--out-slug``      — short kebab-case slug for the archive filename
+
+Uses the latest 2 Beer Hall archives under
+``../ecosystem_change_logs/beer_hall/entries/beer-hall_*.md`` as few-shot style examples
+(auto-picked; override with ``--examples-dir``).
+
+Usage (from ``market_research/``)::
+
+    python3 scripts/draft_beer_hall_digest.py \\
+      --preview /tmp/beer_hall_preview.md \\
+      --out-msg1 /tmp/msg1.txt \\
+      --out-msg2 /tmp/msg2.txt \\
+      --out-slug /tmp/slug.txt
+
+Requires ``ANTHROPIC_API_KEY`` in env. Default model is **Claude Sonnet 4.6**
+(``claude-sonnet-4-6``); override with ``--model``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def _default_examples_dir() -> Path:
+    return _REPO.parent / "ecosystem_change_logs" / "beer_hall" / "entries"
+
+
+def _recent_examples(examples_dir: Path, limit: int = 2) -> list[str]:
+    """Return the body text of the most recent N archive ``.md`` files (frontmatter stripped)."""
+    if not examples_dir.is_dir():
+        return []
+    entries = sorted(examples_dir.glob("beer-hall_*.md"), reverse=True)[:limit]
+    out: list[str] = []
+    for p in entries:
+        raw = p.read_text(encoding="utf-8")
+        m = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)$", raw.strip(), re.DOTALL)
+        body = m.group(2) if m else raw
+        out.append(f"--- Example archive: {p.name} ---\n{body.strip()}\n")
+    return out
+
+
+_SYSTEM = """You draft the weekly **Beer Hall digest** for the TrueSight DAO — a regenerative cacao supply chain DAO. Your audience is DAO contributors, partners, and non-engineer stakeholders (not only developers).
+
+Output is consumed by the truesight.me static Beer Hall feed and by the oracle.truesight.me Grok advisor. It is NOT broadcast to WhatsApp.
+
+Style rules:
+
+1. Write plain, concrete prose. No marketing fluff.
+2. Lead with user-visible outcomes, not technical internals. "81% bars now live in Oscar + Santa Ana" beats "merged PR #65".
+3. Highlight DAO-meaningful shipments only: partner-facing features, sales wiring, contributor tools, blog/narrative, incident response. Drop purely internal chore/docs commits.
+4. Every GitHub URL must be under `https://github.com/TrueSightDAO/...`. No personal or KrakeIO repos.
+5. Group Community (Telegram) signals under a separate "Community" heading inside Message 2 if present — contributor attributions, contested decisions, field notes.
+6. Keep Message 1 ~8–12 bullets. Keep Message 2 focused on meaningful work items (not every single PR) with 1–2 URLs per bullet max.
+7. The opener line is required: "OpenClaw × Cursor digest — retired from WhatsApp posting; archive-only for oracle / feed context (not a manual post from Gary)"
+
+Output format — return **only** these three sections, in order, with the exact markers shown:
+
+===SLUG===
+<kebab-case slug, 3–6 words, capturing the week's headline>
+===MESSAGE_1===
+<opener line + TLDR bullets>
+===MESSAGE_2===
+Shipped
+
+<bulleted list with GitHub URLs>
+
+Community (Telegram log):
+
+<optional: contributor signals if any in evidence>
+
+No commentary before, between, or after the markers."""
+
+
+_USER_TEMPLATE = """Here is this week's evidence pack from generate_beer_hall_preview.py. Synthesise it into Message 1 + Message 2 per the system rules.
+
+{examples_block}
+
+=== THIS WEEK'S EVIDENCE (preview output) ===
+
+{preview}
+"""
+
+
+def _extract_sections(raw: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current = None
+    buf: list[str] = []
+    for line in raw.splitlines():
+        m = re.match(r"^===(SLUG|MESSAGE_1|MESSAGE_2)===\s*$", line.strip())
+        if m:
+            if current:
+                sections[current] = "\n".join(buf).strip()
+            current = m.group(1)
+            buf = []
+        else:
+            if current:
+                buf.append(line)
+    if current:
+        sections[current] = "\n".join(buf).strip()
+    return sections
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--preview", required=True, type=Path, help="Path to generate_beer_hall_preview.py output.")
+    ap.add_argument("--out-msg1", required=True, type=Path)
+    ap.add_argument("--out-msg2", required=True, type=Path)
+    ap.add_argument("--out-slug", required=True, type=Path)
+    ap.add_argument("--examples-dir", type=Path, default=None, help="Beer Hall archive dir for few-shot (default: ../ecosystem_change_logs/beer_hall/entries).")
+    ap.add_argument("--examples-count", type=int, default=2)
+    ap.add_argument("--model", default="claude-sonnet-4-6", help="Anthropic model id (default claude-sonnet-4-6).")
+    ap.add_argument("--max-tokens", type=int, default=4000)
+    args = ap.parse_args()
+
+    if "ANTHROPIC_API_KEY" not in os.environ:
+        sys.stderr.write("ANTHROPIC_API_KEY not set in environment.\n")
+        return 2
+
+    try:
+        import anthropic  # type: ignore
+    except ImportError:
+        sys.stderr.write("The 'anthropic' package is required. Install with: pip install anthropic\n")
+        return 2
+
+    preview_text = args.preview.read_text(encoding="utf-8")
+    examples_dir = args.examples_dir or _default_examples_dir()
+    examples = _recent_examples(examples_dir, limit=args.examples_count)
+    examples_block = (
+        "For style reference, here are the most recent archived digests:\n\n"
+        + "\n".join(examples)
+        if examples
+        else "(No prior archives available for style reference — follow the system rules.)"
+    )
+
+    client = anthropic.Anthropic()
+    resp = client.messages.create(
+        model=args.model,
+        max_tokens=args.max_tokens,
+        system=_SYSTEM,
+        messages=[
+            {
+                "role": "user",
+                "content": _USER_TEMPLATE.format(examples_block=examples_block, preview=preview_text),
+            }
+        ],
+    )
+    text = "".join(block.text for block in resp.content if getattr(block, "type", "") == "text").strip()
+    sections = _extract_sections(text)
+
+    for key in ("SLUG", "MESSAGE_1", "MESSAGE_2"):
+        if not sections.get(key):
+            sys.stderr.write(f"Model response missing section {key}. Full response:\n{text}\n")
+            return 1
+
+    args.out_slug.write_text(sections["SLUG"].strip() + "\n", encoding="utf-8")
+    args.out_msg1.write_text(sections["MESSAGE_1"].rstrip() + "\n", encoding="utf-8")
+    args.out_msg2.write_text(sections["MESSAGE_2"].rstrip() + "\n", encoding="utf-8")
+    print(f"slug:    {sections['SLUG'].strip()}", file=sys.stderr)
+    print(f"msg1:    {args.out_msg1} ({len(sections['MESSAGE_1'])} chars)", file=sys.stderr)
+    print(f"msg2:    {args.out_msg2} ({len(sections['MESSAGE_2'])} chars)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Two new GH Actions workflows + a Claude-powered drafter script — closes the loop the operator asked about (there was no automation at all before).

### Workflow A — \`advisory-snapshot-refresh.yml\` (every 6 h)
Runs \`generate_advisory_snapshot.py --github-api-publish\` after checking out 11 DAO sibling repos shallowly. Pushes to both \`agentic_ai_context\` and \`ecosystem_change_logs\` via the GitHub Contents API. Keeps \`oracle.truesight.me\` Grok context fresh without any human involvement.

### Workflow B — \`beer-hall-digest-weekly.yml\` (Sundays 02:00 UTC)
End-to-end digest drafting:
1. Generate preview
2. Call Claude (Sonnet 4.6) via new \`scripts/draft_beer_hall_digest.py\` — feeds preview + latest 2 archives as few-shot style examples
3. Archive to \`ecosystem_change_logs/beer_hall/entries/\`
4. Refresh advisory snapshot
5. **Open PRs** on \`ecosystem_change_logs\` + \`agentic_ai_context\` — **NOT auto-merged.** Operator reviews before publishing.

No WhatsApp send (retired last PR).

## Secrets required on this repo
- \`ANTHROPIC_API_KEY\` ✅ already set
- \`GOOGLE_CREDENTIALS_JSON\` ✅ already set (shared with other workflows)
- \`ORACLE_ADVISORY_PUSH_TOKEN\` ⚠️ **new — operator must create.** Fine-grained PAT with:
  - Contents: Read+Write on \`ecosystem_change_logs\` and \`agentic_ai_context\`
  - Pull requests: Read+Write on the same two repos
  - Contents: Read on \`Cypher-Defense\` (if it's private)

## Test plan
- [ ] After merge + \`ORACLE_ADVISORY_PUSH_TOKEN\` added: \`gh workflow run advisory-snapshot-refresh.yml -R TrueSightDAO/go_to_market\`
- [ ] Then: \`gh workflow run beer-hall-digest-weekly.yml -R TrueSightDAO/go_to_market\` → review the two opened PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)