### PR TITLE
fix(workflows): pass PLACES_CACHE_PAT to cron jobs that use the Places cache

### DIFF
--- a/.github/workflows/field_agent_location_places_pull.yml
+++ b/.github/workflows/field_agent_location_places_pull.yml
@@ -52,6 +52,10 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
+          # Required for places_cache.py to read+write the persistent
+          # Place Details cache in TrueSightDAO/places-cache. Without it
+          # every cron run hits the live Places API and pays full price.
+          PLACES_CACHE_PAT: ${{ secrets.PLACES_CACHE_PAT }}
           INPUT_LIMIT: ${{ github.event.inputs.limit || '' }}
           DRY: ${{ github.event.inputs.dry_run || '' }}
           SCHEDULE_DEFAULT_LIMIT: "10"

--- a/.github/workflows/hit_list_enrich_contact.yml
+++ b/.github/workflows/hit_list_enrich_contact.yml
@@ -53,6 +53,10 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          # Required for places_cache.py to read+write the persistent
+          # Place Details cache in TrueSightDAO/places-cache. Without it
+          # every cron run hits the live Places API and pays full price.
+          PLACES_CACHE_PAT: ${{ secrets.PLACES_CACHE_PAT }}
           INPUT_LIMIT: ${{ github.event.inputs.limit || '' }}
           DRY: ${{ github.event.inputs.dry_run || '' }}
           SCHEDULE_DEFAULT_LIMIT: "10"

--- a/.github/workflows/hit_list_research_photo_review.yml
+++ b/.github/workflows/hit_list_research_photo_review.yml
@@ -60,6 +60,10 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          # Required for places_cache.py to read+write the persistent
+          # Place Details cache in TrueSightDAO/places-cache. Without it
+          # every cron run hits the live Places API and pays full price.
+          PLACES_CACHE_PAT: ${{ secrets.PLACES_CACHE_PAT }}
           INPUT_LIMIT: ${{ github.event.inputs.limit || '' }}
           INPUT_SHOP: ${{ github.event.inputs.shop || '' }}
           SCHEDULE_DEFAULT_LIMIT: "20"


### PR DESCRIPTION
## Root cause of today's \$200+ Places API spend

PRs #97 and #98 shipped the persistent Place Details cache, but **none of the three hourly cron workflows passed \`PLACES_CACHE_PAT\` into the Python step's env**. Repo secret was populated; env-injection was missing.

## What I observed via Cloud Monitoring on \`get-data-io\`

| Method | Calls today (00:00–05:26 UTC) |
|---|---:|
| \`google.places.Details.Http\` | **11,211** |
| \`google.places.NearbySearch.Http\` | 1 |
| Find Place / Photos | 0 |

\`11,211 calls ÷ ~600 Hit List rows = 18.7 calls per place per day\` — exact fingerprint of the cache being completely bypassed (write fails silently → next call misses too).

Cache repo \`TrueSightDAO/places-cache\` showed **0 commits today, 1 cached record total** (the Sydney test from PR #97 dev). Confirms writes never succeeded.

## Why it failed silently

1. \`places_cache._write_token()\` returned None (no PAT in env)
2. Write skipped with stderr line nobody was watching
3. Read via Contents API also unauthenticated → GitHub 60/hour anonymous rate limit → throttled to 403 → treated as cache miss
4. Repeat

## Fix

Add \`PLACES_CACHE_PAT: \${{ secrets.PLACES_CACHE_PAT }}\` to the env block of the three workflows:

- \`hit_list_enrich_contact.yml\`
- \`hit_list_research_photo_review.yml\`
- \`field_agent_location_places_pull.yml\`

Verified via grep: no other workflow runs a script that uses \`places_cache\` (directly or via the canonical \`dl.place_details\` helper), so these three are the complete set.

## Test plan

- [ ] Wait for next hourly cron tick (will trigger one of the three jobs).
- [ ] Inspect \`TrueSightDAO/places-cache\` commit log — should see new commits accumulating after each tick.
- [ ] Tomorrow morning UTC, re-query Cloud Monitoring on \`get-data-io\` for today's Place Details call count. Should drop dramatically — closer to ~1 call per unique \`place_id\` total per day rather than ~19.
- [ ] If GCP billing console shows Places spend dropping back toward single-digit dollars/day within 48h, fix is confirmed.