### PR TITLE
Fix beer-hall-digest-daily: actually commit beer_hall/ files

### DIFF
--- a/.github/workflows/beer-hall-digest-daily.yml
+++ b/.github/workflows/beer-hall-digest-daily.yml
@@ -145,6 +145,17 @@ jobs:
             --tldr-file /tmp/msg1.txt \
             --message2-file /tmp/msg2.txt \
             --notes "Drafted automatically by .github/workflows/beer-hall-digest-daily.yml"
+          # archive_beer_hall_changelog.py only WRITES files — we still need to commit them
+          # before the advisory-snapshot --git-commit step (which only stages advisory paths).
+          # Without this, beer_hall/entries/ + regenerated beer_hall/feed/ would never reach
+          # the PR, and truesight.me's ecosystem-change-log-feed.js would keep serving stale
+          # data from raw.githubusercontent.com.
+          git add beer_hall/entries/ beer_hall/feed/
+          if git diff --staged --quiet; then
+            echo "archive_beer_hall_changelog.py produced no staged changes — unexpected. Aborting."
+            exit 1
+          fi
+          git commit -m "chore(beer-hall): archive ${DATE_UTC} digest (${SLUG}) [skip ci]"
           echo "BEERHALL_BRANCH=$BRANCH" >> $GITHUB_ENV
           echo "SLUG=$SLUG" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Summary
The daily Beer Hall workflow was silently dropping the beer_hall files it drafted. Since 2026-04-20 the scheduled PRs (\`auto/beer-hall-YYYY-MM-DD-…\`) only changed \`advisory/…\`, while the actual \`beer_hall/entries/*.md,.json\` and regenerated \`beer_hall/feed/page-1.json + manifest.json\` were written in the CI container but never committed.

Consequence: \`truesight.me\`'s \`js/ecosystem-change-log-feed.js\` (which reads \`beer_hall/feed/manifest.json\` + \`page-1.json\` off \`raw.githubusercontent.com\`) kept serving the feed last committed manually on 2026-04-19.

## Root cause
\`archive_beer_hall_changelog.py\` only *writes* files; the next step's \`generate_advisory_snapshot.py --git-commit\` only stages advisory paths. Nothing staged the beer_hall files.

## Fix
After \`archive_beer_hall_changelog.py\`:
- \`git add beer_hall/entries/ beer_hall/feed/\`
- Commit with a clear message
- Abort if nothing was staged (would signal a silent regression)

Ordering preserved: beer_hall commit lands first, then advisory snapshot piles its commit on top of the same feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)