### PR TITLE
feat(email-agent): default --track-opens / --track-clicks to ON

### DIFF
--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -1091,20 +1091,24 @@ def main() -> None:
     parser.add_argument("--skip-label", action="store_true", help="Do not create/apply Gmail label.")
     parser.add_argument(
         "--track-opens",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help=(
             "Add an HTML alternative with a 1×1 open pixel (tid=suggestion_id). "
+            "Default ON; pass --no-track-opens to disable for a one-off batch. "
             "Set EMAIL_AGENT_TRACKING_BASE_URL (default https://edgar.truesight.me); "
             "Edgar must implement GET /email_agent/open.gif — see email_agent_tracking.py."
         ),
     )
     parser.add_argument(
         "--track-clicks",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help=(
             "Rewrite http(s) URLs in the HTML alternative through Edgar "
             "GET /email_agent/click?tid=&r=&to= (recipient + destination are base64url); "
-            "implies a multipart HTML part. Combine with --track-opens as needed."
+            "implies a multipart HTML part. Default ON; pass --no-track-clicks to disable. "
+            "Combine with --track-opens as needed."
         ),
     )
     parser.add_argument(

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -453,13 +453,21 @@ def main() -> None:
     p.add_argument("--skip-reply-promotion", action="store_true")
     p.add_argument(
         "--track-opens",
-        action="store_true",
-        help="Multipart HTML + 1×1 open pixel (tid=suggestion_id); see suggest_manager_followup_drafts --track-opens.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Multipart HTML + 1×1 open pixel (tid=suggestion_id). Default ON; "
+            "pass --no-track-opens to disable for a one-off batch."
+        ),
     )
     p.add_argument(
         "--track-clicks",
-        action="store_true",
-        help="Rewrite http(s) URLs in the HTML part via Edgar /email_agent/click; see suggest_manager_followup_drafts.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Rewrite http(s) URLs in the HTML part via Edgar /email_agent/click. "
+            "Default ON; pass --no-track-clicks to disable for a one-off batch."
+        ),
     )
     args = p.parse_args()
 


### PR DESCRIPTION
## Summary

Switches both `scripts/suggest_warmup_prospect_drafts.py` and `scripts/suggest_manager_followup_drafts.py` from `action=\"store_true\"` to `action=argparse.BooleanOptionalAction, default=True` for `--track-opens` and `--track-clicks`. Adds `--no-track-opens` / `--no-track-clicks` opt-outs.

## Why

Six pending drafts in the operator's inbox right now (5 follow-ups + 1 warm-up) were generated with neither flag passed, so they shipped as plain-text-only with no open pixel and no HTML alternative. Open / Click through measurement is permanently lost for any of those that the operator now sends — there's no way to retro-fit a pixel into mail that already exists.

Making tracking the safe default avoids the silent regression. The agent-driven pipelines exist precisely so we can measure outcomes; an opt-in flag is the wrong default for a tool whose value depends on telemetry.

This also unblocks the **PR #74 cohort study** (warm-up packaging photos). Without tracking on every post-2026-04-27 warm-up, the planned open / click comparison vs the pre-cutoff cohort would be unreliable.

## Behavior

| Invocation | Before | After |
|---|---|---|
| `... ` | tracking off | tracking ON (pixel + HTML alt + click rewrite) |
| `... --track-opens --track-clicks` | tracking on | tracking ON (no-op, idempotent) |
| `... --no-track-opens --no-track-clicks` | n/a | tracking off |
| `... --no-track-opens` | n/a | open pixel off, click rewrite ON |

## Test plan

- [ ] `python3 scripts/suggest_warmup_prospect_drafts.py --help` shows `[--track-opens | --no-track-opens]`.
- [ ] Same for `suggest_manager_followup_drafts.py`.
- [ ] After merge: regenerate the 6 currently-pending plain-text drafts and verify each has the visible Agroverse-logo pixel (Edgar `/email_agent/open.gif?tid=…`) embedded in the HTML alternative.
- [ ] Confirm no behavior change to the PDF / packaging-photo attachments path from PR #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)