### PR TITLE
feat(email-agent): track-clicks, HTML helper, Drafts Open/Click on append

### DIFF
--- a/HIT_LIST_CREDENTIALS.md
+++ b/HIT_LIST_CREDENTIALS.md
@@ -259,7 +259,7 @@ python3 scripts/format_email_agent_suggestions_sheet.py
 | `protocol_version` | e.g. `PARTNER_OUTREACH_PROTOCOL v0.1`. |
 | `notes` | Free text — why this touch, thread summary, etc. |
 | `Open` | Tracked **open** count for this suggestion while it is still a draft (default **`0`**). Edgar (or similar) should increment using pixel `tid=<suggestion_id>` **before** the **Email Agent Follow Up** row exists; values are **ported** to Follow Up **column L** when sync matches this draft to a Gmail **Sent** row. |
-| `Click through` | Same pattern as **Open** for future click redirectors (default **`0`**); ported to Follow Up **column M** on sync. |
+| `Click through` | Same pattern as **Open** for click redirectors when drafts use **`--track-clicks`** (default **`0`**); ported to Follow Up **column M** on sync. |
 
 **Warm-up emails actually sent (Hit List column AU — e.g. “Warm-up email sent”):** Count rows on **`Email Agent Follow Up`** where **`status` = `warmup`** (each row is already a Gmail **Sent** message). That excludes draft-registry **`pending_review`** / **`discarded`** rows on **Email Agent Drafts**, which are **not** sends.
 
@@ -300,6 +300,8 @@ python3 scripts/suggest_manager_followup_drafts.py --max-drafts 1
 ```
 
 Options: `--skip-label`, `--expected-mailbox other@domain` (default `garyjob@agroverse.shop`).
+
+**Open / click tracking (Python draft scripts only):** Pass **`--track-opens`** to add a multipart **HTML** part with a 1×1 pixel to **`GET /email_agent/open.gif?tid=<suggestion_id>`** (default host **`EMAIL_AGENT_TRACKING_BASE_URL`** = `https://edgar.truesight.me`). Pass **`--track-clicks`** to rewrite **`http(s):`** URLs in that HTML part through **`GET /email_agent/click?tid=…&r=…&to=…`** (recipient and destination are base64url, same pattern as newsletter). Plain-text part is unchanged. **Edgar** must implement those routes and increment **Email Agent Drafts** columns **Open** / **Click through**; **`sync_email_agent_followup.py`** ports them to **Email Agent Follow Up** when it matches a sent message to a draft. Apps Script **`EmailAgentDrafts.gs`** does not inject pixels or wrapped links yet.
 
 **Cadence / anti-spam:** Only one **pending** draft per **`to_email`** (see **Email Agent Drafts** `status=pending_review`). The next draft is allowed only after **`min-days-since-sent`** (default **7**) since the latest **`sent_at`** for that address in **Email Agent Follow Up**. Recipients with no follow-up log row are eligible immediately. Use `--verbose` to print per-address skips. When you **Send** from Gmail, run `sync_email_agent_followup.py`, then set the suggestion row to `sent` (or `discarded`); the next scheduled run can draft again once cadence passes.
 

--- a/scripts/email_agent_tracking.py
+++ b/scripts/email_agent_tracking.py
@@ -1,28 +1,36 @@
 """
-Optional open tracking for Email Agent Gmail drafts.
+Optional open / click tracking for Email Agent Gmail drafts.
 
-Embeds a 1×1 image pointing at **Edgar** (or another HTTPS host) so a future endpoint can
+Embeds a 1×1 image pointing at **Edgar** (or another HTTPS host) so an endpoint can
 record opens. The URL carries ``tid=<suggestion_id>`` (same UUID written to **Email Agent Drafts**).
 
-**Email Agent Drafts** now has **Open** / **Click through** (defaults ``0``). Edgar (or similar)
-should increment **those** when the pixel fires and the **Email Agent Follow Up** row does not
-exist yet. When ``sync_email_agent_followup.py`` appends a **Follow Up** row, it copies
-``suggestion_id``, **Open**, and **Click through** from the matched draft row (see ``HIT_LIST_CREDENTIALS.md``).
+**Email Agent Drafts** has **Open** / **Click through** (defaults ``0``). Edgar should increment
+those when the pixel or click redirect fires before the **Email Agent Follow Up** row exists.
+``sync_email_agent_followup.py`` copies ``suggestion_id``, **Open**, and **Click through** from the
+matched draft row when appending a Follow Up row (see ``HIT_LIST_CREDENTIALS.md``).
 
 Environment / CLI
 -------------------
 - ``EMAIL_AGENT_TRACKING_BASE_URL`` — default ``https://edgar.truesight.me`` (no trailing slash required).
-- Draft scripts: ``--track-opens`` to attach the HTML part + pixel (plain part stays for clients that
-  prefer text).
+- Draft scripts: ``--track-opens`` for multipart HTML + open pixel; ``--track-clicks`` rewrites
+  ``http(s):`` URLs in the **HTML** half through ``GET /email_agent/click?tid=…&r=…&to=…`` (same idea
+  as ``send_newsletter.py`` / ``newsletter/click``). Plain part is unchanged.
 
-**Clicks** are not rewritten here; reserve **Click through** (column M) for a future Edgar
-``/email_agent/click`` redirector similar to ``send_newsletter.py``.
+Edgar must implement ``GET /email_agent/open.gif`` and ``GET /email_agent/click`` (redirect) if you use these flags.
 """
 
 from __future__ import annotations
 
+import base64
 import html
+import re
 import urllib.parse
+
+_AGENT_URL_RE = re.compile(r"https?://[^\s<>\"'()\[\]{}]+", re.IGNORECASE)
+
+
+def _b64url(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode("utf-8")).decode("ascii").rstrip("=")
 
 
 def build_open_pixel_html(base_url: str, suggestion_id: str) -> str:
@@ -34,12 +42,82 @@ def build_open_pixel_html(base_url: str, suggestion_id: str) -> str:
     )
 
 
-def plain_text_to_html_with_open_pixel(plain: str, base_url: str, suggestion_id: str) -> str:
-    """Wrap plain text as HTML and append the tracking pixel (multipart/alternative HTML half)."""
-    body = html.escape(plain or "", quote=False)
-    wrapped = (
+def build_email_agent_tracked_link(
+    original_url: str, base_url: str, suggestion_id: str, recipient: str
+) -> str:
+    """Wrap ``http(s)`` URLs for Edgar click logging; other schemes left unchanged."""
+    ou = (original_url or "").strip()
+    if not ou.lower().startswith(("http://", "https://")):
+        return ou
+    tid = urllib.parse.quote((suggestion_id or "").strip(), safe="")
+    r = _b64url(recipient or "")
+    to = _b64url(ou)
+    return f"{base_url.rstrip('/')}/email_agent/click?tid={tid}&r={r}&to={to}"
+
+
+def _html_body_preplain(
+    plain: str,
+    base_url: str,
+    suggestion_id: str,
+    recipient_email: str,
+    *,
+    track_clicks: bool,
+) -> str:
+    s = plain or ""
+    if not track_clicks:
+        body = html.escape(s, quote=False)
+    else:
+        chunks: list[str] = []
+        pos = 0
+        for m in _AGENT_URL_RE.finditer(s):
+            chunks.append(html.escape(s[pos : m.start()], quote=False))
+            raw_url = m.group(0)
+            href = build_email_agent_tracked_link(raw_url, base_url, suggestion_id, recipient_email)
+            chunks.append(
+                f'<a href="{html.escape(href, quote=True)}">{html.escape(raw_url, quote=False)}</a>'
+            )
+            pos = m.end()
+        chunks.append(html.escape(s[pos:], quote=False))
+        body = "".join(chunks)
+    return (
         '<div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;'
         'font-size:15px;line-height:1.45;white-space:pre-wrap;">'
         f"{body}</div>"
     )
-    return wrapped + build_open_pixel_html(base_url, suggestion_id)
+
+
+def plain_text_to_html_for_email_agent(
+    plain: str,
+    base_url: str,
+    suggestion_id: str,
+    recipient_email: str,
+    *,
+    track_opens: bool = False,
+    track_clicks: bool = False,
+) -> str | None:
+    """Build the HTML alternative for Gmail multipart; ``None`` if no tracking requested."""
+    if not track_opens and not track_clicks:
+        return None
+    inner = _html_body_preplain(
+        plain,
+        base_url,
+        suggestion_id,
+        recipient_email,
+        track_clicks=track_clicks,
+    )
+    if track_opens:
+        return inner + build_open_pixel_html(base_url, suggestion_id)
+    return inner
+
+
+def plain_text_to_html_with_open_pixel(plain: str, base_url: str, suggestion_id: str) -> str:
+    """Wrap plain text as HTML and append the tracking pixel (multipart/alternative HTML half)."""
+    out = plain_text_to_html_for_email_agent(
+        plain,
+        base_url,
+        suggestion_id,
+        "",
+        track_opens=True,
+        track_clicks=False,
+    )
+    return out or ""

--- a/scripts/suggest_bulk_info_drafts.py
+++ b/scripts/suggest_bulk_info_drafts.py
@@ -37,7 +37,7 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 import suggest_manager_followup_drafts as sm
-from email_agent_tracking import plain_text_to_html_with_open_pixel
+from email_agent_tracking import plain_text_to_html_for_email_agent
 
 BULK_STATUS = "Bulk Info Requested"
 BULK_PROTOCOL_VERSION = "BULK_INFO_PDF v0.1"
@@ -101,6 +101,11 @@ def main() -> None:
         "--track-opens",
         action="store_true",
         help="Multipart HTML + 1×1 open pixel (tid=suggestion_id); see suggest_manager_followup_drafts --track-opens.",
+    )
+    parser.add_argument(
+        "--track-clicks",
+        action="store_true",
+        help="Rewrite http(s) URLs in the HTML part via Edgar /email_agent/click; see suggest_manager_followup_drafts.",
     )
     parser.add_argument("--expected-mailbox", default=sm.EXPECTED_MAILBOX)
     parser.add_argument("--verbose", action="store_true")
@@ -265,8 +270,20 @@ def main() -> None:
         sug_id = str(uuid.uuid4())
         tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
         html_body = None
-        if args.track_opens and tracking_base:
-            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+        if args.track_opens or args.track_clicks:
+            if not tracking_base:
+                sys.stderr.write(
+                    "EMAIL_AGENT_TRACKING_BASE_URL is empty; cannot use --track-opens/--track-clicks.\n"
+                )
+                sys.exit(2)
+            html_body = plain_text_to_html_for_email_agent(
+                body,
+                tracking_base,
+                sug_id,
+                to_addr,
+                track_opens=args.track_opens,
+                track_clicks=args.track_clicks,
+            )
 
         raw = sm.build_message_raw(
             me,
@@ -319,6 +336,8 @@ def main() -> None:
             sm.DEFAULT_GMAIL_LABEL if not args.skip_label else "",
             BULK_PROTOCOL_VERSION,
             notes,
+            "0",
+            "0",
         ]
         created_rows.append(row)
         n_made += 1

--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -77,7 +77,7 @@ from google.oauth2.service_account import Credentials as SACredentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from email_agent_tracking import plain_text_to_html_with_open_pixel
+from email_agent_tracking import plain_text_to_html_for_email_agent
 from gmail_plain_body import extract_plain_body_from_payload
 from gmail_user_credentials import load_gmail_user_credentials
 
@@ -129,6 +129,8 @@ SUGGESTIONS_HEADERS = [
     "gmail_label",
     "protocol_version",
     "notes",
+    "Open",
+    "Click through",
 ]
 
 
@@ -1097,6 +1099,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--track-clicks",
+        action="store_true",
+        help=(
+            "Rewrite http(s) URLs in the HTML alternative through Edgar "
+            "GET /email_agent/click?tid=&r=&to= (recipient + destination are base64url); "
+            "implies a multipart HTML part. Combine with --track-opens as needed."
+        ),
+    )
+    parser.add_argument(
         "--expected-mailbox",
         default=EXPECTED_MAILBOX,
         help=f"Abort if Gmail profile != this (default: {EXPECTED_MAILBOX}).",
@@ -1326,8 +1337,20 @@ def main() -> None:
         sug_id = str(uuid.uuid4())
         tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
         html_body = None
-        if args.track_opens and tracking_base:
-            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+        if args.track_opens or args.track_clicks:
+            if not tracking_base:
+                sys.stderr.write(
+                    "EMAIL_AGENT_TRACKING_BASE_URL is empty; cannot use --track-opens/--track-clicks.\n"
+                )
+                sys.exit(2)
+            html_body = plain_text_to_html_for_email_agent(
+                body,
+                tracking_base,
+                sug_id,
+                to_addr,
+                track_opens=args.track_opens,
+                track_clicks=args.track_clicks,
+            )
 
         raw = build_message_raw(me, to_addr, subj, body, html_body=html_body)
 
@@ -1375,6 +1398,8 @@ def main() -> None:
             DEFAULT_GMAIL_LABEL if not args.skip_label else "",
             PROTOCOL_VERSION,
             notes,
+            "0",
+            "0",
         ]
         created_rows.append(row)
         n_made += 1

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -49,7 +49,7 @@ if str(_SCRIPTS) not in sys.path:
 
 import suggest_manager_followup_drafts as smf
 
-from email_agent_tracking import plain_text_to_html_with_open_pixel
+from email_agent_tracking import plain_text_to_html_for_email_agent
 _WARMUP_REF = _REPO / "templates" / "warmup_outreach_reference.md"
 _DEFAULT_PDF = _REPO / "retail_price_list" / "agroverse_wholesale_price_list_2026.pdf"
 
@@ -427,6 +427,11 @@ def main() -> None:
         action="store_true",
         help="Multipart HTML + 1×1 open pixel (tid=suggestion_id); see suggest_manager_followup_drafts --track-opens.",
     )
+    p.add_argument(
+        "--track-clicks",
+        action="store_true",
+        help="Rewrite http(s) URLs in the HTML part via Edgar /email_agent/click; see suggest_manager_followup_drafts.",
+    )
     args = p.parse_args()
 
     if args.max_drafts < 0:
@@ -612,8 +617,20 @@ def main() -> None:
         sug_id = str(uuid.uuid4())
         tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
         html_body = None
-        if args.track_opens and tracking_base:
-            html_body = plain_text_to_html_with_open_pixel(body, tracking_base, sug_id)
+        if args.track_opens or args.track_clicks:
+            if not tracking_base:
+                sys.stderr.write(
+                    "EMAIL_AGENT_TRACKING_BASE_URL is empty; cannot use --track-opens/--track-clicks.\n"
+                )
+                sys.exit(2)
+            html_body = plain_text_to_html_for_email_agent(
+                body,
+                tracking_base,
+                sug_id,
+                to_addr,
+                track_opens=args.track_opens,
+                track_clicks=args.track_clicks,
+            )
 
         try:
             raw = build_message_raw_with_pdf(
@@ -667,6 +684,8 @@ def main() -> None:
             DEFAULT_GMAIL_LABEL if not args.skip_label else "",
             PROTOCOL_VERSION,
             notes,
+            "0",
+            "0",
         ]
         created_rows.append(row)
         n_made += 1


### PR DESCRIPTION
Adds `plain_text_to_html_for_email_agent` with optional `--track-opens` and `--track-clicks` (Edgar `/email_agent/click` URL pattern aligned with newsletter). Manager, bulk, and warmup draft scripts append `Open`/`Click through` as `0` and extend `SUGGESTIONS_HEADERS`. Updates HIT_LIST_CREDENTIALS.md (Python flags vs Apps Script gap).

Made with [Cursor](https://cursor.com)