### PR TITLE
fix(places): circuit-break on OVER_QUERY_LIMIT + cap fill-gap by attempts

### DIFF
--- a/scripts/hit_list_enrich_contact.py
+++ b/scripts/hit_list_enrich_contact.py
@@ -787,14 +787,40 @@ def main() -> None:
     fill_skipped = 0
     fill_resolved_notes = 0
     fill_cap = 0 if args.no_fill_gaps else max(0, args.fill_gaps_limit)
+    # Independent attempt cap so a queue of N gappy rows whose Place Details
+    # all return empty (rate-limit, NOT_FOUND, etc.) doesn't keep iterating
+    # all 666 rows trying to find one that fills. Default: 3x fill_cap so a
+    # legitimate run with some misses still completes.
+    fill_attempt_cap = max(fill_cap * 3, 50)
     if fill_cap > 0:
         idx_notes = i_notes  # 0-based Notes column
         print(
-            f"Fill-gap sweep: cap={fill_cap} resolve_missing_pid={bool(args.resolve_missing_place_id)}",
+            f"Fill-gap sweep: cap={fill_cap} (attempt-cap={fill_attempt_cap}) "
+            f"resolve_missing_pid={bool(args.resolve_missing_place_id)}",
             flush=True,
         )
+        # Imported lazily so this module loads even when places_cache isn't on path.
+        try:
+            from places_cache import is_rate_limited
+        except Exception:  # pragma: no cover
+            def is_rate_limited() -> bool:
+                return False
+        fill_attempts = 0
         for ri, raw_row in enumerate(rows[1:], start=2):
             if fill_done >= fill_cap:
+                break
+            if fill_attempts >= fill_attempt_cap:
+                print(
+                    f"  [fill] hit attempt-cap ({fill_attempt_cap}); bailing the rest of the sweep",
+                    flush=True,
+                )
+                break
+            if is_rate_limited():
+                print(
+                    "  [fill] places_cache circuit breaker tripped (Places API rate-limited); "
+                    "bailing the rest of the sweep",
+                    flush=True,
+                )
                 break
             if ri in contact_processed_rows:
                 continue
@@ -841,6 +867,7 @@ def main() -> None:
                 continue
 
             assert pid is not None
+            fill_attempts += 1
             place_res = place_details_full(mkey, pid)
             time.sleep(0.15)
             if not place_res:

--- a/scripts/places_cache.py
+++ b/scripts/places_cache.py
@@ -236,8 +236,38 @@ def _write_cached_record(place_id: str, record: dict, prior_sha: str | None) -> 
     return False
 
 
+# Process-level circuit breaker: once the Places API tells us we're rate
+# limited (OVER_QUERY_LIMIT) or quota-blocked, stop hammering it for the
+# rest of this process. Otherwise a script with a long row queue will
+# burn through the entire queue making failed live calls — every miss
+# returning "" because the cache wasn't populated, then the next miss
+# hitting the same wall. Reset by restarting the process; until then
+# all cached_place_details() callers get an empty result without a live
+# call, and the caller can choose to bail or queue for later.
+_RATE_LIMITED = False
+
+
+def is_rate_limited() -> bool:
+    """True after any live Places call returned OVER_QUERY_LIMIT or REQUEST_DENIED.
+
+    Callers running long sweeps should check this between iterations and
+    bail out — there's no point continuing to attempt live calls once the
+    quota wall is up.
+    """
+    return _RATE_LIMITED
+
+
 def _live_place_details(api_key: str, place_id: str, fields: tuple[str, ...]) -> dict:
-    """Hit Places Details API; return the `result` dict or {} on non-OK."""
+    """Hit Places Details API; return the `result` dict or {} on non-OK.
+
+    On OVER_QUERY_LIMIT / REQUEST_DENIED, also flips the process-level
+    rate-limit circuit breaker so subsequent calls in the same process
+    return empty without re-hitting the API.
+    """
+    global _RATE_LIMITED
+    if _RATE_LIMITED:
+        return {}
+
     params = {
         "place_id": place_id,
         "fields": ",".join(fields),
@@ -254,13 +284,26 @@ def _live_place_details(api_key: str, place_id: str, fields: tuple[str, ...]) ->
         )
         return {}
     data = r.json()
-    if data.get("status") != "OK":
-        # Don't cache non-OK responses (NOT_FOUND, INVALID_REQUEST, etc.).
+    status = data.get("status")
+    if status == "OK":
+        return data.get("result") or {}
+    # Rate limit / quota wall: trip the circuit breaker so the rest of the
+    # process stops trying. The error is otherwise unbounded — without this,
+    # a script with N rows will make N failed live calls.
+    if status in ("OVER_QUERY_LIMIT", "REQUEST_DENIED", "RESOURCE_EXHAUSTED"):
+        _RATE_LIMITED = True
         sys.stderr.write(
-            f"places_cache: live status {data.get('status')!r} for {place_id}\n"
+            f"places_cache: live status {status!r} for {place_id} — "
+            f"tripping process-level rate-limit circuit breaker; subsequent "
+            f"cache misses in this process will return empty without a live call.\n"
         )
         return {}
-    return data.get("result") or {}
+    # Other non-OK (NOT_FOUND, INVALID_REQUEST, ZERO_RESULTS, etc.) — log and
+    # don't cache; let the caller skip this row and continue.
+    sys.stderr.write(
+        f"places_cache: live status {status!r} for {place_id}\n"
+    )
+    return {}
 
 
 def _record_satisfies(record: dict, needed: tuple[str, ...]) -> bool:


### PR DESCRIPTION
## Today's symptom (Gary's run logs)

A single \`hit_list_enrich_contact\` cron run made **60+ live Place Details calls in a row, every one returning \`OVER_QUERY_LIMIT\`**. Three things compounded:

1. The fill-gap sweep iterates **every row in the Hit List** that has any missing field. With ~666 rows and many gaps, that's up to ~666 attempts per run.
2. The cache was **still cold** — PR #99 only just propagated \`PLACES_CACHE_PAT\` into the cron env, so almost every attempt was a cache miss → live API call.
3. Earlier today's spike already burned through quota, so the live API returned OVER_QUERY_LIMIT for every call. But \`fill_cap=20\` **only counts successful fills, not attempts**. Loop kept iterating until end-of-sheet, generating ~666 wasted live calls per run.

## Two-part fix

### (A) \`places_cache.py\` — process-level circuit breaker

When \`_live_place_details()\` sees \`OVER_QUERY_LIMIT\`, \`REQUEST_DENIED\`, or \`RESOURCE_EXHAUSTED\`, set \`_RATE_LIMITED = True\`. Subsequent \`cached_place_details()\` calls in the same process return empty **without re-hitting the API**. New public \`is_rate_limited()\` function for long-sweep callers to query.

### (B) \`hit_list_enrich_contact.py\` fill-gap sweep

- Adds independent **attempt-cap** = \`max(fill_cap * 3, 50)\`. A queue of misses no longer iterates the whole sheet.
- Checks \`places_cache.is_rate_limited()\` each iteration; bails when the circuit breaker has tripped.
- Increments \`fill_attempts\` BEFORE the live call so the cap counts what was tried, not what succeeded.

## Effect on a rate-limited day

At most **1 wasted live call** (the one that trips the breaker) plus a handful of cache-miss attempts before bailout, instead of ~666. Future rate-limit days are bounded.

## Relationship to Gary's manual GCP quota cap

Gary set a quota cap on the Maps API key today to stop the bleeding. That cap is a band-aid. **This PR is the underlying script behavior fix** — when the GCP quota refreshes, the script won't re-trigger the burn.

## Test plan

- [x] \`is_rate_limited()\` returns \`False\` initially, \`True\` after manual flip — verified locally.
- [x] Both files compile (\`py_compile\`).
- [ ] After merge + next cron tick: confirm Cloud Monitoring shows ≤ ~10 Place Details live calls per run, not 60+.
- [ ] Once Gary lifts the GCP quota cap, confirm the cron jobs don't re-burn through it.