### PR TITLE
fix(advisory): read metrics from ecosystem_change_logs; drop CONSTRAINTS

### DIFF
--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -1039,18 +1039,16 @@ def _build_markdown(
     parts.append(f"- Curated clone set: **{len(REPOS)}** repos (same table as Beer Hall preview)\n\n")
 
     # Operator-curated strategic frame. Placed before evidence so the LLM reads
-    # goals / constraints / metrics *first*, then interprets the activity below.
-    # Growth goals are auto-computed against live sheet data (GROWTH_GOALS.json).
+    # goals / metrics *first*, then interprets the activity below. Growth goals
+    # are auto-computed against live sheet data (GROWTH_GOALS.json). Pipeline
+    # metrics are auto-synced from the Holistic Hit List Pipeline Dashboard by
+    # tokenomics/google_app_scripts/pipeline_metrics_snapshot.
     parts.append(_render_goal_progress_block(ctx_root, _REPO / "google_credentials.json"))
     parts.append(_read_operator_block(
-        ctx_root / "CONSTRAINTS.md",
-        "## Constraints / risks this week",
-        "Current bottlenecks (capital, inventory, fulfilment, capacity, distribution).",
-    ))
-    parts.append(_read_operator_block(
-        ctx_root / "METRICS_WEEKLY.md",
-        "## Operator metrics (manual, 7-day)",
-        "Numbers that cannot be auto-derived from sheets. Complements --with-sheet-sales.",
+        eco_repo / "metrics" / "weekly.md",
+        "## Operator metrics (pipeline funnel, auto-synced)",
+        "Partner-pipeline counts by status, mirrored from the Holistic Hit List Pipeline Dashboard. "
+        "Refreshed by tokenomics `pipeline_metrics_snapshot` GAS.",
     ))
 
     parts.append("---\n\n## CONTEXT_UPDATES (append-only, heuristic highlights)\n\n")


### PR DESCRIPTION
## Summary

- Repoint the "Operator metrics" section of `ADVISORY_SNAPSHOT.md` at `ecosystem_change_logs/metrics/weekly.md` (auto-synced by the new `pipeline_metrics_snapshot` GAS in tokenomics) instead of the never-filled `agentic_ai_context/METRICS_WEEKLY.md` stub.
- Drop the "Constraints / risks this week" section entirely — it required manual weekly curation that never happened, and the operator feedback is that qualitative-bullets blocks are dead weight compared to signals already surfacing via reminders + activity evidence.

## Why

`oracle.truesight.me` has been flagging missing operator metrics as a context gap on every call for days, because `ADVISORY_SNAPSHOT.md` has been embedding literal `<!-- TODO: replace the examples below... -->` comments — the stubs in agentic_ai_context were only ever committed as templates.

## What changes

- `scripts/generate_advisory_snapshot.py`: one `_read_operator_block` call repointed (CONSTRAINTS → dropped; METRICS_WEEKLY → `eco_repo / "metrics" / "weekly.md"`).
- No other references to `CONSTRAINTS.md` / `METRICS_WEEKLY.md` anywhere in the tree.
- CI layout unchanged — `repos/ecosystem_change_logs` is already checked out by `advisory-snapshot-refresh.yml`, so `eco_repo` resolves correctly.

## Transition

Graceful: if `metrics/weekly.md` doesn't exist yet (first snapshot after merge, before GAS has run once), `_read_operator_block` prints `_Not yet created. Add weekly.md at ... to surface this here._` in the same slot — visible signal, no hard failure.

Paired PRs:
- tokenomics (adds the GAS that populates the new path): https://github.com/TrueSightDAO/tokenomics/pull/new/feat/pipeline-metrics-snapshot
- agentic_ai_context (drops the now-unused stubs): https://github.com/TrueSightDAO/agentic_ai_context/pull/new/chore/drop-metrics-constraints-stubs

Recommended merge order:
1. tokenomics PR + manually deploy the GAS + `syncPipelineMetrics()` once
2. this PR
3. agentic_ai_context PR

## Test plan

- [ ] Python syntax check: `python3 -c "import ast; ast.parse(open('scripts/generate_advisory_snapshot.py').read())"` (done locally ✓)
- [ ] Dry-run `_read_operator_block` with a missing file — emits "Not yet created" prompt (verified locally ✓)
- [ ] Dry-run with a populated mock `metrics/weekly.md` — strips the leading h1 and embeds body (verified locally ✓)
- [ ] Grep: no remaining references to `CONSTRAINTS.md` or `METRICS_WEEKLY.md` in the repo (verified ✓)
- [ ] After merge, manually trigger `advisory-snapshot-refresh` workflow; confirm the generated snapshot shows either a real funnel (if GAS has already seeded the file) or a "Not yet created" prompt (if not) — not a TODO comment block

🤖 Generated with [Claude Code](https://claude.com/claude-code)