### PR TITLE
chore(beer-hall-digest): reframe Message 1 as daily update, not weekly

### DIFF
--- a/scripts/draft_beer_hall_digest.py
+++ b/scripts/draft_beer_hall_digest.py
@@ -6,7 +6,7 @@ the output of ``generate_beer_hall_preview.py`` to **Anthropic Claude**.
 The Beer Hall WhatsApp send has been retired — digests are **archive-only** artifacts
 that feed the static ``beer_hall/feed/`` (read by truesight.me) and ``ADVISORY_SNAPSHOT.md``
 (read by the oracle at oracle.truesight.me). This drafter replaces the manual/LLM-in-IDE
-summarisation step so the weekly GitHub Action can run end-to-end.
+summarisation step so the daily GitHub Action can run end-to-end.
 
 Writes three files:
 
@@ -59,7 +59,7 @@ def _recent_examples(examples_dir: Path, limit: int = 2) -> list[str]:
     return out
 
 
-_SYSTEM = """You draft the weekly **Beer Hall digest** for the TrueSight DAO — a regenerative cacao supply chain DAO. Your audience is DAO contributors, partners, and non-engineer stakeholders (not only developers).
+_SYSTEM = """You draft the daily **Beer Hall digest** for the TrueSight DAO — a regenerative cacao supply chain DAO. Your audience is DAO contributors, partners, and non-engineer stakeholders (not only developers). The digest publishes daily; the evidence pack you receive may include up to ~7 days of git activity and ~48 h of Telegram community signal because shipped work doesn't perfectly align to the publish cadence — frame Message 1 as **today's update** and let the bullets speak to whatever genuinely shipped or moved since the previous Beer Hall, not "this week".
 
 Output is consumed by the truesight.me static Beer Hall feed and by the oracle.truesight.me Grok advisor. It is NOT broadcast to WhatsApp.
 
@@ -76,7 +76,7 @@ Style rules:
 Output format — return **only** these three sections, in order, with the exact markers shown:
 
 ===SLUG===
-<kebab-case slug, 3–6 words, capturing the week's headline>
+<kebab-case slug, 3–6 words, capturing today's headline>
 ===MESSAGE_1===
 <opener line + TLDR bullets>
 ===MESSAGE_2===
@@ -91,11 +91,13 @@ Community (Telegram log):
 No commentary before, between, or after the markers."""
 
 
-_USER_TEMPLATE = """Here is this week's evidence pack from generate_beer_hall_preview.py. Synthesise it into Message 1 + Message 2 per the system rules.
+_USER_TEMPLATE = """Here is today's evidence pack from generate_beer_hall_preview.py. Synthesise it into Message 1 + Message 2 per the system rules.
+
+The preview's evidence window (`--since-days`, `--telegram-hours`) is wider than 24 h on purpose — DAO work doesn't perfectly chunk into days. Use the wider window as input but write Message 1 as **today's update**, not "this week" — anchor on what genuinely moved since the previous Beer Hall.
 
 {examples_block}
 
-=== THIS WEEK'S EVIDENCE (preview output) ===
+=== TODAY'S EVIDENCE (preview output) ===
 
 {preview}
 """


### PR DESCRIPTION
## Goal

The Beer Hall digest workflow has been shipping **daily** for months (`beer-hall-digest-daily.yml` at 00:00 UTC), but the LLM drafter prompt still tells Claude it's writing a *"weekly digest"*. So Message 1 routinely opens with *"this week we …"* even though the digest publishes every 24 h. Gary asked to reframe as the day's update.

## Changes (only `scripts/draft_beer_hall_digest.py`)

- **System prompt**: *"weekly Beer Hall digest"* → *"daily Beer Hall digest"*, with an explicit note that the evidence pack window is wider than 24 h (~7 d git / ~48 h Telegram by design — shipped work doesn't chunk perfectly into days) and that Message 1 should still be framed as **today's update**, anchoring on what genuinely moved since the previous Beer Hall rather than *"this week"*.
- **Slug guidance**: *"the week's headline"* → *"today's headline"*.
- **User template**: *"this week's evidence pack"* → *"today's evidence pack"*; `=== THIS WEEK'S EVIDENCE ===` → `=== TODAY'S EVIDENCE ===`; inline reminder that the wider-than-one-day window is by design.
- **Stale module-docstring** reference to *"the weekly GitHub Action"* → *"the daily GitHub Action"*.

## Not changed

- `--since-days 7` / `--telegram-hours 48` on `generate_beer_hall_preview.py` — the **evidence look-back** is a separate decision (how much past activity Claude gets to see) and independent of the publish **cadence**. Reducing the look-back to 24 h would strip out shipped work whose commits land more than a day before they're picked up — out of scope for this PR.
- `OPENCLAW_WHATSAPP.md`, `WORKSPACE_CONTEXT.md`, README — none mention *"weekly"* in connection with the Beer Hall, so no docs were stale.

## Test plan

- [x] `python -c 'import ast; ast.parse(open(\"…\").read())'` — parse OK.
- [x] `grep "weekly\|this week\|the week\|THIS WEEK"` returns only the new prompt text instructing Claude not to write "this week".
- [ ] Will be exercised on the next scheduled Beer Hall digest run (daily 00:00 UTC) — auto-merge + PR-against-`ecosystem_change_logs` already wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)