### PR TITLE
feat(hit-list): email follow-up tracking, AU/AV on new rows, discard cadence bypass

### DIFF
--- a/.github/workflows/manager-followup-drafts.yml
+++ b/.github/workflows/manager-followup-drafts.yml
@@ -5,7 +5,7 @@
 # Cadence: suggest_manager_followup_drafts + suggest_warmup_prospect_drafts use the latest sent_at
 # in "Email Agent Follow Up" per recipient (filled by sync_email_agent_followup from Gmail sent mail).
 # A draft is created only if that send is at least min_days_since_sent ago (default 7) and there is
-# no pending_review row in Email Agent Suggestions. Warmup also promotes AI: Warm up prospect →
+# no pending_review row in Email Agent Drafts. Warmup also promotes AI: Warm up prospect →
 # AI: Prospect replied when Gmail shows inbound from the prospect after the last logged send.
 # Most runs may create zero drafts if no one is "due."
 #

--- a/HIT_LIST_CREDENTIALS.md
+++ b/HIT_LIST_CREDENTIALS.md
@@ -163,7 +163,13 @@ If the tab is missing, `scripts/sync_email_agent_followup.py` creates it and wri
 | `subject` | Message subject from Gmail. |
 | `sent_at` | `Date` header from Gmail (as returned by the API). |
 | `snippet` | Short preview text. |
+| `body_plain` | Best-effort plain body (for draft / Grok context). |
+| `status` | Outbound **kind** for this Gmail **Sent** row: `warmup` · `bulk` · `follow_up` · `unknown` — inferred from Gmail labels (`AI/Sent Warm-up`, `AI/Sent Follow-up`, …) plus **Email Agent Drafts** `protocol_version` when labels are ambiguous (e.g. bulk vs manager share the same follow-up sent label). |
 | `sync_source` | e.g. `gmail_sent_sync`. |
+| `Open` | **Column L** — count (or flag) of **tracked opens** for this sent message; new rows default to **`0`**. Intended to be incremented by **Edgar** (or another HTTPS endpoint) when a draft/sent body includes a 1×1 pixel whose URL carries the same **`suggestion_id`** as **Email Agent Drafts** (see `scripts/email_agent_tracking.py` and `--track-opens` on draft scripts). |
+| `Click through` | **Column M** — **click-through** count (or similar); new rows default to **`0`**. Same integration story as **Open**; link rewriting like `send_newsletter.py`’s `/newsletter/click` is not wired into partner drafts yet. |
+
+**Why not only GAS `doGet` for the pixel?** A standalone Apps Script web app *can* log hits and call `SpreadsheetApp`, but: (1) every image load spins a cold execution and burns quotas; (2) the web app must be **Anyone**-accessible without user OAuth, so the URL must carry an **unguessable token** (`tid` = `suggestion_id`) and the script must validate it; (3) at **draft** time there is no **`gmail_message_id`** yet, so the first writes are usually keyed by **`suggestion_id`**, then a small job can copy counts onto the **Follow Up** row after `sync_email_agent_followup.py` matches the sent message. **Edgar** (Rails) is a better fit if you already run tracking pixels for the newsletter: one service account, shared logging, same pattern as `GET …/newsletter/open.gif`.
 
 ### Run sync (after Gmail OAuth + service account sheet share)
 
@@ -172,9 +178,10 @@ cd market_research
 source venv/bin/activate
 python3 scripts/sync_email_agent_followup.py --dry-run    # preview
 python3 scripts/sync_email_agent_followup.py            # append new rows
+python3 scripts/sync_email_agent_followup.py --backfill-status --backfill-only  # classify existing rows
 ```
 
-Options: `--limit N` (max distinct addresses), `--per-address-cap` (max messages per address, default 200).
+Options: `--limit N` (max distinct addresses), `--per-address-cap` (max messages per address, default 200). **`--backfill-status`** fills or refreshes the **`status`** column using Gmail metadata + **Email Agent Drafts** history; add **`--force-backfill-status`** to overwrite non-empty cells.
 
 **Auth:** Sheets = **service account** (`google_credentials.json`). Gmail = **user OAuth** (`credentials/gmail/`). Future “draft + send + update Status” flows can extend this script or call the same libraries.
 
@@ -190,11 +197,11 @@ Safe to run multiple times. If Google returns an error about an existing banded 
 
 ---
 
-## Email Agent Suggestions tab (draft queue + registry)
+## Email Agent Drafts tab (draft queue + registry)
 
 **Purpose:** One row per **proposed follow-up** while the human reviews in **Gmail**. The canonical editable message lives as a **Gmail draft**; this tab is the **audit / queue** (join to Hit List via `store_key` / `hit_list_row`). Pairs with **Email Agent Follow Up**, which logs **sent** mail after you hit Send.
 
-**Sheet:** Same spreadsheet — tab name **`Email Agent Suggestions`**.
+**Sheet:** Same spreadsheet — tab name **`Email Agent Drafts`**.
 
 **Gmail (optional but recommended):** Apply user label **`Email Agent suggestions`** to drafts the automation creates so they are easy to filter in the Gmail UI (create the label once manually, or use `users.labels.create` in a future script). The tab also stores the label name in column `gmail_label` for documentation.
 
@@ -219,18 +226,40 @@ python3 scripts/format_email_agent_suggestions_sheet.py
 | `gmail_draft_id` | Gmail **Draft** id from `drafts.create` / API. |
 | `subject` | Draft subject (mirror of Gmail). |
 | `body_preview` | First ~500 characters of body for quick scan in Sheets. |
-| `status` | `pending_review` · `sent` · `discarded` · `superseded` (conventions; adjust as needed). |
+| `status` | Draft lifecycle on this tab — **not** the same field as **Email Agent Follow Up → `status`**. Typical values: **`pending_review`** (Gmail draft exists; **not yet sent**), **`discarded`** (draft removed / reconciled as abandoned — **not sent**), **`sent`** (optional manual convention if you mark a row after sending), **`superseded`** (replaced by a newer draft row). Cadence scripts (`suggest_*_drafts.py`) reconcile missing drafts to **`discarded`**. |
 | `gmail_label` | e.g. `Email Agent suggestions`. |
 | `protocol_version` | e.g. `PARTNER_OUTREACH_PROTOCOL v0.1`. |
 | `notes` | Free text — why this touch, thread summary, etc. |
 
-**Workflow:** Automation (or you) creates a Gmail draft → append a row here → you **edit/send** from Gmail → run `sync_email_agent_followup.py` so **Email Agent Follow Up** captures the sent message → set `status` to `sent` on this row (manual or future script).
+**Warm-up emails actually sent (Hit List column AU — e.g. “Warm-up email sent”):** Count rows on **`Email Agent Follow Up`** where **`status` = `warmup`** (each row is already a Gmail **Sent** message). That excludes draft-registry **`pending_review`** / **`discarded`** rows on **Email Agent Drafts**, which are **not** sends.
+
+**Follow-up emails actually sent (Hit List column AV — e.g. “Follow-up emails sent”):** Same join, but **`status` = `follow_up`** on **Email Agent Follow Up** (manager-style follow-ups and other non–warm-up sends classified by the sync script).
+
+```excel
+=IF($AD2<>"", COUNTIFS('Email Agent Follow Up'!$C:$C, $AD2, 'Email Agent Follow Up'!$J:$J, "warmup"), IF($K2<>"", COUNTIFS('Email Agent Follow Up'!$E:$E, LOWER($K2), 'Email Agent Follow Up'!$J:$J, "warmup"), 0))
+```
+
+```excel
+=IF($AD2<>"", COUNTIFS('Email Agent Follow Up'!$C:$C, $AD2, 'Email Agent Follow Up'!$J:$J, "follow_up"), IF($K2<>"", COUNTIFS('Email Agent Follow Up'!$E:$E, LOWER($K2), 'Email Agent Follow Up'!$J:$J, "follow_up"), 0))
+```
+
+- **$AD** = Hit List **Store Key**; **$K** = **Email** (fallback when Store Key is blank).  
+- **Follow Up columns:** `C` = `store_key`, `E` = `to_email`, `J` = **`status`** (warmup|bulk|follow_up|unknown).
+
+Re-apply **AU and AV** formulas down the sheet after large imports:
+
+```bash
+cd market_research
+python3 scripts/set_hit_list_warmup_touches_formula.py
+```
+
+**Workflow:** Automation (or you) creates a Gmail draft → append a row on **Email Agent Drafts** with `status=pending_review` → you **edit/send** from Gmail → run `sync_email_agent_followup.py` so **Email Agent Follow Up** captures the **Sent** message (with **`status`** = warmup/bulk/follow_up/unknown). Optionally set the draft row’s **`status`** to `sent` or `discarded` for your own queue hygiene; cadence scripts may set **`discarded`** when the Gmail draft disappears.
 
 ### Create drafts from Hit List (`garyjob@agroverse.shop`)
 
 Script: **`scripts/suggest_manager_followup_drafts.py`** — loads **Manager Follow-up** + **Email**, skips recipients that already have **`pending_review`** (and an open Gmail draft), builds a **Gmail draft** (optional **Grok** + DApp Remarks context), applies label **`Email Agent suggestions`**, appends a row here.
 
-**Warm up prospect (first touch + PDF):** **`scripts/suggest_warmup_prospect_drafts.py`** — **Status** **`AI: Warm up prospect`** + **Email**; same cadence (**7** days default since last logged send in **Email Agent Follow Up**), **`Email Agent Suggestions`** queue, and optional **`--use-grok`** (same xAI API as manager follow-up). Attaches **`retail_price_list/agroverse_wholesale_price_list_2026.pdf`**. Style reference: **`templates/warmup_outreach_reference.md`**. Before drafting, promotes **AI: Warm up prospect → AI: Prospect replied** when Gmail shows an **inbound** from the prospect **after** your latest logged **sent** to that address. CI: **`manager-followup-drafts.yml`** runs this step after manager drafts. Flags: **`--reply-promotion-only`**, **`--skip-reply-promotion`**.
+**Warm up prospect (first touch + PDF):** **`scripts/suggest_warmup_prospect_drafts.py`** — **Status** **`AI: Warm up prospect`** + **Email**; same cadence (**7** days default since last logged send in **Email Agent Follow Up**), **`Email Agent Drafts`** queue, and optional **`--use-grok`** (same xAI API as manager follow-up). Attaches **`retail_price_list/agroverse_wholesale_price_list_2026.pdf`**. Style reference: **`templates/warmup_outreach_reference.md`**. Before drafting, promotes **AI: Warm up prospect → AI: Prospect replied** when Gmail shows an **inbound** from the prospect **after** your latest logged **sent** to that address. CI: **`manager-followup-drafts.yml`** runs this step after manager drafts. Flags: **`--reply-promotion-only`**, **`--skip-reply-promotion`**.
 
 OAuth must include **`https://www.googleapis.com/auth/gmail.modify`**. If your `token.json` was created with older scopes, delete it and run `python3 scripts/gmail_oauth_authorize.py` again (add scope on Google Cloud consent screen first).
 
@@ -242,7 +271,7 @@ python3 scripts/suggest_manager_followup_drafts.py --max-drafts 1
 
 Options: `--skip-label`, `--expected-mailbox other@domain` (default `garyjob@agroverse.shop`).
 
-**Cadence / anti-spam:** Only one **pending** draft per **`to_email`** (see **Email Agent Suggestions** `status=pending_review`). The next draft is allowed only after **`min-days-since-sent`** (default **7**) since the latest **`sent_at`** for that address in **Email Agent Follow Up**. Recipients with no follow-up log row are eligible immediately. Use `--verbose` to print per-address skips. When you **Send** from Gmail, run `sync_email_agent_followup.py`, then set the suggestion row to `sent` (or `discarded`); the next scheduled run can draft again once cadence passes.
+**Cadence / anti-spam:** Only one **pending** draft per **`to_email`** (see **Email Agent Drafts** `status=pending_review`). The next draft is allowed only after **`min-days-since-sent`** (default **7**) since the latest **`sent_at`** for that address in **Email Agent Follow Up**. Recipients with no follow-up log row are eligible immediately. Use `--verbose` to print per-address skips. When you **Send** from Gmail, run `sync_email_agent_followup.py`, then set the suggestion row to `sent` (or `discarded`); the next scheduled run can draft again once cadence passes.
 
 **`Bulk Info Requested`:** **`scripts/suggest_bulk_info_drafts.py`** — wholesale-focused template + same PDF attachment; same cadence rules.
 

--- a/physical_stores/find_nearby_stores.gs
+++ b/physical_stores/find_nearby_stores.gs
@@ -128,6 +128,53 @@ const HIT_LIST_OPENING_HOUR_HEADERS = [
 const GOOGLE_LISTING_HEADER = 'Google listing';
 
 /**
+ * Hit List columns **AU** / **AV** (1-based A=1 …), same layout as
+ * ``market_research/scripts/set_hit_list_warmup_touches_formula.py``.
+ */
+const HIT_LIST_COL_AU = 47;
+const HIT_LIST_COL_AV = 48;
+
+/**
+ * COUNTIFS against **Email Agent Follow Up** (``C`` = ``store_key``, ``E`` = ``to_email``, ``J`` = ``status``).
+ * @param {number} row Hit List data row (1-based, matches Sheets).
+ * @param {string} status ``warmup`` or ``follow_up`` (from ``sync_email_agent_followup.py``).
+ * @return {string}
+ */
+function hitListSentTouchCountFormula_(row, status) {
+  return (
+    '=IF($AD' +
+      row +
+      '<>"", COUNTIFS(\'Email Agent Follow Up\'!$C:$C, $AD' +
+      row +
+      ', \'Email Agent Follow Up\'!$J:$J, "' +
+      status +
+      '"), IF($K' +
+      row +
+      '<>"", COUNTIFS(\'Email Agent Follow Up\'!$E:$E, LOWER($K' +
+      row +
+      '), \'Email Agent Follow Up\'!$J:$J, "' +
+      status +
+      '"), 0))'
+  );
+}
+
+/**
+ * Writes AU (warm-up sends) and AV (follow-up sends) for one Hit List row.
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ * @param {number} rowNum 1-based sheet row
+ */
+function applyHitListAuAvFormulasToRow_(sheet, rowNum) {
+  sheet
+    .getRange(rowNum, HIT_LIST_COL_AU, rowNum, HIT_LIST_COL_AV)
+    .setFormulas([
+      [
+        hitListSentTouchCountFormula_(rowNum, 'warmup'),
+        hitListSentTouchCountFormula_(rowNum, 'follow_up'),
+      ],
+    ]);
+}
+
+/**
  * Sheets often returns times as Date (1899-12-30 wall clock) or as a day-fraction number.
  * Open-now parsing expects "HH:mm" text; this normalizes before parseHmToMinutes_.
  * @param {*} raw Cell value from getValues()
@@ -1068,6 +1115,7 @@ function addNewStore(storeData) {
   }
 
   sheet.appendRow(row);
+  applyHitListAuAvFormulasToRow_(sheet, sheet.getLastRow());
 
   const submissionId = logDappSubmission_(spreadsheet, storeData.shopName, storeData.status, storeData.remarks, submittedBy, true);
   return {

--- a/scripts/email_agent_tracking.py
+++ b/scripts/email_agent_tracking.py
@@ -1,0 +1,45 @@
+"""
+Optional open tracking for Email Agent Gmail drafts.
+
+Embeds a 1×1 image pointing at **Edgar** (or another HTTPS host) so a future endpoint can
+record opens. The URL carries ``tid=<suggestion_id>`` (same UUID written to **Email Agent Drafts**).
+
+**Follow Up sheet** columns **Open** / **Click through** (see ``sync_email_agent_followup.py``) are
+intended to be updated by that endpoint (or a small relay) once a matching **sent** row exists.
+At draft time there is no ``gmail_message_id`` yet, so the pixel cannot target column L/M directly
+until Edgar correlates ``tid`` → ``gmail_message_id`` after ``sync_email_agent_followup.py`` runs.
+
+Environment / CLI
+-------------------
+- ``EMAIL_AGENT_TRACKING_BASE_URL`` — default ``https://edgar.truesight.me`` (no trailing slash required).
+- Draft scripts: ``--track-opens`` to attach the HTML part + pixel (plain part stays for clients that
+  prefer text).
+
+**Clicks** are not rewritten here; reserve **Click through** (column M) for a future Edgar
+``/email_agent/click`` redirector similar to ``send_newsletter.py``.
+"""
+
+from __future__ import annotations
+
+import html
+import urllib.parse
+
+
+def build_open_pixel_html(base_url: str, suggestion_id: str) -> str:
+    tid = urllib.parse.quote((suggestion_id or "").strip(), safe="")
+    url = f"{base_url.rstrip('/')}/email_agent/open.gif?tid={tid}"
+    return (
+        f'<img src="{url}" alt="" width="1" height="1" '
+        'style="display:block;border:0;width:1px;height:1px;" />'
+    )
+
+
+def plain_text_to_html_with_open_pixel(plain: str, base_url: str, suggestion_id: str) -> str:
+    """Wrap plain text as HTML and append the tracking pixel (multipart/alternative HTML half)."""
+    body = html.escape(plain or "", quote=False)
+    wrapped = (
+        '<div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;'
+        'font-size:15px;line-height:1.45;white-space:pre-wrap;">'
+        f"{body}</div>"
+    )
+    return wrapped + build_open_pixel_html(base_url, suggestion_id)

--- a/scripts/ensure_email_agent_suggestions_sheet.py
+++ b/scripts/ensure_email_agent_suggestions_sheet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Create the Hit List tab "Email Agent Suggestions" with a standard header row if missing.
+Create the Hit List tab "Email Agent Drafts" with a standard header row if missing.
 
 Use this registry alongside Gmail API drafts.create: each suggestion row tracks store context,
 gmail_draft_id, and status. Optional Gmail user label: "Email Agent suggestions" (see HIT_LIST_CREDENTIALS.md).
@@ -22,7 +22,8 @@ from google.oauth2.service_account import Credentials as SACredentials
 _REPO = Path(__file__).resolve().parent.parent
 _SA_CREDS = _REPO / "google_credentials.json"
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
-SUGGESTIONS_WS = "Email Agent Suggestions"
+SUGGESTIONS_WS = "Email Agent Drafts"
+LEGACY_SUGGESTIONS_WS = "Email Agent Suggestions"
 
 SHEETS_SCOPES = [
     "https://www.googleapis.com/auth/spreadsheets",
@@ -63,11 +64,17 @@ def main() -> None:
     try:
         ws = sh.worksheet(SUGGESTIONS_WS)
     except gspread.WorksheetNotFound:
-        ws = sh.add_worksheet(title=SUGGESTIONS_WS, rows=2000, cols=len(SUGGESTIONS_HEADERS))
-        ws.append_row(SUGGESTIONS_HEADERS, value_input_option="USER_ENTERED")
-        print(f"Created {SUGGESTIONS_WS!r} with header row ({len(SUGGESTIONS_HEADERS)} columns).")
-        print(f"Optional Gmail label for drafts: {DEFAULT_GMAIL_LABEL!r}")
-        return
+        try:
+            legacy = sh.worksheet(LEGACY_SUGGESTIONS_WS)
+            legacy.update_title(SUGGESTIONS_WS)
+            print(f"Renamed worksheet {LEGACY_SUGGESTIONS_WS!r} -> {SUGGESTIONS_WS!r}.")
+            ws = sh.worksheet(SUGGESTIONS_WS)
+        except gspread.WorksheetNotFound:
+            ws = sh.add_worksheet(title=SUGGESTIONS_WS, rows=2000, cols=len(SUGGESTIONS_HEADERS))
+            ws.append_row(SUGGESTIONS_HEADERS, value_input_option="USER_ENTERED")
+            print(f"Created {SUGGESTIONS_WS!r} with header row ({len(SUGGESTIONS_HEADERS)} columns).")
+            print(f"Optional Gmail label for drafts: {DEFAULT_GMAIL_LABEL!r}")
+            return
 
     vals = ws.get_all_values()
     if not vals:

--- a/scripts/field_agent_location_places_pull.py
+++ b/scripts/field_agent_location_places_pull.py
@@ -7,6 +7,8 @@ Process **Recent Field Agent Location** rows (Status=pending) for the holistic w
   mark this row **ignored because already pulled** and **do not** call Google Places Nearby.
 - Otherwise run **Places Nearby Search** around the agent lat/lng, enrich with Place Details,
   dedupe against the live **Hit List**, append new **Research** rows, set Status **pulled**.
+  After appends, writes **AU** / **AV** COUNTIFS formulas (same as ``set_hit_list_warmup_touches_formula.py``)
+  so warm-up / follow-up **sent** counts resolve from **Email Agent Follow Up**.
 
 Also appends an audit row to **DApp Remarks** (Processed=Yes) summarizing each agent row handled.
 
@@ -49,6 +51,7 @@ from hit_list_dapp_remarks_sheet import (  # noqa: E402
     _parse_row_from_append_response,
     gspread_retry,
 )
+from set_hit_list_warmup_touches_formula import write_au_av_for_hit_list_rows  # noqa: E402
 
 SPREADSHEET_ID = dl.SPREADSHEET_ID
 HIT_LIST_NAME = dl.HIT_LIST_WS
@@ -478,6 +481,9 @@ def main() -> None:
             if ur:
                 append_updated_ranges.append(str(ur))
             hit_lr = _parse_row_from_append_response(ar_dict)
+            if hit_lr is None:
+                nv = gspread_retry(hit_ws.get_all_values)
+                hit_lr = len(nv) if nv else None
             if hit_lr is not None:
                 appended_hit_rows.append(hit_lr)
             appended += 1
@@ -488,6 +494,17 @@ def main() -> None:
             if na:
                 name_addr.add(na)
             time.sleep(0.06)
+
+        if appended_hit_rows:
+            try:
+                n_au_av = write_au_av_for_hit_list_rows(hit_ws, appended_hit_rows)
+                summary_lines.append(
+                    f"Hit List AU/AV formulas applied to **{n_au_av}** new row(s) (warm-up / follow-up send counts)."
+                )
+            except Exception as exc:
+                warn = f"AU/AV formula write failed ({exc}) — run `python3 scripts/set_hit_list_warmup_touches_formula.py` once."
+                summary_lines.append(warn)
+                print(f"Row {row_num}: warning: {warn}", flush=True)
 
         set_recent_status(recent_ws, row_num, col_idx["Status"] + 1, STATUS_PULLED)
         summary_lines.append(f"Places raw results: {len(raw)}")

--- a/scripts/format_email_agent_followup_sheet.py
+++ b/scripts/format_email_agent_followup_sheet.py
@@ -26,7 +26,7 @@ _REPO = Path(__file__).resolve().parent.parent
 _SA_CREDS = _REPO / "google_credentials.json"
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
 LOG_WS = "Email Agent Follow Up"
-NUM_COLS = 10  # matches LOG_HEADERS in sync_email_agent_followup.py
+NUM_COLS = 13  # matches LOG_HEADERS in sync_email_agent_followup.py (incl. Open, Click through)
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
@@ -34,8 +34,8 @@ SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 _HEADER_BG = {"red": 0.176, "green": 0.353, "blue": 0.153}
 _HEADER_FG = {"red": 1.0, "green": 1.0, "blue": 1.0}
 
-# Column widths (pixels) — A..J (snippet + body_plain)
-_COL_WIDTHS = [220, 150, 200, 160, 240, 280, 170, 320, 480, 130]
+# Column widths (pixels) — A..M (snippet + body_plain + status + engagement)
+_COL_WIDTHS = [220, 150, 200, 160, 240, 280, 170, 320, 420, 120, 130, 72, 110]
 
 
 def get_sheet_id(service, title: str) -> int:

--- a/scripts/format_email_agent_suggestions_sheet.py
+++ b/scripts/format_email_agent_suggestions_sheet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Readable layout for "Email Agent Suggestions":
+Readable layout for "Email Agent Drafts":
 - Freeze header, green header row, column widths, wrap on body_preview / notes
 - Filter + banded rows (removes old banding first)
 
@@ -21,7 +21,7 @@ from sheets_banding import delete_banded_ranges_for_sheet
 _REPO = Path(__file__).resolve().parent.parent
 _SA_CREDS = _REPO / "google_credentials.json"
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
-WS_TITLE = "Email Agent Suggestions"
+WS_TITLE = "Email Agent Drafts"
 NUM_COLS = 13
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]

--- a/scripts/label_historical_sent.py
+++ b/scripts/label_historical_sent.py
@@ -4,7 +4,7 @@ One-off: apply AI/Sent Follow-up or AI/Sent Warm-up to historical sent messages
 (messages that went out before the review→sent label-swap was in place).
 
 Matching strategy (per row in Email Agent Follow Up):
-  1. Find all Email Agent Suggestions rows with the same to_email.
+  1. Find all Email Agent Drafts rows with the same to_email.
   2. If all suggestions for that email are one type → apply that type.
   3. If mixed, pick the suggestion with the latest created_at_utc BEFORE the
      sent_at of the follow-up row (closest prior suggestion).

--- a/scripts/relabel_existing_drafts.py
+++ b/scripts/relabel_existing_drafts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 One-off script: relabel existing Gmail drafts from "Email Agent suggestions"
-to "AI/Follow-up" or "AI/Warm-up" based on the Email Agent Suggestions sheet.
+to "AI/Follow-up" or "AI/Warm-up" based on the Email Agent Drafts sheet.
 
 Matching logic:
   - protocol_version contains "warmup_intro" → AI/Warm-up

--- a/scripts/set_hit_list_warmup_touches_formula.py
+++ b/scripts/set_hit_list_warmup_touches_formula.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Write Hit List formulas for outbound touch counts from **Email Agent Follow Up**:
+
+- **Column AU** — warm-up **sent** count: ``status`` = ``warmup``.
+- **Column AV** — follow-up **sent** count: ``status`` = ``follow_up``.
+
+Each uses the same join keys as the sheet (**Store Key** in AD, else **Email** in K vs Follow Up
+``store_key`` / ``to_email``). Counts are Gmail **Sent** rows classified by
+``sync_email_agent_followup.py``, not draft rows on Email Agent Drafts.
+
+Requires market_research/google_credentials.json with Editor access to the Hit List spreadsheet.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+
+import gspread
+from google.oauth2.service_account import Credentials
+
+SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
+HIT_LIST_WS = "Hit List"
+# Column AU = warm-up sent count; AV = follow-up sent count (1-based A=1 …)
+AU_COL_INDEX = 47
+AV_COL_INDEX = 48
+CRED_PATH = _REPO / "google_credentials.json"
+SCOPES = (
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive.readonly",
+)
+
+
+def _touch_count_formula(row: int, status: str) -> str:
+    """Row is 2-based Hit List data row (matches Google row number)."""
+    # Follow Up: C = store_key, E = to_email, J = status (after body_plain migration + status column).
+    return (
+        f'=IF($AD{row}<>"", '
+        f'COUNTIFS(\'Email Agent Follow Up\'!$C:$C, $AD{row}, '
+        f'\'Email Agent Follow Up\'!$J:$J, "{status}"), '
+        f'IF($K{row}<>"", '
+        f'COUNTIFS(\'Email Agent Follow Up\'!$E:$E, LOWER($K{row}), '
+        f'\'Email Agent Follow Up\'!$J:$J, "{status}"), '
+        f"0))"
+    )
+
+
+def _au_formula(row: int) -> str:
+    return _touch_count_formula(row, "warmup")
+
+
+def _av_formula(row: int) -> str:
+    return _touch_count_formula(row, "follow_up")
+
+
+def _sheet_range_a1(tab_title: str, a1_suffix: str) -> str:
+    """Quote sheet tab for A1 notation (handles spaces and embedded quotes)."""
+    t = tab_title or ""
+    if "'" in t:
+        return "'" + t.replace("'", "''") + "'!" + a1_suffix
+    if any(ch in t for ch in (" ", ".")):
+        return "'" + t + "'!" + a1_suffix
+    return t + "!" + a1_suffix
+
+
+def write_au_av_for_hit_list_rows(ws: gspread.Worksheet, rows: list[int]) -> int:
+    """Write AU/AV COUNTIFS formulas for each 1-based Hit List row (typically new appends).
+
+    Uses one ``values_batch_update`` call for all rows. Raises if the worksheet has fewer than
+    **AV** columns in row 1.
+    """
+    uniq = sorted({int(r) for r in rows if r is not None and int(r) >= 2})
+    if not uniq:
+        return 0
+
+    header = ws.row_values(1)
+    if len(header) < AV_COL_INDEX:
+        raise ValueError(
+            f"Hit List row 1 has only {len(header)} columns; need at least {AV_COL_INDEX} (AV)."
+        )
+
+    tab = ws.title
+    data: list[dict] = []
+    for r in uniq:
+        rng = _sheet_range_a1(tab, f"AU{r}:AV{r}")
+        data.append({"range": rng, "values": [[_au_formula(r), _av_formula(r)]]})
+
+    ws.spreadsheet.values_batch_update({"valueInputOption": "USER_ENTERED", "data": data})
+    return len(uniq)
+
+
+def main() -> None:
+    if not CRED_PATH.is_file():
+        raise SystemExit(f"Missing {CRED_PATH}")
+
+    creds = Credentials.from_service_account_file(str(CRED_PATH), scopes=SCOPES)
+    gc = gspread.authorize(creds)
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    ws = sh.worksheet(HIT_LIST_WS)
+
+    values = ws.get_all_values()
+    if len(values) < 2:
+        raise SystemExit("Hit List has no data rows.")
+
+    header = values[0]
+    if len(header) < AV_COL_INDEX:
+        raise SystemExit(
+            f"Hit List header has only {len(header)} columns; need at least {AV_COL_INDEX} (AV)."
+        )
+    au_header = header[AU_COL_INDEX - 1].strip()
+    if au_header and "warm" not in au_header.lower():
+        print(
+            f"Warning: AU1 is {au_header!r} — expected something like 'Warm-up email sent'. Proceeding.",
+            file=sys.stderr,
+        )
+    av_header = header[AV_COL_INDEX - 1].strip()
+    if av_header and "follow" not in av_header.lower():
+        print(
+            f"Warning: AV1 is {av_header!r} — expected something like 'Follow-up emails sent'. Proceeding.",
+            file=sys.stderr,
+        )
+
+    last_row = len(values)
+    au_rng = f"AU2:AU{last_row}"
+    av_rng = f"AV2:AV{last_row}"
+    au_formulas = [[_au_formula(r)] for r in range(2, last_row + 1)]
+    av_formulas = [[_av_formula(r)] for r in range(2, last_row + 1)]
+
+    print(f"Updating {au_rng} ({len(au_formulas)} rows) …", file=sys.stderr)
+    ws.update(range_name=au_rng, values=au_formulas, value_input_option="USER_ENTERED")
+    print(f"Updating {av_rng} ({len(av_formulas)} rows) …", file=sys.stderr)
+    ws.update(range_name=av_rng, values=av_formulas, value_input_option="USER_ENTERED")
+    print(f"OK: wrote AU warm-up + AV follow-up COUNTIFS into {au_rng} and {av_rng}.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/suggest_bulk_info_drafts.py
+++ b/scripts/suggest_bulk_info_drafts.py
@@ -9,8 +9,10 @@ Parallel to ``suggest_manager_followup_drafts.py`` but:
 - **Does not** change manager-follow-up behavior (separate script).
 
 Same cadence rules as manager follow-up: pending_review + open draft blocks; min days since
-last **Email Agent Follow Up** row per ``to_email``. Run ``sync_email_agent_followup.py`` first
-so the log includes sends for **Bulk Info Requested** rows (sync script includes that status).
+last **Email Agent Follow Up** row per ``to_email``, **except** after a **discarded** pending draft
+(Gmail draft removed / reconcile), which bypasses the min-days gate like manager follow-up.
+Run ``sync_email_agent_followup.py`` first so the log includes sends for **Bulk Info Requested** rows
+(sync script includes that status).
 
 Usage:
   cd market_research
@@ -23,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -34,6 +37,7 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 import suggest_manager_followup_drafts as sm
+from email_agent_tracking import plain_text_to_html_with_open_pixel
 
 BULK_STATUS = "Bulk Info Requested"
 BULK_PROTOCOL_VERSION = "BULK_INFO_PDF v0.1"
@@ -93,6 +97,11 @@ def main() -> None:
         help=f"Min days since last logged send in {sm.LOG_WS!r} (default {sm.DEFAULT_MIN_DAYS_SINCE_SENT}).",
     )
     parser.add_argument("--skip-label", action="store_true")
+    parser.add_argument(
+        "--track-opens",
+        action="store_true",
+        help="Multipart HTML + 1×1 open pixel (tid=suggestion_id); see suggest_manager_followup_drafts --track-opens.",
+    )
     parser.add_argument("--expected-mailbox", default=sm.EXPECTED_MAILBOX)
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument(
@@ -140,7 +149,7 @@ def main() -> None:
         )
 
     last_sent = sm.last_sent_utctime_per_to_email(log_ws)
-    pending_to, n_reconciled = sm.pending_review_emails_after_gmail_reconcile(
+    pending_to, n_reconciled, freshly_discarded = sm.pending_review_emails_after_gmail_reconcile(
         gsvc, sugg_ws, dry_run=args.dry_run, verbose=args.verbose
     )
     if n_reconciled:
@@ -148,6 +157,7 @@ def main() -> None:
             f"Reconciled {n_reconciled} row(s) in {sm.SUGGESTIONS_WS!r}: "
             "pending_review → discarded (Gmail draft was deleted or missing)."
         )
+    latest_discard_utc = sm.latest_discarded_utc_per_to_email(sugg_ws)
     now = datetime.now(timezone.utc)
 
     targets = sm.load_hit_list_targets(hit_ws, hit_status=BULK_STATUS)
@@ -181,13 +191,24 @@ def main() -> None:
         if prev is not None:
             d = sm.days_since_utc(prev, now)
             if d < args.min_days_since_sent:
-                skipped_cadence += 1
+                if not sm.cadence_bypass_after_discarded_draft(
+                    em,
+                    last_sent_dt=prev,
+                    freshly_discarded_emails=freshly_discarded,
+                    latest_discard_utc_per_email=latest_discard_utc,
+                ):
+                    skipped_cadence += 1
+                    if args.verbose:
+                        print(
+                            f"  skip {em}: last logged send {d:.1f}d ago "
+                            f"(need >= {args.min_days_since_sent}d; sent_at={prev.date().isoformat()})"
+                        )
+                    continue
                 if args.verbose:
                     print(
-                        f"  skip {em}: last logged send {d:.1f}d ago "
-                        f"(need >= {args.min_days_since_sent}d; sent_at={prev.date().isoformat()})"
+                        f"  allow {em}: cadence bypass (discarded draft after last logged send "
+                        f"at {prev.date().isoformat()})"
                     )
-                continue
         candidates.append(em)
 
     def sort_key(email: str) -> tuple:
@@ -241,11 +262,18 @@ def main() -> None:
         subj = draft_subject_bulk(shop)
         body = draft_body_bulk(shop, snippets)
 
+        sug_id = str(uuid.uuid4())
+        tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
+        html_body = None
+        if args.track_opens and tracking_base:
+            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+
         raw = sm.build_message_raw(
             me,
             to_addr,
             subj,
             body,
+            html_body=html_body,
             attachment_path=pdf_path,
             attachment_filename=args.attachment_filename,
         )
@@ -272,7 +300,6 @@ def main() -> None:
             except Exception as e:
                 sys.stderr.write(f"Warning: could not apply label to draft message {msg_id}: {e}\n")
 
-        sug_id = str(uuid.uuid4())
         preview = body.replace("\n", " ")[: sm.BODY_PREVIEW_MAX]
         notes = (
             f"Bulk info PDF draft; file={pdf_path.name}; cadence min_days={args.min_days_since_sent}; "

--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """
 Create Gmail **drafts** for Hit List rows with Status = Manager Follow-up and Email set,
-append a row to **Email Agent Suggestions**, and apply label **Email Agent suggestions**.
+append a row to **Email Agent Drafts**, and apply label **Email Agent suggestions**.
 
 **Cadence (anti-spam):**
-- At most **one pending draft per recipient** (`to_email`): we block while **Email Agent Suggestions**
+- At most **one pending draft per recipient** (`to_email`): we block while **Email Agent Drafts**
   has `status=pending_review` **and** a matching **open Gmail draft** (by `gmail_draft_id`, or by scanning
   draft **To:** headers if the id cell is empty). If you **delete the draft in Gmail**, the next run
-  discards that row (unless `--dry-run`) so a new draft can be created when cadence allows.
-- Next draft only after **Email Agent Follow Up** shows a prior **sent** to that address older than
+  discards that row (unless `--dry-run`) so a new draft can be created. **Discarding a draft bypasses**
+  the min-days-since-sent gate until the next logged send: if reconcile marks a row discarded (or the
+  sheet already records a ``[UTC] discarded:`` note **after** your latest **Email Agent Follow Up**
+  ``sent_at`` for that address), you get another draft on the same or next run without waiting the
+  full cadence (so you can iterate after changing prompts or templates).
+- Otherwise, next draft only after **Email Agent Follow Up** shows a prior **sent** to that address older than
   `--min-days-since-sent` (default **7** calendar days). Recipients with **no** log row are eligible
   immediately (treat as “no recorded send yet” for cadence).
 - **Source of truth for “last sent”:** the latest `sent_at` in **Email Agent Follow Up** for that
@@ -73,16 +77,21 @@ from google.oauth2.service_account import Credentials as SACredentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from email_agent_tracking import plain_text_to_html_with_open_pixel
 from gmail_plain_body import extract_plain_body_from_payload
 from gmail_user_credentials import load_gmail_user_credentials
 
 _REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
 _SA_CREDS = _REPO / "google_credentials.json"
 _GMAIL_TOKEN = _REPO / "credentials" / "gmail" / "token.json"
 
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
 HIT_LIST_WS = "Hit List"
-SUGGESTIONS_WS = "Email Agent Suggestions"
+SUGGESTIONS_WS = "Email Agent Drafts"
 LOG_WS = "Email Agent Follow Up"
 DAPP_REMARKS_WS = "DApp Remarks"
 
@@ -522,6 +531,73 @@ def last_sent_utctime_per_to_email(log_ws: gspread.Worksheet | None) -> dict[str
     return best
 
 
+# Reconcile appends notes like ``[2026-04-23T12:00:00Z] discarded: ...`` — used to bypass cadence
+# when the user removed the Gmail draft (iterate before min-days since last *sent*).
+_DISCARD_NOTE_TS_RE = re.compile(
+    r"\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\]\s*discarded:",
+    re.IGNORECASE,
+)
+
+
+def parse_latest_discard_utc_from_notes(notes: str) -> datetime | None:
+    """Latest UTC timestamp from any ``[...Z] discarded:`` segment in *notes*."""
+    best: datetime | None = None
+    for m in _DISCARD_NOTE_TS_RE.finditer(notes or ""):
+        ts = m.group(1)
+        try:
+            dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        if best is None or dt > best:
+            best = dt
+    return best
+
+
+def latest_discarded_utc_per_to_email(ws: gspread.Worksheet) -> dict[str, datetime]:
+    """Per ``to_email``, max parsed discard time from ``discarded`` rows' ``notes``."""
+    values = ws.get_all_values()
+    if len(values) < 2:
+        return {}
+    hdr = header_map(values[0])
+    em_i = hdr.get("to_email")
+    st_i = hdr.get("status")
+    notes_i = hdr.get("notes")
+    if em_i is None or st_i is None:
+        return {}
+    best: dict[str, datetime] = {}
+    for row in values[1:]:
+        if cell(row, st_i).lower() != "discarded":
+            continue
+        em = normalize_email(cell(row, em_i))
+        if not em:
+            continue
+        notes = cell(row, notes_i) if notes_i is not None else ""
+        dt = parse_latest_discard_utc_from_notes(notes)
+        if dt is None:
+            continue
+        prev = best.get(em)
+        if prev is None or dt > prev:
+            best[em] = dt
+    return best
+
+
+def cadence_bypass_after_discarded_draft(
+    em: str,
+    *,
+    last_sent_dt: datetime | None,
+    freshly_discarded_emails: set[str],
+    latest_discard_utc_per_email: dict[str, datetime],
+) -> bool:
+    """True if min-days-since-sent should not block *em* (user discarded the pending Gmail draft)."""
+    if em in freshly_discarded_emails:
+        return True
+    disc = latest_discard_utc_per_email.get(em)
+    if disc is None or last_sent_dt is None:
+        return False
+    ls = last_sent_dt.astimezone(timezone.utc)
+    return disc > ls
+
+
 def _draft_resource_is_trashed(draft_resource: dict) -> bool:
     """True if the draft's message is in Gmail Trash (API still returns 200; we treat like deleted)."""
     msg = draft_resource.get("message") or {}
@@ -606,21 +682,25 @@ def pending_review_emails_after_gmail_reconcile(
     *,
     dry_run: bool,
     verbose: bool,
-) -> tuple[set[str], int]:
+) -> tuple[set[str], int, set[str]]:
     """Recipients still blocked by a real pending draft.
 
     Discards ``pending_review`` rows whose Gmail draft is gone, then **re-fetches** the sheet and
     re-scans so the same run does not keep blocking addresses that were only waiting on a stale row
     (e.g. iChakras after deleting the draft).
+
+    Returns ``(pending_emails, n_rows_marked_discarded, freshly_discarded_emails)``. The third set
+    is every ``to_email`` from a stale ``pending_review`` row in this invocation (including dry-run),
+    so callers can bypass min-days cadence for those addresses in the same run.
     """
     values = ws.get_all_values()
     if len(values) < 2:
-        return set(), 0
+        return set(), 0, set()
     hdr = header_map(values[0])
     st_i = hdr.get("status")
     notes_i = hdr.get("notes")
     if st_i is None or hdr.get("to_email") is None:
-        return set(), 0
+        return set(), 0, set()
 
     status_col = st_i + 1
     notes_col = (notes_i + 1) if notes_i is not None else None
@@ -628,15 +708,20 @@ def pending_review_emails_after_gmail_reconcile(
     total_updated = 0
     pending_emails: set[str] = set()
     stale: list[tuple[int, str, str]] = []
+    freshly_discarded_emails: set[str] = set()
 
     for _ in range(4):
         pending_emails, stale = _scan_pending_review_rows(
             service, values, verbose=verbose, dry_run=dry_run
         )
         if not stale:
-            return pending_emails, total_updated
+            return pending_emails, total_updated, freshly_discarded_emails
+        for _, em_stale, _ in stale:
+            ne = normalize_email(em_stale)
+            if ne:
+                freshly_discarded_emails.add(ne)
         if dry_run:
-            return pending_emails, 0
+            return pending_emails, 0, freshly_discarded_emails
 
         now_tag = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         for sheet_row, _em, draft_id in stale:
@@ -659,7 +744,7 @@ def pending_review_emails_after_gmail_reconcile(
 
         values = ws.get_all_values()
 
-    return pending_emails, total_updated
+    return pending_emails, total_updated, freshly_discarded_emails
 
 
 def days_since_utc(last: datetime, now: datetime) -> float:
@@ -911,12 +996,44 @@ def ensure_user_label_id(service, label_name: str) -> str:
     return str(created["id"])
 
 
-def build_message_raw(sender: str, to: str, subject: str, body: str) -> dict:
+def build_message_raw(
+    sender: str,
+    to: str,
+    subject: str,
+    body: str,
+    *,
+    html_body: str | None = None,
+    attachment_path: Path | None = None,
+    attachment_filename: str | None = None,
+) -> dict:
+    """Build Gmail ``raw`` RFC822. Optional **html_body** for ``multipart/alternative``; optional PDF."""
     msg = EmailMessage()
     msg["From"] = sender
     msg["To"] = to
     msg["Subject"] = subject
-    msg.set_content(body, charset="utf-8")
+
+    if attachment_path is not None:
+        if not attachment_path.is_file():
+            raise FileNotFoundError(f"Attachment not found: {attachment_path}")
+        data = attachment_path.read_bytes()
+        fn = attachment_filename or attachment_path.name
+        if html_body:
+            inner = EmailMessage()
+            inner.set_content(body, charset="utf-8")
+            inner.add_alternative(html_body, subtype="html")
+            msg.make_mixed()
+            msg.attach(inner)
+            msg.add_attachment(data, maintype="application", subtype="pdf", filename=fn)
+        else:
+            msg.make_mixed()
+            msg.set_content(body, charset="utf-8")
+            msg.add_attachment(data, maintype="application", subtype="pdf", filename=fn)
+    elif html_body:
+        msg.set_content(body, charset="utf-8")
+        msg.add_alternative(html_body, subtype="html")
+    else:
+        msg.set_content(body, charset="utf-8")
+
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
     return {"raw": raw}
 
@@ -970,6 +1087,15 @@ def main() -> None:
         help=f"Min days since last logged send in {LOG_WS!r} before drafting again (default {DEFAULT_MIN_DAYS_SINCE_SENT}).",
     )
     parser.add_argument("--skip-label", action="store_true", help="Do not create/apply Gmail label.")
+    parser.add_argument(
+        "--track-opens",
+        action="store_true",
+        help=(
+            "Add an HTML alternative with a 1×1 open pixel (tid=suggestion_id). "
+            "Set EMAIL_AGENT_TRACKING_BASE_URL (default https://edgar.truesight.me); "
+            "Edgar must implement GET /email_agent/open.gif — see email_agent_tracking.py."
+        ),
+    )
     parser.add_argument(
         "--expected-mailbox",
         default=EXPECTED_MAILBOX,
@@ -1038,7 +1164,7 @@ def main() -> None:
             f"Note: worksheet {DAPP_REMARKS_WS!r} not found — Grok context will omit DApp visit remarks."
         )
     last_sent = last_sent_utctime_per_to_email(log_ws)
-    pending_to, n_reconciled = pending_review_emails_after_gmail_reconcile(
+    pending_to, n_reconciled, freshly_discarded = pending_review_emails_after_gmail_reconcile(
         gsvc, sugg_ws, dry_run=args.dry_run, verbose=args.verbose
     )
     if n_reconciled:
@@ -1046,6 +1172,7 @@ def main() -> None:
             f"Reconciled {n_reconciled} row(s) in {SUGGESTIONS_WS!r}: "
             "pending_review → discarded (Gmail draft was deleted or missing)."
         )
+    latest_discard_utc = latest_discarded_utc_per_to_email(sugg_ws)
     now = datetime.now(timezone.utc)
 
     targets = load_hit_list_targets(hit_ws)
@@ -1079,13 +1206,24 @@ def main() -> None:
         if prev is not None:
             d = days_since_utc(prev, now)
             if d < args.min_days_since_sent:
-                skipped_cadence += 1
+                if not cadence_bypass_after_discarded_draft(
+                    em,
+                    last_sent_dt=prev,
+                    freshly_discarded_emails=freshly_discarded,
+                    latest_discard_utc_per_email=latest_discard_utc,
+                ):
+                    skipped_cadence += 1
+                    if args.verbose:
+                        print(
+                            f"  skip {em}: last logged send {d:.1f}d ago "
+                            f"(need >= {args.min_days_since_sent}d; sent_at={prev.date().isoformat()})"
+                        )
+                    continue
                 if args.verbose:
                     print(
-                        f"  skip {em}: last logged send {d:.1f}d ago "
-                        f"(need >= {args.min_days_since_sent}d; sent_at={prev.date().isoformat()})"
+                        f"  allow {em}: cadence bypass (discarded draft after last logged send "
+                        f"at {prev.date().isoformat()})"
                     )
-                continue
         candidates.append(em)
 
     def sort_key(email: str) -> tuple:
@@ -1185,7 +1323,13 @@ def main() -> None:
             subj = draft_subject(shop)
             body = draft_body_template(shop, snippets)
 
-        raw = build_message_raw(me, to_addr, subj, body)
+        sug_id = str(uuid.uuid4())
+        tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
+        html_body = None
+        if args.track_opens and tracking_base:
+            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+
+        raw = build_message_raw(me, to_addr, subj, body, html_body=html_body)
 
         if args.dry_run:
             print(f"\n--- dry-run draft #{n_made + 1} → {to_addr} ({shop}) ---")
@@ -1211,7 +1355,6 @@ def main() -> None:
             except Exception as e:
                 sys.stderr.write(f"Warning: could not apply label to draft message {msg_id}: {e}\n")
 
-        sug_id = str(uuid.uuid4())
         preview = body.replace("\n", " ")[:BODY_PREVIEW_MAX]
         notes = (
             f"Auto draft ({source}); cadence min_days={args.min_days_since_sent}; "

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -3,8 +3,9 @@
 Gmail **drafts** for Hit List rows with Status = **AI: Warm up prospect** and Email set.
 
 - Cadence: same as manager follow-up — at most one **pending_review** suggestion per recipient
-  while the Gmail draft exists; next draft only after **Email Agent Follow Up** shows a prior
-  **sent** at least ``--min-days-since-sent`` ago (default **7**). Run **sync_email_agent_followup.py** first.
+  while the Gmail draft exists; next draft after **Email Agent Follow Up** shows a prior **sent** at least
+  ``--min-days-since-sent`` ago (default **7**), **unless** a pending draft was **discarded** (Gmail draft
+  deleted / reconcile), in which case the next draft is allowed immediately. Run **sync_email_agent_followup.py** first.
 - **Attachment:** ``retail_price_list/agroverse_wholesale_price_list_2026.pdf`` on each draft.
 - **Grok** (optional ``--use-grok``): first-touch intro; no in-person visit assumption; flexible consignment or bulk;
   lead with Amazon rainforest restoration (tree per bag, QR traceability); style reference in
@@ -27,6 +28,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 import re
 import sys
 import uuid
@@ -40,9 +42,14 @@ import requests
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
 import suggest_manager_followup_drafts as smf
 
-_REPO = Path(__file__).resolve().parent.parent
+from email_agent_tracking import plain_text_to_html_with_open_pixel
 _WARMUP_REF = _REPO / "templates" / "warmup_outreach_reference.md"
 _DEFAULT_PDF = _REPO / "retail_price_list" / "agroverse_wholesale_price_list_2026.pdf"
 
@@ -344,6 +351,8 @@ def build_message_raw_with_pdf(
     subject: str,
     body: str,
     pdf_path: Path,
+    *,
+    html_body: str | None = None,
 ) -> dict[str, str]:
     if not pdf_path.is_file():
         raise FileNotFoundError(f"Wholesale PDF not found: {pdf_path}")
@@ -352,13 +361,21 @@ def build_message_raw_with_pdf(
     msg["From"] = sender
     msg["To"] = to
     msg["Subject"] = subject
-    msg.set_content(body, charset="utf-8")
-    msg.add_attachment(
-        data,
-        maintype="application",
-        subtype="pdf",
-        filename=pdf_path.name,
-    )
+    if html_body:
+        inner = EmailMessage()
+        inner.set_content(body, charset="utf-8")
+        inner.add_alternative(html_body, subtype="html")
+        msg.make_mixed()
+        msg.attach(inner)
+        msg.add_attachment(data, maintype="application", subtype="pdf", filename=pdf_path.name)
+    else:
+        msg.set_content(body, charset="utf-8")
+        msg.add_attachment(
+            data,
+            maintype="application",
+            subtype="pdf",
+            filename=pdf_path.name,
+        )
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
     return {"raw": raw}
 
@@ -405,6 +422,11 @@ def main() -> None:
     )
     p.add_argument("--reply-promotion-only", action="store_true", help="Only promote Warm up → Prospect replied.")
     p.add_argument("--skip-reply-promotion", action="store_true")
+    p.add_argument(
+        "--track-opens",
+        action="store_true",
+        help="Multipart HTML + 1×1 open pixel (tid=suggestion_id); see suggest_manager_followup_drafts --track-opens.",
+    )
     args = p.parse_args()
 
     if args.max_drafts < 0:
@@ -448,13 +470,14 @@ def main() -> None:
 
     log_tab_present = log_ws is not None
     last_sent = smf.last_sent_utctime_per_to_email(log_ws)
-    pending_to, n_reconciled = smf.pending_review_emails_after_gmail_reconcile(
+    pending_to, n_reconciled, freshly_discarded = smf.pending_review_emails_after_gmail_reconcile(
         gsvc, sugg_ws, dry_run=args.dry_run, verbose=args.verbose
     )
     if n_reconciled:
         print(
             f"Reconciled {n_reconciled} row(s) in {SUGGESTIONS_WS!r}: pending_review → discarded."
         )
+    latest_discard_utc = smf.latest_discarded_utc_per_to_email(sugg_ws)
     now = datetime.now(timezone.utc)
 
     targets = load_warmup_targets(hit_ws)
@@ -483,10 +506,21 @@ def main() -> None:
         if prev is not None:
             d = smf.days_since_utc(prev, now)
             if d < args.min_days_since_sent:
-                skipped_cadence += 1
+                if not smf.cadence_bypass_after_discarded_draft(
+                    em,
+                    last_sent_dt=prev,
+                    freshly_discarded_emails=freshly_discarded,
+                    latest_discard_utc_per_email=latest_discard_utc,
+                ):
+                    skipped_cadence += 1
+                    if args.verbose:
+                        print(f"  skip {em}: last send {d:.1f}d ago (need {args.min_days_since_sent})")
+                    continue
                 if args.verbose:
-                    print(f"  skip {em}: last send {d:.1f}d ago (need {args.min_days_since_sent})")
-                continue
+                    print(
+                        f"  allow {em}: cadence bypass (discarded draft after last logged send "
+                        f"at {prev.date().isoformat()})"
+                    )
         candidates.append(em)
 
     def sort_key(email: str) -> tuple:
@@ -575,8 +609,16 @@ def main() -> None:
             subj = warmup_subject_template(shop)
             body = warmup_body_template(shop)
 
+        sug_id = str(uuid.uuid4())
+        tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
+        html_body = None
+        if args.track_opens and tracking_base:
+            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+
         try:
-            raw = build_message_raw_with_pdf(me, to_addr, subj, body, args.pdf_path)
+            raw = build_message_raw_with_pdf(
+                me, to_addr, subj, body, args.pdf_path, html_body=html_body
+            )
         except FileNotFoundError as e:
             sys.stderr.write(f"{e}\n")
             sys.exit(1)
@@ -605,7 +647,6 @@ def main() -> None:
             except Exception as e:
                 sys.stderr.write(f"Warning: label on draft message {msg_id}: {e}\n")
 
-        sug_id = str(uuid.uuid4())
         preview = body.replace("\n", " ")[:BODY_PREVIEW_MAX]
         notes = (
             f"kind=warmup_intro; attachment={args.pdf_path.name}; source={source}; "

--- a/scripts/sync_email_agent_followup.py
+++ b/scripts/sync_email_agent_followup.py
@@ -24,6 +24,8 @@ Usage
   python3 scripts/sync_email_agent_followup.py              # migrate tab if needed, append new log rows
   python3 scripts/sync_email_agent_followup.py --migrate-only  # insert body_plain header only (no Gmail)
   python3 scripts/sync_email_agent_followup.py --backfill-body-plain  # fill empty body_plain for existing rows
+  python3 scripts/sync_email_agent_followup.py --backfill-status       # fill status (warmup|bulk|follow_up|unknown)
+  python3 scripts/sync_email_agent_followup.py --backfill-status --force-backfill-status  # overwrite existing status
   python3 scripts/sync_email_agent_followup.py --dry-run
   python3 scripts/sync_email_agent_followup.py --limit 5
 """
@@ -33,6 +35,7 @@ from __future__ import annotations
 import argparse
 import sys
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import gspread
@@ -50,6 +53,7 @@ _GMAIL_TOKEN = _REPO / "credentials" / "gmail" / "token.json"
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
 HIT_LIST_WS = "Hit List"
 LOG_WS = "Email Agent Follow Up"
+SUGGESTIONS_WS = "Email Agent Drafts"
 
 HIT_STATUSES_FOR_SYNC = (
     "Manager Follow-up",
@@ -81,8 +85,133 @@ LOG_HEADERS = [
     "sent_at",
     "snippet",
     "body_plain",
+    # Pipeline kind for this outbound (Gmail Sent row). Not the same as Email Agent Drafts status.
+    "status",
     "sync_source",
+    # Engagement (defaults 0 on append). Intended to be updated by Edgar (or similar) when a
+    # tracking pixel / redirect fires — see scripts/email_agent_tracking.py and HIT_LIST_CREDENTIALS.md.
+    "Open",
+    "Click through",
 ]
+
+
+def touch_kind_from_protocol(proto: str) -> str:
+    """Map Email Agent Drafts protocol_version to a coarse outbound kind."""
+    p = (proto or "").lower()
+    if "warmup" in p:
+        return "warmup"
+    if "bulk" in p:
+        return "bulk"
+    return "follow_up"
+
+
+def parse_sent_at_header(raw: str) -> datetime | None:
+    if not raw or not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    try:
+        dt = parsedate_to_datetime(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (TypeError, ValueError, OverflowError):
+        pass
+    try:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_suggestions_touch_kinds(sa) -> dict[str, list[dict]]:
+    """{to_email: [{created, subject, kind}]} where kind is warmup|bulk|follow_up."""
+    sh = sa.open_by_key(SPREADSHEET_ID)
+    try:
+        ws = sh.worksheet(SUGGESTIONS_WS)
+    except gspread.WorksheetNotFound:
+        return {}
+    values = ws.get_all_values()
+    if len(values) < 2:
+        return {}
+    hdr = header_map(values[0])
+    em_i = hdr.get("to_email")
+    subj_i = hdr.get("subject")
+    proto_i = hdr.get("protocol_version")
+    created_i = hdr.get("created_at_utc")
+    if em_i is None:
+        return {}
+    out: dict[str, list[dict]] = {}
+    for row in values[1:]:
+        em = normalize_email(cell(row, em_i))
+        if not em:
+            continue
+        proto = cell(row, proto_i) if proto_i is not None else ""
+        subject = cell(row, subj_i) if subj_i is not None else ""
+        created = parse_sent_at_header(cell(row, created_i)) if created_i is not None else None
+        out.setdefault(em, []).append(
+            {
+                "created": created,
+                "subject": subject,
+                "kind": touch_kind_from_protocol(proto),
+            }
+        )
+    for em in out:
+        out[em].sort(key=lambda x: x["created"] or datetime.min.replace(tzinfo=timezone.utc))
+    return out
+
+
+def pick_touch_kind_from_suggestions(
+    suggestions: list[dict], sent_at: datetime | None, subject: str
+) -> str | None:
+    if not suggestions:
+        return None
+    kinds = {s["kind"] for s in suggestions}
+    if len(kinds) == 1:
+        return kinds.pop()
+    if sent_at is not None:
+        prior = [s for s in suggestions if s["created"] and s["created"] <= sent_at]
+        if prior:
+            return prior[-1]["kind"]
+    subj = (subject or "").strip()
+    for s in suggestions:
+        if s["subject"].strip() == subj:
+            return s["kind"]
+    return suggestions[-1]["kind"]
+
+
+def label_names_for_ids(label_ids: list[str], id_to_name: dict[str, str]) -> set[str]:
+    return {id_to_name.get(i, "") for i in (label_ids or []) if i}
+
+
+def infer_followup_log_status(
+    *,
+    label_ids: list[str],
+    id_to_name: dict[str, str],
+    to_email: str,
+    sent_at_raw: str,
+    subject: str,
+    sug_by_email: dict[str, list[dict]],
+) -> str:
+    """Return warmup | bulk | follow_up | unknown for one Gmail Sent log row."""
+    names = label_names_for_ids(label_ids, id_to_name)
+    if SENT_LABEL_WARMUP in names or REVIEW_LABEL_WARMUP in names:
+        return "warmup"
+    sug_kind = pick_touch_kind_from_suggestions(
+        sug_by_email.get(to_email, []),
+        parse_sent_at_header(sent_at_raw),
+        subject,
+    )
+    if SENT_LABEL_FOLLOWUP in names or REVIEW_LABEL_FOLLOWUP in names:
+        return sug_kind if sug_kind else "follow_up"
+    if sug_kind:
+        return sug_kind
+    return "unknown"
 
 
 def _get_or_create_label_id(service, name: str, label_map: dict[str, str]) -> str:
@@ -178,8 +307,52 @@ def ensure_log_worksheet(sh):
     if not vals:
         ws.append_row(LOG_HEADERS, value_input_option="USER_ENTERED")
     else:
-        migrate_followup_log_add_body_plain(ws, vals[0])
+        hdr = vals[0]
+        if migrate_followup_log_add_body_plain(ws, hdr):
+            vals = ws.get_all_values()
+            hdr = vals[0] if vals else []
+        migrate_followup_log_add_status(ws, hdr)
+        vals = ws.get_all_values()
+        hdr = vals[0] if vals else []
+        migrate_followup_log_add_open_click(ws, hdr)
     return ws
+
+
+def migrate_followup_log_add_open_click(ws: gspread.Worksheet, header_row: list[str]) -> bool:
+    """Append **Open** and **Click through** at the end of row 1 if missing (columns L–M after K)."""
+    hm = header_map(header_row)
+    if hm.get("Open") is not None and hm.get("Click through") is not None:
+        return False
+
+    last_used = 0
+    for i, cell in enumerate(header_row):
+        if str(cell or "").strip():
+            last_used = i + 1
+    insert_at = last_used  # 0-based column index to insert before (append at end)
+
+    ws.spreadsheet.batch_update(
+        {
+            "requests": [
+                {
+                    "insertDimension": {
+                        "range": {
+                            "sheetId": ws.id,
+                            "dimension": "COLUMNS",
+                            "startIndex": insert_at,
+                            "endIndex": insert_at + 2,
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    ws.update_cell(1, insert_at + 1, "Open")
+    ws.update_cell(1, insert_at + 2, "Click through")
+    print(
+        "Migrated sheet: appended columns 'Open' and 'Click through' "
+        f"(inserted at 1-based columns {insert_at + 1}–{insert_at + 2})."
+    )
+    return True
 
 
 def migrate_followup_log_add_body_plain(ws: gspread.Worksheet, header_row: list[str]) -> bool:
@@ -215,6 +388,41 @@ def migrate_followup_log_add_body_plain(ws: gspread.Worksheet, header_row: list[
     # 1-based column index: inserted column is at sync_i + 1
     ws.update_cell(1, sync_i + 1, "body_plain")
     print(f"Migrated sheet: inserted column 'body_plain' before former column {sync_i + 1} (sync_source).")
+    return True
+
+
+def migrate_followup_log_add_status(ws: gspread.Worksheet, header_row: list[str]) -> bool:
+    """Insert **status** immediately before **sync_source** if missing. Returns True if modified."""
+    hm = header_map(header_row)
+    if "status" in hm:
+        return False
+    sync_i = hm.get("sync_source")
+    if sync_i is None:
+        print(
+            "migrate: no 'sync_source' column on Email Agent Follow Up — "
+            "cannot insert status; fix headers manually.",
+            file=sys.stderr,
+        )
+        return False
+
+    ws.spreadsheet.batch_update(
+        {
+            "requests": [
+                {
+                    "insertDimension": {
+                        "range": {
+                            "sheetId": ws.id,
+                            "dimension": "COLUMNS",
+                            "startIndex": sync_i,
+                            "endIndex": sync_i + 1,
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    ws.update_cell(1, sync_i + 1, "status")
+    print(f"Migrated sheet: inserted column 'status' before former column {sync_i + 1} (sync_source).")
     return True
 
 
@@ -288,6 +496,102 @@ def backfill_empty_body_plain(
             print(f"  backfilled {updated}/{len(todo)}...")
     flush_chunk()
     print(f"backfill: wrote body_plain for {updated} row(s).")
+    return updated
+
+
+def backfill_followup_status(
+    service: object,
+    log_ws: gspread.Worksheet,
+    sa,
+    *,
+    dry_run: bool,
+    limit: int,
+    force: bool,
+) -> int:
+    """Fill **status** on Email Agent Follow Up using Gmail labels + Email Agent Drafts protocols."""
+    values = log_ws.get_all_values()
+    if len(values) < 2:
+        return 0
+    hdr = header_map(values[0])
+    mid_i = hdr.get("gmail_message_id")
+    st_i = hdr.get("status")
+    em_i = hdr.get("to_email")
+    subj_i = hdr.get("subject")
+    sent_i = hdr.get("sent_at")
+    if mid_i is None or st_i is None or em_i is None:
+        print(
+            "backfill-status: sheet needs gmail_message_id, status, to_email columns.",
+            file=sys.stderr,
+        )
+        return 0
+
+    label_map = build_label_id_map(service)
+    id_to_name = {str(v): str(k) for k, v in label_map.items()}
+    sug_by_email = load_suggestions_touch_kinds(sa)
+
+    todo: list[tuple[int, str, str, str, str]] = []
+    for r, row in enumerate(values[1:], start=2):
+        mid = cell(row, mid_i)
+        if not mid:
+            continue
+        existing = cell(row, st_i) if st_i < len(row) else ""
+        if existing.strip() and not force:
+            continue
+        em = normalize_email(cell(row, em_i)) or ""
+        subj = cell(row, subj_i) if subj_i is not None else ""
+        sent_raw = cell(row, sent_i) if sent_i is not None else ""
+        todo.append((r, mid, em, subj, sent_raw))
+        if limit > 0 and len(todo) >= limit:
+            break
+
+    print(f"backfill-status: {len(todo)} row(s) to classify.")
+    if not todo:
+        return 0
+    if dry_run:
+        for item in todo[:15]:
+            print(f"  dry-run row {item[0]} id={item[1][:16]}… to={item[2]}")
+        if len(todo) > 15:
+            print(f"  ... and {len(todo) - 15} more")
+        return 0
+
+    updated = 0
+    col = st_i + 1
+    chunk: list[gspread.Cell] = []
+
+    def flush_chunk() -> None:
+        nonlocal chunk, updated
+        if not chunk:
+            return
+        log_ws.update_cells(chunk, value_input_option="USER_ENTERED")
+        updated += len(chunk)
+        chunk = []
+
+    for r, mid, em, subj, sent_raw in todo:
+        try:
+            meta = (
+                service.users()
+                .messages()
+                .get(userId="me", id=mid, format="metadata", metadataHeaders=["Subject"])
+                .execute()
+            )
+            lids = meta.get("labelIds") or []
+            status_val = infer_followup_log_status(
+                label_ids=[str(x) for x in lids],
+                id_to_name=id_to_name,
+                to_email=em,
+                sent_at_raw=sent_raw,
+                subject=subj,
+                sug_by_email=sug_by_email,
+            )
+        except Exception as e:
+            print(f"  row {r} id={mid[:16]}… skip: {e}", file=sys.stderr)
+            continue
+        chunk.append(gspread.Cell(row=r, col=col, value=status_val))
+        if len(chunk) >= 30:
+            flush_chunk()
+            print(f"  backfilled status {updated}/{len(todo)}...")
+    flush_chunk()
+    print(f"backfill-status: wrote status for {updated} row(s).")
     return updated
 
 
@@ -389,7 +693,7 @@ def main() -> None:
     parser.add_argument(
         "--migrate-only",
         action="store_true",
-        help="Only ensure worksheet + insert body_plain column if missing (no Gmail).",
+        help="Only ensure worksheet + run column migrations (body_plain, status) if missing (no Gmail).",
     )
     parser.add_argument(
         "--backfill-body-plain",
@@ -419,6 +723,16 @@ def main() -> None:
         default=200,
         help="Max Gmail messages to pull per recipient address.",
     )
+    parser.add_argument(
+        "--backfill-status",
+        action="store_true",
+        help="Classify and fill Email Agent Follow Up **status** (warmup|bulk|follow_up|unknown) using Gmail labels + Email Agent Drafts.",
+    )
+    parser.add_argument(
+        "--force-backfill-status",
+        action="store_true",
+        help="With --backfill-status: overwrite non-empty status cells too.",
+    )
     args = parser.parse_args()
 
     sa = get_sheets_client()
@@ -426,7 +740,7 @@ def main() -> None:
     log_ws = ensure_log_worksheet(sh)
 
     if args.migrate_only:
-        print(f"'{LOG_WS}' headers OK (body_plain present or migrated). Done.")
+        print(f"'{LOG_WS}' worksheet ensured (body_plain + status migrations applied if needed). Done.")
         return
 
     service = None
@@ -436,6 +750,21 @@ def main() -> None:
             service = build("gmail", "v1", credentials=gcreds, cache_discovery=False)
         backfill_empty_body_plain(
             service, log_ws, dry_run=args.dry_run, limit=args.backfill_limit
+        )
+        if args.backfill_only:
+            return
+
+    if args.backfill_status:
+        if service is None:
+            gcreds = get_gmail_creds()
+            service = build("gmail", "v1", credentials=gcreds, cache_discovery=False)
+        backfill_followup_status(
+            service,
+            log_ws,
+            sa,
+            dry_run=args.dry_run,
+            limit=args.backfill_limit,
+            force=args.force_backfill_status,
         )
         if args.backfill_only:
             return
@@ -466,6 +795,10 @@ def main() -> None:
         gcreds = get_gmail_creds()
         service = build("gmail", "v1", credentials=gcreds, cache_discovery=False)
 
+    label_map = build_label_id_map(service)
+    id_to_name = {str(v): str(k) for k, v in label_map.items()}
+    sug_by_email = load_suggestions_touch_kinds(sa)
+
     synced_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     new_rows: list[list[str]] = []
     # Track label_ids per new message for the review→sent label swap below.
@@ -482,6 +815,14 @@ def main() -> None:
                 body_plain = ""
             else:
                 body_plain = fetch_plain_body_for_message(service, mid)
+            status_val = infer_followup_log_status(
+                label_ids=[str(x) for x in (m.get("label_ids") or [])],
+                id_to_name=id_to_name,
+                to_email=m["to_email"],
+                sent_at_raw=m.get("sent_at") or "",
+                subject=m.get("subject") or "",
+                sug_by_email=sug_by_email,
+            )
             new_rows.append(
                 [
                     mid,
@@ -493,7 +834,10 @@ def main() -> None:
                     m["sent_at"],
                     m["snippet"],
                     body_plain,
+                    status_val,
                     "gmail_sent_sync",
+                    "0",
+                    "0",
                 ]
             )
             new_msg_label_ids[mid] = m.get("label_ids") or []
@@ -515,7 +859,6 @@ def main() -> None:
     # Gmail carries draft labels onto the sent message automatically, so once
     # we detect a sent message still wearing a review label we swap it out so
     # the review queue (AI/Follow-up, AI/Warm-up) only shows unsent drafts.
-    label_map = build_label_id_map(service)
     for name in [REVIEW_LABEL_FOLLOWUP, REVIEW_LABEL_WARMUP,
                  SENT_LABEL_FOLLOWUP, SENT_LABEL_WARMUP]:
         _get_or_create_label_id(service, name, label_map)


### PR DESCRIPTION
Ships Hit List / Email Agent work: Follow Up Open/Click columns and sync; draft scripts with discard→cadence bypass and optional open pixel; AU/AV formulas on field-agent appends and find_nearby Hit List appends; GAS find_nearby mirror path unchanged in repo (physical_stores). Merge before or with tokenomics GAS PR for coordinated deploy.

Made with [Cursor](https://cursor.com)