### PR TITLE
feat(email-agent): Drafts engagement columns and Follow Up suggestion_id

### DIFF
--- a/HIT_LIST_CREDENTIALS.md
+++ b/HIT_LIST_CREDENTIALS.md
@@ -48,6 +48,33 @@ python3 scripts/field_agent_location_places_pull.py --limit 10
 
 Cross-links: **`agentic_ai_context/DAPP_PAGE_CONVENTIONS.md`** §14 (*Field agent location*), **`tokenomics/SCHEMA.md`** §4.
 
+## Pipeline Dashboard — sub-pipeline (touch histogram) columns **F:M**
+
+**Tab:** [**Pipeline Dashboard**](https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit?gid=1606881029#gid=1606881029) (`gid=1606881029`).
+
+The bar chart (`pipeline_dashboard_chart_colors.py`) reads **D:E** only, so **E** stays the single **total stores** bar per status. **F through M** (8 columns by default) add a **histogram** of logged sends on that touch axis (same joins as Hit List **AU** / **AV**):
+
+| Columns | Meaning |
+|---------|--------|
+| **F** | **0** sends (blank or `0`) |
+| **G–L** | Exactly **1 … 6** sends |
+| **M** | **7+** sends (`>=7`) |
+
+- **AI: Warm up prospect** — histogram uses **AU** (warm-up sends from **Email Agent Follow Up**).
+- **Manager Follow-up**, **Bulk Info Requested**, **AI: Prospect replied** — when those labels appear in column **D**, histogram uses **AV** (follow-up sends).
+
+Bucket counts are configurable in **`scripts/pipeline_dashboard_touch_columns.py`** (`MAX_EXACT`, `TAIL_MIN`).
+
+Refresh / apply formulas:
+
+```bash
+cd market_research
+python3 scripts/pipeline_dashboard_touch_columns.py --dry-run
+python3 scripts/pipeline_dashboard_touch_columns.py
+```
+
+Row **1** sets the header labels (e.g. `0 sends`, `1 send`, `2 sends`, …, `7+ sends`). The GAS `sync_pipeline_metrics` job still reads **C:E** for `weekly.json`; it does **not** sum **F:M**, so operator funnel totals stay unchanged.
+
 ---
 
 ## Research queue — Google Places + Grok photo review
@@ -166,10 +193,11 @@ If the tab is missing, `scripts/sync_email_agent_followup.py` creates it and wri
 | `body_plain` | Best-effort plain body (for draft / Grok context). |
 | `status` | Outbound **kind** for this Gmail **Sent** row: `warmup` · `bulk` · `follow_up` · `unknown` — inferred from Gmail labels (`AI/Sent Warm-up`, `AI/Sent Follow-up`, …) plus **Email Agent Drafts** `protocol_version` when labels are ambiguous (e.g. bulk vs manager share the same follow-up sent label). |
 | `sync_source` | e.g. `gmail_sent_sync`. |
-| `Open` | **Column L** — count (or flag) of **tracked opens** for this sent message; new rows default to **`0`**. Intended to be incremented by **Edgar** (or another HTTPS endpoint) when a draft/sent body includes a 1×1 pixel whose URL carries the same **`suggestion_id`** as **Email Agent Drafts** (see `scripts/email_agent_tracking.py` and `--track-opens` on draft scripts). |
-| `Click through` | **Column M** — **click-through** count (or similar); new rows default to **`0`**. Same integration story as **Open**; link rewriting like `send_newsletter.py`’s `/newsletter/click` is not wired into partner drafts yet. |
+| `Open` | **Column L** — count (or flag) of **tracked opens** for this sent message. On append, **`sync_email_agent_followup.py`** seeds this from the matched **Email Agent Drafts** row’s **Open** (often `0`). Edgar (or similar) can increment **Drafts** while the recipient opens mail **before** the Follow Up row exists; sync then copies the draft value here. |
+| `Click through` | **Column M** — click-through count; same story as **Open** (seeded from **Email Agent Drafts → Click through** on append). |
+| `suggestion_id` | **Column N** — same UUID as **Email Agent Drafts → `suggestion_id`** for the matched draft (matches tracking pixel `tid=`). Empty string when sync cannot match a draft row. |
 
-**Why not only GAS `doGet` for the pixel?** A standalone Apps Script web app *can* log hits and call `SpreadsheetApp`, but: (1) every image load spins a cold execution and burns quotas; (2) the web app must be **Anyone**-accessible without user OAuth, so the URL must carry an **unguessable token** (`tid` = `suggestion_id`) and the script must validate it; (3) at **draft** time there is no **`gmail_message_id`** yet, so the first writes are usually keyed by **`suggestion_id`**, then a small job can copy counts onto the **Follow Up** row after `sync_email_agent_followup.py` matches the sent message. **Edgar** (Rails) is a better fit if you already run tracking pixels for the newsletter: one service account, shared logging, same pattern as `GET …/newsletter/open.gif`.
+**Why not only GAS `doGet` for the pixel?** A standalone Apps Script web app *can* log hits and call `SpreadsheetApp`, but: (1) every image load spins a cold execution and burns quotas; (2) the web app must be **Anyone**-accessible without user OAuth, so the URL must carry an **unguessable token** (`tid` = `suggestion_id`) and the script must validate it; (3) at **draft** time there is no **`gmail_message_id`** yet, so the first engagement writes should target **Email Agent Drafts** (`Open` / `Click through`); when **`sync_email_agent_followup.py`** appends the **Follow Up** row, it ports **`suggestion_id`** and those counters onto the sent log. **Edgar** (Rails) is a better fit if you already run tracking pixels for the newsletter: one service account, shared logging, same pattern as `GET …/newsletter/open.gif`.
 
 ### Run sync (after Gmail OAuth + service account sheet share)
 
@@ -230,6 +258,8 @@ python3 scripts/format_email_agent_suggestions_sheet.py
 | `gmail_label` | e.g. `Email Agent suggestions`. |
 | `protocol_version` | e.g. `PARTNER_OUTREACH_PROTOCOL v0.1`. |
 | `notes` | Free text — why this touch, thread summary, etc. |
+| `Open` | Tracked **open** count for this suggestion while it is still a draft (default **`0`**). Edgar (or similar) should increment using pixel `tid=<suggestion_id>` **before** the **Email Agent Follow Up** row exists; values are **ported** to Follow Up **column L** when sync matches this draft to a Gmail **Sent** row. |
+| `Click through` | Same pattern as **Open** for future click redirectors (default **`0`**); ported to Follow Up **column M** on sync. |
 
 **Warm-up emails actually sent (Hit List column AU — e.g. “Warm-up email sent”):** Count rows on **`Email Agent Follow Up`** where **`status` = `warmup`** (each row is already a Gmail **Sent** message). That excludes draft-registry **`pending_review`** / **`discarded`** rows on **Email Agent Drafts**, which are **not** sends.
 

--- a/scripts/email_agent_tracking.py
+++ b/scripts/email_agent_tracking.py
@@ -4,10 +4,10 @@ Optional open tracking for Email Agent Gmail drafts.
 Embeds a 1×1 image pointing at **Edgar** (or another HTTPS host) so a future endpoint can
 record opens. The URL carries ``tid=<suggestion_id>`` (same UUID written to **Email Agent Drafts**).
 
-**Follow Up sheet** columns **Open** / **Click through** (see ``sync_email_agent_followup.py``) are
-intended to be updated by that endpoint (or a small relay) once a matching **sent** row exists.
-At draft time there is no ``gmail_message_id`` yet, so the pixel cannot target column L/M directly
-until Edgar correlates ``tid`` → ``gmail_message_id`` after ``sync_email_agent_followup.py`` runs.
+**Email Agent Drafts** now has **Open** / **Click through** (defaults ``0``). Edgar (or similar)
+should increment **those** when the pixel fires and the **Email Agent Follow Up** row does not
+exist yet. When ``sync_email_agent_followup.py`` appends a **Follow Up** row, it copies
+``suggestion_id``, **Open**, and **Click through** from the matched draft row (see ``HIT_LIST_CREDENTIALS.md``).
 
 Environment / CLI
 -------------------

--- a/scripts/ensure_email_agent_suggestions_sheet.py
+++ b/scripts/ensure_email_agent_suggestions_sheet.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 import gspread
+from gspread.utils import rowcol_to_a1
 from google.oauth2.service_account import Credentials as SACredentials
 
 _REPO = Path(__file__).resolve().parent.parent
@@ -44,10 +45,62 @@ SUGGESTIONS_HEADERS = [
     "gmail_label",
     "protocol_version",
     "notes",
+    "Open",
+    "Click through",
 ]
+
+# Before engagement columns (matches prior script revision).
+SUGGESTIONS_HEADERS_LEGACY = SUGGESTIONS_HEADERS[:-2]
 
 # Canonical label name to apply via Gmail API when creating drafts (future script).
 DEFAULT_GMAIL_LABEL = "Email Agent suggestions"
+
+
+def header_map(header_row: list[str]) -> dict[str, int]:
+    return {str(c or "").strip(): i for i, c in enumerate(header_row) if str(c or "").strip()}
+
+
+def migrate_drafts_add_open_click(ws: gspread.Worksheet, header_row: list[str]) -> bool:
+    """Append **Open** and **Click through** at end of row 1 if missing; fill ``0`` for existing rows."""
+    hm = header_map(header_row)
+    if hm.get("Open") is not None and hm.get("Click through") is not None:
+        return False
+
+    # Append at the end of the row (sheet grid may be exactly full — use appendDimension).
+    col_count_before = len(header_row)
+    ws.spreadsheet.batch_update(
+        {
+            "requests": [
+                {
+                    "appendDimension": {
+                        "sheetId": ws.id,
+                        "dimension": "COLUMNS",
+                        "length": 2,
+                    }
+                }
+            ]
+        }
+    )
+    c_open = col_count_before + 1
+    c_click = col_count_before + 2
+    ws.update_cell(1, c_open, "Open")
+    ws.update_cell(1, c_click, "Click through")
+
+    vals = ws.get_all_values()
+    nrows = max(0, len(vals) - 1)
+    if nrows:
+        zeros = [["0", "0"]] * nrows
+        ws.update(
+            range_name=f"{rowcol_to_a1(2, c_open)}:{rowcol_to_a1(1 + nrows, c_click)}",
+            values=zeros,
+            value_input_option="USER_ENTERED",
+        )
+
+    print(
+        "Migrated Email Agent Drafts: appended columns 'Open' and 'Click through' "
+        f"(1-based columns {c_open}–{c_click}); filled 0 for {nrows} data row(s)."
+    )
+    return True
 
 
 def get_client():
@@ -87,9 +140,15 @@ def main() -> None:
         print(f"{SUGGESTIONS_WS!r} already has the expected header row.")
         return
 
+    if first == SUGGESTIONS_HEADERS_LEGACY:
+        migrate_drafts_add_open_click(ws, vals[0])
+        print(f"{SUGGESTIONS_WS!r} migrated to include Open / Click through.")
+        return
+
     sys.stderr.write(
         f"{SUGGESTIONS_WS!r} row 1 does not match expected headers.\n"
-        f"Expected: {SUGGESTIONS_HEADERS}\n"
+        f"Expected (new): {SUGGESTIONS_HEADERS}\n"
+        f"Or legacy (13 cols): {SUGGESTIONS_HEADERS_LEGACY}\n"
         f"Found:    {first}\n"
         "Fix manually or rename the tab if this is a different sheet.\n"
     )

--- a/scripts/format_email_agent_suggestions_sheet.py
+++ b/scripts/format_email_agent_suggestions_sheet.py
@@ -22,7 +22,7 @@ _REPO = Path(__file__).resolve().parent.parent
 _SA_CREDS = _REPO / "google_credentials.json"
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
 WS_TITLE = "Email Agent Drafts"
-NUM_COLS = 13
+NUM_COLS = 15
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
@@ -43,6 +43,8 @@ _COL_WIDTHS = [
     160,
     110,
     200,
+    72,
+    88,
 ]
 
 

--- a/scripts/sync_email_agent_followup.py
+++ b/scripts/sync_email_agent_followup.py
@@ -88,11 +88,25 @@ LOG_HEADERS = [
     # Pipeline kind for this outbound (Gmail Sent row). Not the same as Email Agent Drafts status.
     "status",
     "sync_source",
-    # Engagement (defaults 0 on append). Intended to be updated by Edgar (or similar) when a
-    # tracking pixel / redirect fires — see scripts/email_agent_tracking.py and HIT_LIST_CREDENTIALS.md.
+    # Engagement (defaults 0 on append). Pre-filled from **Email Agent Drafts** when sync matches a
+    # draft row (Edgar may increment Drafts before the Follow Up row exists). See email_agent_tracking.py.
     "Open",
     "Click through",
+    # Same UUID as Email Agent Drafts `suggestion_id` for the matched draft (pixel `tid`).
+    "suggestion_id",
 ]
+
+
+def parse_nonneg_int(raw: str, default: int = 0) -> int:
+    """Parse a non-negative integer from a sheet cell (Open / Click through)."""
+    s = (raw or "").strip()
+    if not s:
+        return default
+    try:
+        n = int(float(s.replace(",", "")))
+        return max(0, n)
+    except (TypeError, ValueError):
+        return default
 
 
 def touch_kind_from_protocol(proto: str) -> str:
@@ -130,7 +144,7 @@ def parse_sent_at_header(raw: str) -> datetime | None:
 
 
 def load_suggestions_touch_kinds(sa) -> dict[str, list[dict]]:
-    """{to_email: [{created, subject, kind}]} where kind is warmup|bulk|follow_up."""
+    """{to_email: [draft row dicts]} each with created, subject, kind, suggestion_id, open, click."""
     sh = sa.open_by_key(SPREADSHEET_ID)
     try:
         ws = sh.worksheet(SUGGESTIONS_WS)
@@ -144,6 +158,9 @@ def load_suggestions_touch_kinds(sa) -> dict[str, list[dict]]:
     subj_i = hdr.get("subject")
     proto_i = hdr.get("protocol_version")
     created_i = hdr.get("created_at_utc")
+    sug_i = hdr.get("suggestion_id")
+    open_i = hdr.get("Open")
+    click_i = hdr.get("Click through")
     if em_i is None:
         return {}
     out: dict[str, list[dict]] = {}
@@ -154,11 +171,15 @@ def load_suggestions_touch_kinds(sa) -> dict[str, list[dict]]:
         proto = cell(row, proto_i) if proto_i is not None else ""
         subject = cell(row, subj_i) if subj_i is not None else ""
         created = parse_sent_at_header(cell(row, created_i)) if created_i is not None else None
+        sid = (cell(row, sug_i) if sug_i is not None else "").strip()
         out.setdefault(em, []).append(
             {
+                "suggestion_id": sid,
                 "created": created,
                 "subject": subject,
                 "kind": touch_kind_from_protocol(proto),
+                "open": parse_nonneg_int(cell(row, open_i) if open_i is not None else "", 0),
+                "click": parse_nonneg_int(cell(row, click_i) if click_i is not None else "", 0),
             }
         )
     for em in out:
@@ -166,23 +187,40 @@ def load_suggestions_touch_kinds(sa) -> dict[str, list[dict]]:
     return out
 
 
-def pick_touch_kind_from_suggestions(
+def pick_suggestion_row_for_sent(
     suggestions: list[dict], sent_at: datetime | None, subject: str
-) -> str | None:
+) -> dict | None:
+    """Pick the Email Agent Drafts row that best matches a Gmail Sent row (same heuristics as status)."""
     if not suggestions:
         return None
     kinds = {s["kind"] for s in suggestions}
     if len(kinds) == 1:
-        return kinds.pop()
+        # Same outbound kind for all drafts — still pick the row closest to this Sent (subject / time).
+        if sent_at is not None:
+            prior = [s for s in suggestions if s.get("created") and s["created"] <= sent_at]
+            if prior:
+                return prior[-1]
+        subj = (subject or "").strip()
+        for s in suggestions:
+            if (s.get("subject") or "").strip() == subj:
+                return s
+        return suggestions[-1]
     if sent_at is not None:
-        prior = [s for s in suggestions if s["created"] and s["created"] <= sent_at]
+        prior = [s for s in suggestions if s.get("created") and s["created"] <= sent_at]
         if prior:
-            return prior[-1]["kind"]
+            return prior[-1]
     subj = (subject or "").strip()
     for s in suggestions:
-        if s["subject"].strip() == subj:
-            return s["kind"]
-    return suggestions[-1]["kind"]
+        if (s.get("subject") or "").strip() == subj:
+            return s
+    return suggestions[-1]
+
+
+def pick_touch_kind_from_suggestions(
+    suggestions: list[dict], sent_at: datetime | None, subject: str
+) -> str | None:
+    row = pick_suggestion_row_for_sent(suggestions, sent_at, subject)
+    return row["kind"] if row else None
 
 
 def label_names_for_ids(label_ids: list[str], id_to_name: dict[str, str]) -> set[str]:
@@ -315,7 +353,36 @@ def ensure_log_worksheet(sh):
         vals = ws.get_all_values()
         hdr = vals[0] if vals else []
         migrate_followup_log_add_open_click(ws, hdr)
+        vals = ws.get_all_values()
+        hdr = vals[0] if vals else []
+        migrate_followup_log_add_suggestion_id(ws, hdr)
     return ws
+
+
+def migrate_followup_log_add_suggestion_id(ws: gspread.Worksheet, header_row: list[str]) -> bool:
+    """Append **suggestion_id** at end of row 1 if missing (column after Click through)."""
+    hm = header_map(header_row)
+    if hm.get("suggestion_id") is not None:
+        return False
+
+    col_count_before = len(header_row)
+    ws.spreadsheet.batch_update(
+        {
+            "requests": [
+                {
+                    "appendDimension": {
+                        "sheetId": ws.id,
+                        "dimension": "COLUMNS",
+                        "length": 1,
+                    }
+                }
+            ]
+        }
+    )
+    c_sid = col_count_before + 1
+    ws.update_cell(1, c_sid, "suggestion_id")
+    print(f"Migrated sheet: appended column 'suggestion_id' (1-based column {c_sid}).")
+    return True
 
 
 def migrate_followup_log_add_open_click(ws: gspread.Worksheet, header_row: list[str]) -> bool:
@@ -324,33 +391,27 @@ def migrate_followup_log_add_open_click(ws: gspread.Worksheet, header_row: list[
     if hm.get("Open") is not None and hm.get("Click through") is not None:
         return False
 
-    last_used = 0
-    for i, cell in enumerate(header_row):
-        if str(cell or "").strip():
-            last_used = i + 1
-    insert_at = last_used  # 0-based column index to insert before (append at end)
-
+    col_count_before = len(header_row)
     ws.spreadsheet.batch_update(
         {
             "requests": [
                 {
-                    "insertDimension": {
-                        "range": {
-                            "sheetId": ws.id,
-                            "dimension": "COLUMNS",
-                            "startIndex": insert_at,
-                            "endIndex": insert_at + 2,
-                        }
+                    "appendDimension": {
+                        "sheetId": ws.id,
+                        "dimension": "COLUMNS",
+                        "length": 2,
                     }
                 }
             ]
         }
     )
-    ws.update_cell(1, insert_at + 1, "Open")
-    ws.update_cell(1, insert_at + 2, "Click through")
+    c_open = col_count_before + 1
+    c_click = col_count_before + 2
+    ws.update_cell(1, c_open, "Open")
+    ws.update_cell(1, c_click, "Click through")
     print(
         "Migrated sheet: appended columns 'Open' and 'Click through' "
-        f"(inserted at 1-based columns {insert_at + 1}–{insert_at + 2})."
+        f"(1-based columns {c_open}–{c_click})."
     )
     return True
 
@@ -740,7 +801,10 @@ def main() -> None:
     log_ws = ensure_log_worksheet(sh)
 
     if args.migrate_only:
-        print(f"'{LOG_WS}' worksheet ensured (body_plain + status migrations applied if needed). Done.")
+        print(
+            f"'{LOG_WS}' worksheet ensured (body_plain, status, Open/Click, suggestion_id migrations "
+            "applied if needed). Run ensure_email_agent_suggestions_sheet.py for Email Agent Drafts columns."
+        )
         return
 
     service = None
@@ -823,6 +887,14 @@ def main() -> None:
                 subject=m.get("subject") or "",
                 sug_by_email=sug_by_email,
             )
+            sug_row = pick_suggestion_row_for_sent(
+                sug_by_email.get(m["to_email"], []),
+                parse_sent_at_header(m.get("sent_at") or ""),
+                m.get("subject") or "",
+            )
+            open_ct = str(sug_row["open"]) if sug_row else "0"
+            click_ct = str(sug_row["click"]) if sug_row else "0"
+            sugg_id = (sug_row.get("suggestion_id") or "").strip() if sug_row else ""
             new_rows.append(
                 [
                     mid,
@@ -836,8 +908,9 @@ def main() -> None:
                     body_plain,
                     status_val,
                     "gmail_sent_sync",
-                    "0",
-                    "0",
+                    open_ct,
+                    click_ct,
+                    sugg_id,
                 ]
             )
             new_msg_label_ids[mid] = m.get("label_ids") or []


### PR DESCRIPTION
Adds Open and Click through to Email Agent Drafts (ensure/format scripts). Adds Open, Click through, and suggestion_id to Email Agent Follow Up; sync_email_agent_followup ports from matched draft when appending from Gmail Sent. Migrations use appendDimension for new trailing columns. Updates HIT_LIST_CREDENTIALS and email_agent_tracking notes.

Made with [Cursor](https://cursor.com)