### PR TITLE
feat(places): cost optimizations 1–3 (photo gate + Nearby coverage cache + status refresh)

### DIFF
--- a/scripts/discover_apothecaries_la_hit_list.py
+++ b/scripts/discover_apothecaries_la_hit_list.py
@@ -655,23 +655,33 @@ def collect_nearby_for_center(
     keyword: str,
     label: str,
     sleep_s: float,
+    *,
+    refresh: bool = False,
 ) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    pagetoken: str | None = None
-    page = 0
-    while True:
-        page += 1
-        data = nearby_page(key, lat, lng, radius, keyword, pagetoken)
-        st = data.get("status")
-        if st not in ("OK", "ZERO_RESULTS"):
-            raise RuntimeError(f"Nearby search failed ({label} p{page}): {data}")
-        for res in data.get("results") or []:
-            out.append({**res, "_search_label": label})
-        pagetoken = data.get("next_page_token")
-        if not pagetoken:
-            break
-        time.sleep(max(2.0, sleep_s))
-    return out
+    """Cached Nearby Search around a centroid.
+
+    Delegates to ``places_cache.cached_nearby_search`` so re-runs of the
+    discovery pipeline against an already-covered (lat, lng, radius_m,
+    keyword) combo skip the live API call entirely (Nearby Search is
+    $32/1k — the most expensive Places endpoint we hit).
+
+    Pass ``refresh=True`` to bypass the cache and re-search a centroid.
+
+    The ``_search_label`` annotation is preserved so downstream dedup logic
+    in this script keeps working.
+    """
+    from places_cache import cached_nearby_search
+    results, was_live = cached_nearby_search(
+        key, lat, lng, radius, keyword,
+        label=label, refresh=refresh, sleep_between_pages=sleep_s,
+    )
+    if not was_live:
+        print(
+            f"[nearby] {label}: cache hit (no live call) "
+            f"+{len(results)} cached results",
+            flush=True,
+        )
+    return [{**res, "_search_label": label} for res in results]
 
 
 def place_details(key: str, place_id: str) -> dict[str, Any]:
@@ -942,6 +952,15 @@ def main() -> None:
         metavar="KEY",
         help=f"Region preset: {', '.join(sorted(REGIONS.keys()))} (default: la).",
     )
+    p.add_argument(
+        "--refresh-coverage",
+        action="store_true",
+        help=(
+            "Bypass the Nearby Search coverage cache for this run and re-search "
+            "every centroid live. Default is to skip live calls for already-covered "
+            "(lat, lng, radius, keyword) combos."
+        ),
+    )
     p.add_argument("--dry-run", action="store_true", help="Do not write the sheet; print plan.")
     p.add_argument(
         "--keyword",
@@ -975,7 +994,8 @@ def main() -> None:
     print(f"Region: {region.key} ({region.notes_label})", flush=True)
     for lat, lng, radius, label in region.centers:
         chunk = collect_nearby_for_center(
-            key, lat, lng, radius, args.keyword, label, sleep_s=2.0
+            key, lat, lng, radius, args.keyword, label, sleep_s=2.0,
+            refresh=args.refresh_coverage,
         )
         raw_results.extend(chunk)
         print(f"[nearby] {label}: +{len(chunk)} raw (running total {len(raw_results)})", flush=True)

--- a/scripts/hit_list_research_photo_review.py
+++ b/scripts/hit_list_research_photo_review.py
@@ -40,6 +40,11 @@ import requests
 from google.oauth2.service_account import Credentials
 
 from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply
+# Reuse the site-keyword crawler from detect_circle_hosting_retailers so the
+# "site shows qualifying signals?" check stays consistent between the two
+# scripts. Crawl is HTTP-only (free) — used here as a gate before triggering
+# Place Photos at $7/1k each.
+from detect_circle_hosting_retailers import crawl_site as _crawl_site_for_gate
 
 REPO = Path(__file__).resolve().parents[1]
 SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
@@ -55,9 +60,12 @@ GROK_MODEL = "grok-4-1-fast-non-reasoning"
 SUBMITTED_BY_LABEL = "Grok photo scan (Google Places)"
 SUBMITTED_BY_NO_PHOTOS = "Hit List photo automation (no Places images)"
 SUBMITTED_BY_ERROR = "Hit List photo automation (run error)"
+SUBMITTED_BY_GATE_SKIP = "Hit List photo automation (skipped — site signals weak)"
 MAX_PHOTOS_DEFAULT = 5
 PLACES_MAX_WIDTH = 1200
 SLEEP_BETWEEN_SHOPS_SEC = 3
+GATE_CRAWL_SLEEP_S = 0.5
+GATE_CRAWL_MAX_CHARS = 200_000
 
 
 def load_dotenv_repo() -> None:
@@ -433,6 +441,8 @@ def collect_target_rows(
             "Address": cells[idx["Address"]].strip(),
             "City": cells[idx["City"]].strip(),
             "State": cells[idx["State"]].strip(),
+            "Website": cells[idx["Website"]].strip() if "Website" in idx else "",
+            "Hosts Circles": cells[idx["Hosts Circles"]].strip() if "Hosts Circles" in idx else "",
             "lat": lat_s,
             "lng": lng_s,
             "_lat_float": lat,
@@ -444,6 +454,60 @@ def collect_target_rows(
     return out
 
 
+def should_fetch_photos(fields: dict[str, Any]) -> tuple[bool, str]:
+    """Cheap site-crawl gate — returns ``(allow_photos, reason)``.
+
+    Place Photos cost $7/1k each, and the per-shop run downloads up to 5,
+    so an unqualified shop costs ~$0.04 in photo billing alone before the
+    Grok vision call. The gate uses HTTP-only signal detection (free) to
+    skip shops whose website shows no qualifying keywords (cacao ceremony /
+    women's circle / sound bath / etc.) — same keyword set as
+    ``detect_circle_hosting_retailers.py`` for consistency.
+
+    Order of evidence (cheapest first):
+      1. ``Hosts Circles`` cell already populated by a prior detect run →
+         site already known to qualify; let the photo path proceed.
+      2. ``Website`` blank → can't crawl; skip photos.
+      3. Crawl site; if any keyword found → proceed; otherwise skip.
+    """
+    cached = (fields.get("Hosts Circles") or "").strip()
+    if cached:
+        return True, f"prior detect run flagged: {cached[:120]}"
+
+    site = (fields.get("Website") or "").strip()
+    if not site:
+        return False, "no website on Hit List row to crawl"
+
+    fetched, found = _crawl_site_for_gate(
+        site, sleep_s=GATE_CRAWL_SLEEP_S, max_chars=GATE_CRAWL_MAX_CHARS,
+    )
+    if not fetched:
+        return False, f"site fetch failed for {site}"
+    if found:
+        return True, f"crawl found signals: {', '.join(found[:5])}"
+    return False, f"crawled {site} — no qualifying keywords found"
+
+
+def format_gate_skip_remarks(
+    name: str, addr: str, city: str, state: str, gate_reason: str,
+) -> str:
+    return (
+        f"Photo automation skipped for {name} ({addr}, {city}, {state}).\n"
+        f"\n"
+        f"Reason: {gate_reason}.\n"
+        f"\n"
+        f"No Place Photos were fetched and no Grok vision rubric ran. The "
+        f"site-crawl keyword gate (see detect_circle_hosting_retailers.py "
+        f"for the keyword set) found no positive signals; spending on "
+        f"Place Photos for this row would not have improved the AI "
+        f"classification beyond what the site itself already says.\n"
+        f"\n"
+        f"If this row deserves a manual look despite the weak site "
+        f"signals, run with --photo-gate=off to force the photo + Grok "
+        f"path."
+    )
+
+
 def run_one_shop(
     hit_ws: gspread.Worksheet,
     remark_ws: gspread.Worksheet,
@@ -451,12 +515,35 @@ def run_one_shop(
     fields: dict[str, Any],
     max_photos: int,
     dry_run: bool,
+    photo_gate: str = "strict",
 ) -> None:
-    mkey = maps_api_key()
     name = fields["Shop Name"]
     addr = fields["Address"]
     city = fields["City"]
     state = fields["State"]
+
+    # Cheap gate first — skip Find Place + Photos + Grok entirely if the
+    # site shows no qualifying signal. Saves $7/1k * up to 5 photos plus
+    # the Find Place / Details and the Grok vision invocation.
+    if photo_gate != "off":
+        gate_ok, gate_reason = should_fetch_photos(fields)
+        if not gate_ok:
+            print(f"[{name}] photo gate: SKIP — {gate_reason}", flush=True)
+            remarks = format_gate_skip_remarks(name, addr, city, state, gate_reason)
+            submission_id = str(uuid.uuid4())
+            submitted_at = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
+            if dry_run:
+                print("--- Remarks (preview) ---")
+                print(remarks)
+                return
+            append_dapp_remark_and_apply(
+                hit_ws, remark_ws, sheet_row, name,
+                "AI: Photo rejected", remarks,
+                SUBMITTED_BY_GATE_SKIP, submitted_at, submission_id,
+            )
+            return
+
+    mkey = maps_api_key()
     lat_f = fields.get("_lat_float")
     lng_f = fields.get("_lng_float")
     query = f"{name} {addr} {city} {state}".strip()
@@ -563,6 +650,17 @@ def main() -> None:
         action="store_true",
         help="Exit with code 1 if any shop in the batch raised (for CI alerting). Default: exit 0 so partial success keeps the job green.",
     )
+    p.add_argument(
+        "--photo-gate",
+        choices=("strict", "off"),
+        default="strict",
+        help=(
+            "Site-crawl gate that runs BEFORE Place Photos / Find Place / Grok. "
+            "'strict' (default): only proceed if Hosts Circles is already populated "
+            "or a fresh crawl finds qualifying keywords. 'off': legacy behavior, "
+            "always fetch photos regardless of site signals."
+        ),
+    )
     args = p.parse_args()
 
     gc = gspread_client()
@@ -578,7 +676,10 @@ def main() -> None:
     failed = 0
     for i, (sheet_row, fields) in enumerate(targets):
         try:
-            run_one_shop(hit_ws, remark_ws, sheet_row, fields, args.max_photos, args.dry_run)
+            run_one_shop(
+                hit_ws, remark_ws, sheet_row, fields,
+                args.max_photos, args.dry_run, photo_gate=args.photo_gate,
+            )
         except Exception as exc:
             print(f"ERROR row {sheet_row} {fields.get('Shop Name')!r}: {exc}", flush=True)
             try:

--- a/scripts/places_cache.py
+++ b/scripts/places_cache.py
@@ -316,6 +316,170 @@ def cached_place_details_full(api_key: str, place_id: str, *, refresh: bool = Fa
     return cached_place_details(api_key, place_id, fields=FULL_FIELDS, refresh=refresh)
 
 
+# ---- Nearby Search coverage cache -----------------------------------------
+#
+# Nearby Search at $32/1k is the most expensive Places endpoint we hit. The
+# discovery pipeline iterates ~50+ centroids per region and re-runs land on
+# the same centroids; without a coverage cache, every re-run repays for
+# already-discovered geography. The cache below stores the raw Nearby result
+# list per (keyword, lat, lng, radius_m) combo so re-runs short-circuit and
+# return the cached results — same dedup / Place Details flow downstream.
+#
+# Layout in the cache repo:
+#   coverage/nearby/<sanitized_combo>.json
+# where sanitized_combo encodes lat/lng/radius/keyword.
+#
+# Permanent by default; pass ``refresh=True`` to bypass and re-search a combo.
+
+NEARBY_SEARCH_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json"
+
+
+def _coverage_path(keyword: str, lat: float, lng: float, radius_m: int) -> str:
+    safe_kw = (
+        "".join(c if c.isalnum() else "_" for c in (keyword or "").strip().lower())
+        or "nokeyword"
+    )
+    fname = f"{safe_kw}__lat{lat:.4f}_lng{lng:.4f}_r{int(radius_m)}m.json"
+    return f"coverage/nearby/{fname}"
+
+
+def _fetch_coverage_record(combo_path: str) -> tuple[dict | None, str | None]:
+    api_url = f"{CONTENTS_API}/{combo_path}?ref={CACHE_REPO_BRANCH}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = _write_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        r = requests.get(api_url, headers=headers, timeout=15)
+    except requests.RequestException:
+        return None, None
+    if r.status_code == 404:
+        return None, None
+    if r.status_code != 200:
+        return None, None
+    payload = r.json()
+    sha = payload.get("sha")
+    encoded = payload.get("content", "")
+    if not encoded:
+        return None, sha
+    try:
+        decoded = base64.b64decode(encoded).decode("utf-8")
+        return json.loads(decoded), sha
+    except (ValueError, json.JSONDecodeError):
+        return None, sha
+
+
+def _write_coverage_record(combo_path: str, record: dict, prior_sha: str | None) -> bool:
+    token = _write_token()
+    if not token:
+        return False
+    body = {
+        "message": f"coverage: {combo_path.split('/')[-1]}",
+        "content": base64.b64encode(
+            json.dumps(record, indent=2, sort_keys=True).encode("utf-8")
+        ).decode("ascii"),
+        "branch": CACHE_REPO_BRANCH,
+    }
+    if prior_sha:
+        body["sha"] = prior_sha
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        r = requests.put(f"{CONTENTS_API}/{combo_path}", headers=headers, json=body, timeout=30)
+    except requests.RequestException:
+        return False
+    return r.status_code in (200, 201)
+
+
+def _live_nearby_search(
+    api_key: str, lat: float, lng: float, radius: int, keyword: str, sleep_between_pages: float = 2.0
+) -> list[dict]:
+    """Hit Nearby Search live, exhausting pagination. Returns full results list."""
+    out: list[dict] = []
+    pagetoken: str | None = None
+    while True:
+        params: dict = {
+            "location": f"{lat},{lng}",
+            "radius": str(int(radius)),
+            "keyword": keyword,
+            "key": api_key,
+        }
+        if pagetoken:
+            params["pagetoken"] = pagetoken
+        try:
+            r = requests.get(NEARBY_SEARCH_URL, params=params, timeout=45)
+        except requests.RequestException as e:
+            sys.stderr.write(f"places_cache: nearby live failed: {e}\n")
+            return out
+        if r.status_code != 200:
+            sys.stderr.write(f"places_cache: nearby HTTP {r.status_code}: {r.text[:200]}\n")
+            return out
+        data = r.json()
+        st = data.get("status")
+        if st not in ("OK", "ZERO_RESULTS"):
+            sys.stderr.write(f"places_cache: nearby status {st!r}: {data}\n")
+            return out
+        for res in data.get("results") or []:
+            out.append(res)
+        pagetoken = data.get("next_page_token")
+        if not pagetoken:
+            break
+        time.sleep(max(2.0, sleep_between_pages))
+    return out
+
+
+def cached_nearby_search(
+    api_key: str,
+    lat: float,
+    lng: float,
+    radius_m: int,
+    keyword: str,
+    *,
+    label: str = "",
+    refresh: bool = False,
+    sleep_between_pages: float = 2.0,
+) -> tuple[list[dict], bool]:
+    """Cache-aware Nearby Search.
+
+    Returns ``(results, was_live)`` — ``was_live`` indicates whether this
+    incarnation hit the live API (and was billed). Results are the raw
+    Nearby Search response items from Google.
+
+    On a cache hit the live call is skipped entirely; the cached
+    ``results`` list is returned as-is. On a miss we hit the live API,
+    write the response to the cache repo, and return.
+    """
+    combo = _coverage_path(keyword, lat, lng, radius_m)
+    cached, sha = (None, None) if refresh else _fetch_coverage_record(combo)
+    if cached and isinstance(cached.get("results"), list) and cached["results"]:
+        return cached["results"], False
+    # Treat empty-result records the same as a cached zero — they're a real
+    # finding (the geography returned nothing for this keyword) and still
+    # worth not re-paying for.
+    if cached and "results" in cached:
+        return cached.get("results") or [], False
+
+    live = _live_nearby_search(
+        api_key, lat, lng, radius_m, keyword, sleep_between_pages=sleep_between_pages
+    )
+    record = {
+        "centroid": {"lat": lat, "lng": lng, "radius_m": int(radius_m)},
+        "keyword": keyword,
+        "label": label,
+        "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "result_count": len(live),
+        "results": live,
+    }
+    _write_coverage_record(combo, record, sha)
+    return live, True
+
+
 # ---- CLI for ad-hoc inspection ---------------------------------------------
 
 def _cli(argv=None) -> int:

--- a/scripts/refresh_places_cache_status.py
+++ b/scripts/refresh_places_cache_status.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Refresh the ``business_status`` of every record in ``TrueSightDAO/places-cache``.
+
+The places-cache is permanent by design, but three Place Details fields decay
+over time: ``business_status`` (stores can close), ``opening_hours``, and
+``formatted_phone_number``. This sweep refreshes ``business_status`` cheaply
+by re-calling Place Details with **Basic-tier fields only** (free SKU on the
+legacy Places API) for every cached record. Contact-tier fields (phone /
+website / hours) in the cached record are left untouched — they were paid
+for once and don't decay fast enough to justify re-paying.
+
+Run on a cron / manually:
+
+    cd market_research
+    python3 scripts/refresh_places_cache_status.py --dry-run
+    python3 scripts/refresh_places_cache_status.py --limit 200
+    python3 scripts/refresh_places_cache_status.py             # full sweep
+
+Exits with the count of records refreshed and the count flagged
+``CLOSED_PERMANENTLY`` so the operator can act on closures.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from places_cache import (  # noqa: E402
+    CACHE_REPO_BRANCH,
+    CACHE_REPO_NAME,
+    CACHE_REPO_OWNER,
+    CONTENTS_API,
+    PLACES_DETAILS_URL,
+    _fetch_cached_record,
+    _write_cached_record,
+    _write_token,
+    BASIC_FIELDS,
+)
+
+
+TREES_API = (
+    f"https://api.github.com/repos/{CACHE_REPO_OWNER}/{CACHE_REPO_NAME}/git/trees"
+)
+
+
+def list_cached_place_ids() -> list[str]:
+    """Return every cached place_id by walking the repo tree once.
+
+    Uses the recursive trees API which returns the whole tree in one call.
+    GitHub caps that response at 100k entries — for places-cache (one file
+    per place_id, ~3-5KB each) this is plenty of headroom.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = _write_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"{TREES_API}/{CACHE_REPO_BRANCH}?recursive=1"
+    r = requests.get(url, headers=headers, timeout=30)
+    if r.status_code != 200:
+        sys.stderr.write(f"trees API HTTP {r.status_code}: {r.text[:200]}\n")
+        return []
+    payload = r.json()
+    if payload.get("truncated"):
+        sys.stderr.write(
+            "WARNING: tree response truncated. Cache has >100k records — implement pagination.\n"
+        )
+    out = []
+    for item in payload.get("tree", []) or []:
+        if item.get("type") != "blob":
+            continue
+        path = item.get("path", "")
+        if not path.startswith("places/"):
+            continue
+        if not path.endswith(".json"):
+            continue
+        # Path shape: places/<prefix>/<place_id>.json
+        parts = path.split("/")
+        if len(parts) != 3:
+            continue
+        place_id = parts[-1][:-len(".json")]
+        if place_id and place_id != ".gitkeep":
+            out.append(place_id)
+    return out
+
+
+def refresh_basic_fields(api_key: str, place_id: str) -> dict | None:
+    """Hit Place Details with Basic-only fields. Returns ``result`` or None on error."""
+    params = {
+        "place_id": place_id,
+        "fields": ",".join(BASIC_FIELDS),
+        "key": api_key,
+    }
+    try:
+        r = requests.get(PLACES_DETAILS_URL, params=params, timeout=30)
+    except requests.RequestException as e:
+        sys.stderr.write(f"refresh: live failed for {place_id}: {e}\n")
+        return None
+    if r.status_code != 200:
+        sys.stderr.write(f"refresh: HTTP {r.status_code} for {place_id}: {r.text[:200]}\n")
+        return None
+    data = r.json()
+    status = data.get("status")
+    if status == "NOT_FOUND":
+        # Place removed by Google — flag in the record so operator notices.
+        return {"_status": "NOT_FOUND", "place_id": place_id}
+    if status != "OK":
+        sys.stderr.write(f"refresh: status {status!r} for {place_id}\n")
+        return None
+    return data.get("result") or {}
+
+
+def merge_basic_into_record(rec: dict, fresh_basic: dict) -> tuple[dict, str]:
+    """Update Basic-tier fields in the cached record without touching Contact /
+    Atmosphere fields. Returns (new_record, change_summary).
+    """
+    cached_result = (rec.get("result") or {}).copy()
+    change_bits = []
+
+    if fresh_basic.get("_status") == "NOT_FOUND":
+        cached_result["business_status"] = "NOT_FOUND_BY_GOOGLE"
+        change_bits.append("flagged NOT_FOUND")
+    else:
+        for field in BASIC_FIELDS:
+            new_val = fresh_basic.get(field)
+            if new_val is None:
+                continue
+            old_val = cached_result.get(field)
+            if old_val != new_val:
+                if field == "business_status":
+                    change_bits.append(f"business_status: {old_val!r} → {new_val!r}")
+                else:
+                    change_bits.append(field)
+                cached_result[field] = new_val
+
+    new_rec = dict(rec)
+    new_rec["result"] = cached_result
+    new_rec["last_status_refresh_at"] = datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    return new_rec, ", ".join(change_bits) if change_bits else "no changes"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--limit", type=int, default=None,
+                   help="Max records to refresh in this run (default: all).")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report what would change without writing.")
+    p.add_argument("--sleep", type=float, default=0.1,
+                   help="Sleep between live calls in seconds (default 0.1).")
+    args = p.parse_args(argv)
+
+    api_key = (
+        os.environ.get("GOOGLE_MAPS_API_KEY")
+        or os.environ.get("GOOGLE_PLACES_API_KEY", "")
+    )
+    if not api_key:
+        sys.stderr.write("Set GOOGLE_MAPS_API_KEY or GOOGLE_PLACES_API_KEY in env / .env\n")
+        return 1
+
+    place_ids = list_cached_place_ids()
+    print(f"Found {len(place_ids)} cached records.", flush=True)
+    if args.limit is not None:
+        place_ids = place_ids[: args.limit]
+        print(f"Limiting to first {len(place_ids)} for this run.", flush=True)
+
+    refreshed = 0
+    closed_count = 0
+    not_found_count = 0
+    write_failures = 0
+
+    for i, pid in enumerate(place_ids, start=1):
+        rec, sha = _fetch_cached_record(pid)
+        if not rec:
+            sys.stderr.write(f"  [{i}/{len(place_ids)}] {pid}: read failed; skipping\n")
+            continue
+        fresh = refresh_basic_fields(api_key, pid)
+        if fresh is None:
+            sys.stderr.write(f"  [{i}/{len(place_ids)}] {pid}: live call failed; skipping\n")
+            continue
+        new_rec, change_summary = merge_basic_into_record(rec, fresh)
+        if "CLOSED_PERMANENTLY" in str(new_rec.get("result", {}).get("business_status", "")):
+            closed_count += 1
+        if new_rec.get("result", {}).get("business_status") == "NOT_FOUND_BY_GOOGLE":
+            not_found_count += 1
+        print(f"  [{i}/{len(place_ids)}] {pid}: {change_summary}", flush=True)
+        if args.dry_run:
+            continue
+        if change_summary == "no changes":
+            # Still touch last_status_refresh_at? Yes — record that we checked.
+            pass
+        ok = _write_cached_record(pid, new_rec, sha)
+        if ok:
+            refreshed += 1
+        else:
+            write_failures += 1
+        time.sleep(max(0.0, args.sleep))
+
+    print()
+    print(f"Refreshed:     {refreshed}")
+    print(f"Closed perm:   {closed_count}")
+    print(f"Not found:     {not_found_count}")
+    print(f"Write failed:  {write_failures}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Three follow-ups to PR #97 (persistent Place Details cache). All three land specific savings the cost audit named.

## Item 1 — Crawl-first → photo-second gate

**File:** `hit_list_research_photo_review.py`

Before: every Hit List row with `Status=Research` triggered Find Place + Place Details + up to 5 Place Photos at $7/1k each + a Grok vision call — even when the shop's site clearly didn't fit the cacao customer profile.

After: a cheap HTTP-only site-crawl (free) runs FIRST, using the same `KEYWORD_PATTERNS` as `detect_circle_hosting_retailers.py`. If `Hosts Circles` is already populated OR a fresh crawl finds qualifying signals (cacao ceremony / women's circle / sound bath / …), the photo path proceeds. Otherwise the row is short-circuited with `AI: Photo rejected` and a remark explaining "site signals weak; no photos fetched."

- New flag `--photo-gate=strict` (default) `| off` (legacy).
- Skipped rows can still be rescued later by `detect_circle_hosting_retailers` if the site updates.
- **Expected impact:** ~10% of rows show qualifying signals → photo+Grok spend drops to ~10% of current.

## Item 2 — Nearby Search coverage cache

**Files:** `places_cache.py` (new helpers) + `discover_apothecaries_la_hit_list.py`

Before: every re-run of the discovery pipeline re-paid for every centroid×keyword combo at $32/1k (Nearby Search is the most expensive Places endpoint).

After: `cached_nearby_search(...)` checks `TrueSightDAO/places-cache` for `coverage/nearby/<sanitized_combo>.json`. On cache hit the live API call is skipped entirely; cached results flow into the dedup pipeline as if fresh.

- New flag `--refresh-coverage` to force a re-search.
- **Expected impact:** re-runs on already-covered geography become $0 on Nearby Search.

## Item 3 — Cheap `business_status` refresh sweep

**File:** `scripts/refresh_places_cache_status.py` (new)

The cache from #97 is permanent by design, but `business_status` decays. This sweep walks every cached record via the GitHub Trees API (one recursive call), re-fetches Place Details with **Basic-tier fields ONLY** (legacy Places "Basic Data" SKU is $0), merges fresh Basic fields into the cached record without touching Contact/Atmosphere fields, writes back.

Flags closures and `NOT_FOUND_BY_GOOGLE` so operators can act.

```
python3 scripts/refresh_places_cache_status.py --dry-run
python3 scripts/refresh_places_cache_status.py --limit 200
python3 scripts/refresh_places_cache_status.py             # full sweep
```

## Item 4 — DEFERRED / not a win

Took a closer look at Places API (New) per-SKU pricing. For our typical field pattern (Basic + Contact), the New API breaks billing into Pro + Enterprise SKUs at ~$45/1k vs $20/1k on the Legacy combined tiers we use. The New API only wins for narrower slices (Essentials at $5/1k for photos+types+place_id). Our usage doesn't fit that profile.

**Decision:** stay on Legacy Place Details. Revisit if a narrow-slice use case appears or Google announces pricing changes.

## Test plan

- [x] All four touched files compile (`py_compile`).
- [x] `refresh_places_cache_status.py --dry-run` runs against the live places-cache (1 record) and reports correctly.
- [ ] Operator runs `discover_apothecaries_la_hit_list.py --region la` twice and confirms second run hits cache (no Nearby API charges in the GCP console).
- [ ] Operator runs `hit_list_research_photo_review.py --limit 3` against shops with empty Hosts Circles + sites that don't match the keyword set; confirms photos are NOT fetched and rows go to `AI: Photo rejected` with a "site signals weak" remark.
- [ ] Operator runs `refresh_places_cache_status.py --limit 5` and confirms cached records get a `last_status_refresh_at` timestamp without losing Contact-tier fields.