### PR TITLE
fix(newsletter): compact image layout + swap farm photo URLs

### DIFF
--- a/newsletter_drafts/2026-04-20_two_bahia_bars.md
+++ b/newsletter_drafts/2026-04-20_two_bahia_bars.md
@@ -12,14 +12,14 @@ Kirsten Ritschel (KiKi's Cocoa) just finished a pair of 81% single-estate dark c
 
 **Oscar's Farm — Bahia, 2024**
 
-![Oscar's farm in Bahia, Brazil — three generations of cacao growers](https://agroverse.shop/assets/images/products/oscars-farm.jpeg)
+![Oscar's farm in Bahia, Brazil — three generations of cacao growers](https://raw.githubusercontent.com/TrueSightDAO/truesight_me/main/assets/shipments/agl14.avif)
 
 Deep chocolate and buttery smoothness, moderate earth, a rich full-bodied arc. Oscar's family has been growing cacao in Bahia for three generations — we've been documenting their bean selection on film.
 [Check Oscar's Farm 2024](https://agroverse.shop/product-page/organic-81-dark-chocolate-bar-50g-oscar-bahia-2024/index.html)
 
 **Fazenda Santa Ana — Bahia, 2023**
 
-![Fazenda Santa Ana — a Coopercabruca regenerative farm in Bahia, Brazil](https://agroverse.shop/assets/images/products/fazenda-santa-ana-product.jpg)
+![Fazenda Santa Ana — a Coopercabruca regenerative farm in Itacaré, Bahia](https://agroverse.shop/assets/images/farms/fazenda-santa-ana-itacare.jpg)
 
 Opens nutty and bright (without citrus), moves through a super-smooth earthy mid-palate with no astringency, then shifts to coffee-mocha with a short finish. Sourced through Coopercabruca — a network of regenerative farms supporting ecosystem biodiversity.
 [Check Fazenda Santa Ana 2023](https://agroverse.shop/product-page/organic-81-dark-chocolate-bar-50g-fazenda-santa-ana-bahia-2023/index.html)

--- a/scripts/send_newsletter.py
+++ b/scripts/send_newsletter.py
@@ -42,7 +42,7 @@ Body markdown supports a tiny vocabulary:
   **bold**                          → <strong>bold</strong>
   *italic*                          → <em>italic</em>
   [text](https://url)               → <a href="…">text</a>
-  ![alt](https://image-url)         → <img src="…" alt="…" width="480" …>
+  ![alt](https://image-url)         → <img src="…" alt="…" width="320" …>
   Blank lines separate paragraphs.
 
 Sheet log columns (appended to Agroverse News Letter Emails):
@@ -305,12 +305,16 @@ _MD_IMG_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
 
 def _img_html_substitution(match: re.Match) -> str:
+    # 320px default keeps inline images from dominating mobile / Gmail
+    # newsletter layouts (the first cut was 480px and felt cluttered with
+    # three stacked heroes). max-width:100% scales down on narrow viewports;
+    # margin:auto centers horizontally so images breathe between paragraphs.
     alt = match.group(1).replace('"', '&quot;')
     src = match.group(2)
     return (
-        f'<img src="{src}" alt="{alt}" width="480" '
+        f'<img src="{src}" alt="{alt}" width="320" '
         f'style="max-width:100%;height:auto;display:block;'
-        f'border-radius:8px;margin:12px 0;" />'
+        f'border-radius:8px;margin:18px auto;" />'
     )
 
 


### PR DESCRIPTION
## Summary

Two operator-feedback fixes on v2 of the two-Bahia-bars newsletter draft.

### 1. Compact images

v2 review send felt cluttered with three 480px-wide heroes stacked vertically. Drop the default image width on `markdown_to_html` from **480px → 320px**, center horizontally with `margin:18px auto`, keep `max-width:100%` so mobile stays responsive. Single converter change — every future newsletter image inherits the new sizing.

### 2. Farm photo URL swaps

Per operator instruction:

| Section | Was | Now |
|---|---|---|
| Oscar's Farm | `agroverse.shop/assets/images/products/oscars-farm.jpeg` | `raw.githubusercontent.com/TrueSightDAO/truesight_me/main/assets/shipments/agl14.avif` |
| Fazenda Santa Ana | `products/fazenda-santa-ana-product.jpg` | `agroverse.shop/assets/images/farms/fazenda-santa-ana-itacare.jpg` |

Santa Ana alt text updated to mention Itacaré (the new image is from there).

## Compat note: AVIF in email

`agl14.avif` renders cleanly in **Gmail web + Apple Mail (Big Sur+)** but **Outlook desktop does NOT decode AVIF** — recipients on that client will see the alt text, not the image. Acceptable for the review send to Gary's personal Gmail. **For the full-list send, consider a JPG mirror.**

## Test plan

- [ ] Review send to garyjob@gmail.com — confirm three images render at the smaller width and the email feels less crowded.
- [ ] Click the Oscar / Santa Ana CTAs — confirm both still route through Edgar (`/newsletter/click`).
- [ ] Hit-test on mobile viewport — confirm images scale down, don't overflow the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)