### PR TITLE
feat(email): parallel audience labels — DTC on newsletters, B2B on outreach

### DIFF
--- a/scripts/send_newsletter.py
+++ b/scripts/send_newsletter.py
@@ -105,6 +105,13 @@ NEWSLETTER_LOG_SPREADSHEET_ID = "1ed3q3SJ8ztGwfWit6Wxz_S72Cn5jKQFkNrHpeOVXP8s"
 SUBSCRIBERS_WS = "Agroverse News Letter Subscribers"
 EMAILS_WS = "Agroverse News Letter Emails"
 
+# Top-level audience label applied to every newsletter send alongside the
+# per-campaign label (e.g. "Newsletter/2 Chocolate Bars"). Lets the operator
+# filter "all consumer-facing email I've sent, across every campaign, ever"
+# with a single Gmail click. Parallel to the per-campaign label — both
+# applied; nothing renamed; existing per-campaign saved searches keep working.
+AUDIENCE_LABEL_DTC = "DTC"
+
 # Main Ledger: "Agroverse QR codes" tab — used by --exclude-buyers-of-substring
 # to skip recipients who already hold a QR for the SKU(s) the campaign is about
 # (don't pitch a bar to someone who already bought it). Column layout:
@@ -595,8 +602,14 @@ def main() -> None:
         sys.exit(2)
 
     label_id: str | None = None
-    if args.label and not args.dry_run:
-        label_id = ensure_user_label_id(gsvc, args.label)
+    audience_label_id: str | None = None
+    if not args.dry_run:
+        if args.label:
+            label_id = ensure_user_label_id(gsvc, args.label)
+        # Audience label is applied unconditionally (every send through this
+        # script is by definition DTC — goes to the consumer subscriber
+        # list). Skip in dry-run since we're not creating any messages.
+        audience_label_id = ensure_user_label_id(gsvc, AUDIENCE_LABEL_DTC)
 
     print(f"Mailbox:     {me}")
     print(f"Mode:        {args.mode}")
@@ -656,9 +669,13 @@ def main() -> None:
             status = "sent"
             print(f"Sent: {gmail_msg_id!r} -> {recipient}")
 
-        if label_id and gmail_msg_id:
+        label_ids_to_apply = [lid for lid in (label_id, audience_label_id) if lid]
+        if label_ids_to_apply and gmail_msg_id:
             try:
-                apply_label(gsvc, gmail_msg_id, label_id)
+                gsvc.users().messages().modify(
+                    userId="me", id=gmail_msg_id,
+                    body={"addLabelIds": label_ids_to_apply},
+                ).execute()
             except Exception as e:
                 sys.stderr.write(f"Warning: label apply failed for {gmail_msg_id}: {e}\n")
 

--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -1272,8 +1272,14 @@ def main() -> None:
         return
 
     label_id: str | None = None
+    audience_label_id: str | None = None
     if not args.dry_run and not args.skip_label:
         label_id = ensure_user_label_id(gsvc, DEFAULT_GMAIL_LABEL)
+        # Top-level audience label parallel to AI/Follow-up. Every follow-up
+        # draft from this script targets a retailer (Manager Follow-up /
+        # Bulk Info Requested / AI: Prospect replied), so by definition B2B.
+        # Applied as a SECOND label so existing AI/* filters keep working.
+        audience_label_id = ensure_user_label_id(gsvc, "B2B")
 
     created_rows: list[list[str]] = []
     n_made = 0
@@ -1372,12 +1378,13 @@ def main() -> None:
         msg = draft.get("message") or {}
         msg_id = msg.get("id", "") or ""
 
-        if label_id and msg_id:
+        ids_to_apply = [lid for lid in (label_id, audience_label_id) if lid]
+        if ids_to_apply and msg_id:
             try:
                 gsvc.users().messages().modify(
                     userId="me",
                     id=msg_id,
-                    body={"addLabelIds": [label_id]},
+                    body={"addLabelIds": ids_to_apply},
                 ).execute()
             except Exception as e:
                 sys.stderr.write(f"Warning: could not apply label to draft message {msg_id}: {e}\n")

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -595,8 +595,16 @@ def main() -> None:
         return
 
     label_id: str | None = None
+    audience_label_id: str | None = None
     if not args.dry_run and not args.skip_label:
         label_id = smf.ensure_user_label_id(gsvc, DEFAULT_GMAIL_LABEL)
+        # Top-level audience label parallel to AI/Warm-up. Every warm-up draft
+        # produced by this script targets a retailer (Hit List status =
+        # AI: Warm up prospect), so it's by definition B2B. Applied as a
+        # SECOND label — Gmail keeps both, and the AI/* lifecycle swap
+        # downstream (sync_email_agent_followup.py: AI/Warm-up →
+        # AI/Sent Warm-up) leaves this label alone.
+        audience_label_id = smf.ensure_user_label_id(gsvc, "B2B")
 
     created_rows: list[list[str]] = []
     n_made = 0
@@ -703,12 +711,13 @@ def main() -> None:
         msg = draft.get("message") or {}
         msg_id = msg.get("id", "") or ""
 
-        if label_id and msg_id:
+        ids_to_apply = [lid for lid in (label_id, audience_label_id) if lid]
+        if ids_to_apply and msg_id:
             try:
                 gsvc.users().messages().modify(
                     userId="me",
                     id=msg_id,
-                    body={"addLabelIds": [label_id]},
+                    body={"addLabelIds": ids_to_apply},
                 ).execute()
             except Exception as e:
                 sys.stderr.write(f"Warning: label on draft message {msg_id}: {e}\n")


### PR DESCRIPTION
## Summary

Adds top-level audience labels alongside the existing per-campaign / per-stage labels. The operator can now filter "all consumer-facing email I've ever sent" or "all retailer outreach" with one Gmail click, across every campaign, ever.

## Three pipelines, three changes

| Pipeline | Existing label | New parallel label |
|---|---|---|
| `send_newsletter.py` | `Newsletter/<campaign>` (e.g. `Newsletter/2 Chocolate Bars`) | **`DTC`** |
| `suggest_warmup_prospect_drafts.py` | `AI/Warm-up` (→ `AI/Sent Warm-up` after the swap in `sync_email_agent_followup.py`) | **`B2B`** |
| `suggest_manager_followup_drafts.py` | `AI/Follow-up` (→ `AI/Sent Follow-up`) | **`B2B`** |

Both labels are applied in a single Gmail `messages.modify` call so each message gets both labels atomically. The `AI/*` lifecycle swap downstream leaves the `B2B` label alone — only the `AI/<X>` ↔ `AI/Sent <X>` pair gets touched.

## Why parallel rather than nested

Considered `DTC/Newsletter/<campaign>` (nested). Rejected: would rename every existing newsletter thread and any saved Gmail search. Marginal taxonomy gain for real disruption. Parallel labels cost two labels per message instead of one but every existing filter keeps working unchanged.

## Behaviour

- Audience label applied **unconditionally** when not `--dry-run`. Every newsletter through `send_newsletter.py` is by definition DTC (consumer subscriber list); every draft from the AI scripts targets a retailer status.
- `--dry-run` skips the audience label too (no message to label).
- `--skip-label` on the AI scripts still skips both (it's the operator-explicit "no labels at all" path).

## Test plan

- [ ] Send a single-recipient newsletter (`--mode send --to garyjob@gmail.com`). Confirm both `Newsletter/<campaign>` and `DTC` labels appear in Gmail.
- [ ] Run `suggest_warmup_prospect_drafts.py --dry-run` — confirm no labels touched.
- [ ] Run `suggest_warmup_prospect_drafts.py` (live, with at least one eligible Hit-List row). Confirm the resulting draft carries both `AI/Warm-up` and `B2B`.
- [ ] After sending the warm-up from Gmail, run `sync_email_agent_followup.py`. Confirm `AI/Warm-up` → `AI/Sent Warm-up` swap fires and `B2B` is preserved.
- [ ] Same flow for `suggest_manager_followup_drafts.py` → `AI/Follow-up` + `B2B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)