### PR TITLE
chore(advisory): track governor_chatbot_service in daily digest + snapshot

### DIFF
--- a/.github/workflows/advisory-snapshot-refresh.yml
+++ b/.github/workflows/advisory-snapshot-refresh.yml
@@ -116,6 +116,13 @@ jobs:
           fetch-depth: 100
           token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
 
+      - name: Checkout governor_chatbot_service
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/governor_chatbot_service
+          path: repos/governor_chatbot_service
+          fetch-depth: 100
+
       - name: Checkout ecosystem_change_logs (for BASE.md + archives + reminders)
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/beer-hall-digest-daily.yml
+++ b/.github/workflows/beer-hall-digest-daily.yml
@@ -75,6 +75,13 @@ jobs:
           fetch-depth: 100
           token: ${{ secrets.ORACLE_ADVISORY_PUSH_TOKEN }}
 
+      - name: Checkout governor_chatbot_service
+        uses: actions/checkout@v4
+        with:
+          repository: TrueSightDAO/governor_chatbot_service
+          path: repos/governor_chatbot_service
+          fetch-depth: 100
+
       # --- target repos (writable; need PAT so we can push branches) ---
 
       - name: Checkout ecosystem_change_logs (target)

--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -81,6 +81,7 @@ REPOS: list[tuple[str, str]] = [
     ("agroverse_shop", "agroverse_shop_beta"),
     ("iching_oracle", "oracle"),
     ("Cypher-Defense", "Cypher-Defense"),
+    ("governor_chatbot_service", "governor_chatbot_service"),
 ]
 
 # Heuristic: CONTEXT_UPDATES lines mentioning these names (case-insensitive).

--- a/scripts/generate_beer_hall_preview.py
+++ b/scripts/generate_beer_hall_preview.py
@@ -58,6 +58,7 @@ REPOS: list[tuple[str, str]] = [
     ("agroverse_shop", "agroverse_shop_beta"),
     ("iching_oracle", "oracle"),
     ("Cypher-Defense", "Cypher-Defense"),
+    ("governor_chatbot_service", "governor_chatbot_service"),
 ]
 
 


### PR DESCRIPTION
## Goal
Include the new `governor_chatbot_service` repo in the automated advisory snapshot and Beer Hall digest workflows so oracle context and daily digests reflect Governor Chatbot activity.

## Changes
- `advisory-snapshot-refresh.yml`: added checkout step for `TrueSightDAO/governor_chatbot_service`
- `beer-hall-digest-daily.yml`: added checkout step for `TrueSightDAO/governor_chatbot_service`
- `generate_advisory_snapshot.py`: added to `REPOS` list
- `generate_beer_hall_preview.py`: added to `REPOS` list

## Testing
- Verified grep matches in all 4 files.
- No functional code changes; workflow syntax unchanged.

## Rollout
- Next scheduled runs (advisory: 6-hourly, Beer Hall: daily 00:00 UTC) will automatically include the new repo.