### PR TITLE
refactor(hit-list): rename 'AI: Photo rejected' → 'AI: No fit signal'

### DIFF
--- a/HIT_LIST_CREDENTIALS.md
+++ b/HIT_LIST_CREDENTIALS.md
@@ -82,7 +82,7 @@ Row **1** sets the header labels (e.g. `0 sends`, `1 send`, `2 sends`, …, `7+ 
 Rows with **Status = Research** are the default input for **`scripts/hit_list_research_photo_review.py`** (see also **`agentic_ai_context/WORKSPACE_CONTEXT.md`** — bullets under *Hit List — Status = Research*).
 
 1. **Places:** find + details + download up to **5** listing photos (`maxwidth` 1200). Requires **`GOOGLE_MAPS_API_KEY`** (server-usable key) in **`market_research/.env`**.
-2. **Vision:** **Grok** returns JSON → suggested status **`AI: Shortlisted`**, **`AI: Photo rejected`**, or **`AI: Photo needs review`** (`GROK_API_KEY`).
+2. **Vision:** **Grok** returns JSON → suggested status **`AI: Shortlisted`**, **`AI: No fit signal`** (renamed from legacy **`AI: Photo rejected`** on 2026-05-03; the script remaps Grok's old label automatically), or **`AI: Photo needs review`** (`GROK_API_KEY`). Note that the **cron path** that consumed this output is **retired** (PR #101); only manual `workflow_dispatch` triggers reach this code.
 3. **DApp Remarks:** append a row; column **Remarks** (D) is **plain text with blank lines** between sections (Location, Google Places review, bullet lists, model summary) so operators can enable **wrap** in Sheets and read it like mini memo.
 4. **Hit List:** status and **Sales Process Notes** updated in one pass (same semantics as **`physical_stores/process_dapp_remarks.py`**), and the new **DApp Remarks** row is marked **Processed**.
 

--- a/scripts/detect_circle_hosting_retailers.py
+++ b/scripts/detect_circle_hosting_retailers.py
@@ -37,13 +37,13 @@ photos and run them through a vision rubric to confirm.
 
 Rejection on no signal (default ON; disable with ``--no-reject-no-signal``):
 when a row's site is crawled successfully but **no** keyword matches, the
-script promotes Status to ``AI: Photo rejected`` with an audit remark
+script promotes Status to ``AI: No fit signal`` (legacy ``AI: Photo rejected``) with an audit remark
 explaining "no site signal". The status name is preserved for back-compat
 with downstream filters; under the new model it means "site shows no
 qualifying keywords" rather than "photos didn't show fit".
 
 Retroactive rescue (``--rescue-rejected``, default ON): also re-evaluates
-``AI: Photo rejected`` rows by crawling their sites and promoting any whose
+``AI: No fit signal`` (legacy ``AI: Photo rejected``) rows by crawling their sites and promoting any whose
 Hosts Circles comes back as ``Yes``. Default-on so existing photo-rejected
 rows (which were never crawled by site keyword) get re-evaluated under the
 new criteria. Pass ``--no-rescue-rejected`` to opt out.
@@ -102,7 +102,17 @@ SCOPES = [
 HOSTS_CIRCLES_COL = "Hosts Circles"
 SUBMITTED_BY_CIRCLE = "detect_circle_hosting_retailers"
 PROMOTABLE_FROM_RESEARCH = "Research"
-PROMOTABLE_FROM_REJECTED = "AI: Photo rejected"
+# 2026-05-03 rename: was "AI: Photo rejected" — but the photo+Grok pipeline
+# is retired (PR #101) and the status is now produced exclusively by the
+# site-crawl-no-signal path. The old name was misleading. The legacy name
+# is still accepted on read so existing rows in the old state get
+# re-evaluated by the rescue path during the migration window.
+REJECTED_STATUS = "AI: No fit signal"
+LEGACY_REJECTED_STATUSES = ("AI: Photo rejected",)
+PROMOTABLE_FROM_REJECTED_STATUSES = (REJECTED_STATUS,) + LEGACY_REJECTED_STATUSES
+# Back-compat alias for any external import.
+PROMOTABLE_FROM_REJECTED = REJECTED_STATUS
+
 # Two promotion targets, picked at runtime based on whether the row has an
 # email already — see promote_row_to_enrichment().
 PROMOTION_TARGET_STATUS_ENRICH = "AI: Enrich with contact"
@@ -210,7 +220,7 @@ def reject_row_no_signal(
     *,
     dry_run: bool,
 ) -> bool:
-    """Mark ``rn`` as ``AI: Photo rejected`` because a successful site crawl
+    """Mark ``rn`` as ``AI: No fit signal`` because a successful site crawl
     found no qualifying circle / ceremony / cacao keywords.
 
     This replaces the photo+Grok rubric that ``hit_list_research_photo_review``
@@ -218,6 +228,12 @@ def reject_row_no_signal(
     direct signal: if the site doesn't say it hosts circles, photos won't
     confidently say it does either. ``--rescue-rejected`` still re-promotes
     such rows later if the site develops the keywords.
+
+    State name was renamed from legacy ``AI: Photo rejected`` to
+    ``AI: No fit signal`` on 2026-05-03 since the photo+Grok pipeline is
+    retired and the new state is grounded in site-crawl evidence, not
+    photos. The rescue path still accepts the legacy name for back-compat
+    (see ``LEGACY_REJECTED_STATUSES``).
     """
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     submitted_at = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
@@ -229,7 +245,7 @@ def reject_row_no_signal(
 
     if dry_run:
         print(
-            f"  [dry-run] row {rn} {shop!r}: would reject (no signal) -> AI: Photo rejected",
+            f"  [dry-run] row {rn} {shop!r}: would reject (no signal) -> {REJECTED_STATUS}",
             flush=True,
         )
         return True
@@ -239,7 +255,7 @@ def reject_row_no_signal(
         remark_ws,
         rn,
         shop,
-        "AI: Photo rejected",
+        REJECTED_STATUS,
         remark,
         SUBMITTED_BY_CIRCLE,
         submitted_at,
@@ -267,8 +283,9 @@ def promote_row_to_enrichment(
       - ``has_email=False`` → ``AI: Enrich with contact`` (Enrich runs to
         harvest the email, then promotes onward to Warm up prospect).
 
-    ``rescue=True`` indicates we're un-rejecting an AI: Photo rejected row
-    by site-crawl signal; the audit text reflects that.
+    ``rescue=True`` indicates we're un-rejecting a previously-rejected row
+    (current ``AI: No fit signal`` or legacy ``AI: Photo rejected``) by
+    site-crawl signal; the audit text reflects that.
     """
     target = PROMOTION_TARGET_STATUS_WARMUP if has_email else PROMOTION_TARGET_STATUS_ENRICH
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -277,7 +294,7 @@ def promote_row_to_enrichment(
     skip_note = "skip_enrich=true" if has_email else "skip_enrich=false"
     if rescue:
         remark = (
-            f"[circle-detect {stamp}] outcome=rescue_from_photo_rejection "
+            f"[circle-detect {stamp}] outcome=rescue_from_no_fit_signal "
             f"matched={matched_str} {skip_note}"
         )
     else:
@@ -291,7 +308,10 @@ def promote_row_to_enrichment(
         )
 
     if dry_run:
-        action = "rescue from AI: Photo rejected" if rescue else "promote from Research"
+        action = (
+            f"rescue from {REJECTED_STATUS} (or legacy)"
+            if rescue else "promote from Research"
+        )
         print(
             f"  [dry-run] row {rn} {shop!r}: would {action} -> {target}",
             flush=True,
@@ -342,20 +362,21 @@ def main() -> None:
     p.add_argument(
         "--no-promote",
         action="store_true",
-        help="Disable ALL promotion/rescue when Hosts Circles=Yes. Prevents Research → AI: Enrich with contact, and prevents rescue of AI: Photo rejected / AI: Enrich — manual / AI: Photo needs review rows.",
+        help="Disable ALL promotion/rescue when Hosts Circles=Yes. Prevents Research → AI: Enrich with contact, and prevents rescue of AI: No fit signal (or legacy AI: Photo rejected) / AI: Enrich — manual / AI: Photo needs review rows.",
     )
     p.add_argument(
         "--no-rescue-rejected",
         action="store_true",
-        help="Disable re-evaluation of AI: Photo rejected rows. Default is to "
-        "rescue: crawl their sites and promote any whose Hosts Circles comes "
-        "back as Yes. Default-on so existing photo-rejected rows (which were "
-        "never crawled by site keyword) get re-evaluated under the new criteria.",
+        help="Disable re-evaluation of AI: No fit signal (or legacy AI: Photo "
+        "rejected) rows. Default is to rescue: crawl their sites and promote "
+        "any whose Hosts Circles comes back as Yes. Default-on so legacy "
+        "rows (which were never crawled by site keyword) get re-evaluated "
+        "under the new criteria.",
     )
     p.add_argument(
         "--no-reject-no-signal",
         action="store_true",
-        help="Disable Research -> AI: Photo rejected when the site crawl "
+        help="Disable Research -> AI: No fit signal when the site crawl "
         "succeeds but finds no qualifying keywords. Default is to reject — "
         "this is the simplification that retires the photo+Grok rubric "
         "(which used to gate Research -> rejected). Pass this flag to keep "
@@ -450,12 +471,17 @@ def main() -> None:
                 promote_count += 1
                 if not args.dry_run:
                     time.sleep(max(0.0, args.sleep_write))
-            elif cur_status in (PROMOTABLE_FROM_REJECTED, PROMOTABLE_FROM_MANUAL, PROMOTABLE_FROM_NEEDS_REVIEW):
-                # Rescue dead-end rows: photo-rejected, enrichment-gave-up, or
-                # photo-needs-review. All three are stuck states where a clear
+            elif (
+                cur_status in PROMOTABLE_FROM_REJECTED_STATUSES
+                or cur_status == PROMOTABLE_FROM_MANUAL
+                or cur_status == PROMOTABLE_FROM_NEEDS_REVIEW
+            ):
+                # Rescue dead-end rows: no-fit-signal (current name) OR
+                # legacy AI: Photo rejected OR enrichment-gave-up OR
+                # photo-needs-review. All are stuck states where a clear
                 # circle-hosting signal on the website is strong enough to
                 # fast-track back into the pipeline.
-                if cur_status == PROMOTABLE_FROM_REJECTED and not rescue_rejected:
+                if cur_status in PROMOTABLE_FROM_REJECTED_STATUSES and not rescue_rejected:
                     pass  # user opted out of rejected rescue
                 else:
                     promote_row_to_enrichment(
@@ -466,10 +492,9 @@ def main() -> None:
                     if not args.dry_run:
                         time.sleep(max(0.0, args.sleep_write))
         elif not hits and reject_no_signal and cur_status == PROMOTABLE_FROM_RESEARCH and not args.no_promote:
-            # Site crawled OK + zero matches → mark as photo-rejected
-            # (the status name is preserved for back-compat with downstream
-            # filters; meaning under new model is "site shows no qualifying
-            # signals," which retires the photo+Grok rubric).
+            # Site crawled OK + zero matches → mark as AI: No fit signal
+            # (renamed from legacy "AI: Photo rejected" on 2026-05-03;
+            # both names are read in the rescue path for back-compat).
             reject_row_no_signal(ws, remark_ws, ri, shop, dry_run=args.dry_run)
             reject_count += 1
             if not args.dry_run:
@@ -502,8 +527,12 @@ def main() -> None:
                 swept_promote += 1
                 if not args.dry_run:
                     time.sleep(max(0.0, args.sleep_write))
-            elif status in (PROMOTABLE_FROM_REJECTED, PROMOTABLE_FROM_MANUAL, PROMOTABLE_FROM_NEEDS_REVIEW):
-                if status == PROMOTABLE_FROM_REJECTED and not rescue_rejected:
+            elif (
+                status in PROMOTABLE_FROM_REJECTED_STATUSES
+                or status == PROMOTABLE_FROM_MANUAL
+                or status == PROMOTABLE_FROM_NEEDS_REVIEW
+            ):
+                if status in PROMOTABLE_FROM_REJECTED_STATUSES and not rescue_rejected:
                     pass
                 else:
                     promote_row_to_enrichment(

--- a/scripts/hit_list_research_photo_review.py
+++ b/scripts/hit_list_research_photo_review.py
@@ -536,9 +536,12 @@ def run_one_shop(
                 print("--- Remarks (preview) ---")
                 print(remarks)
                 return
+            # 2026-05-03: write the renamed status. Was "AI: Photo rejected";
+            # now "AI: No fit signal" since the photo+Grok rubric is retired
+            # and the meaning is now "site shows no qualifying signals".
             append_dapp_remark_and_apply(
                 hit_ws, remark_ws, sheet_row, name,
-                "AI: Photo rejected", remarks,
+                "AI: No fit signal", remarks,
                 SUBMITTED_BY_GATE_SKIP, submitted_at, submission_id,
             )
             return
@@ -573,7 +576,14 @@ def run_one_shop(
         ctx = f"Shop: {name}. Address: {addr}, {city}, {state}. place_id: {place_id}."
         grok = grok_photo_rubric(paths, ctx)
         ai_status = (grok.get("recommended_hit_list_status") or "").strip()
-        if ai_status not in ("AI: Shortlisted", "AI: Photo rejected", "AI: Photo needs review"):
+        # 2026-05-03 rename: Grok's prompt still uses the legacy "AI: Photo
+        # rejected" label, so map it to the new canonical "AI: No fit signal"
+        # before writing. Other legacy labels stay as-is (this script is
+        # manual-only / debug after the cron retirement, so keeping the
+        # photo-review-specific labels is fine).
+        if ai_status == "AI: Photo rejected":
+            ai_status = "AI: No fit signal"
+        if ai_status not in ("AI: Shortlisted", "AI: No fit signal", "AI: Photo needs review"):
             ai_status = "AI: Photo needs review"
         photo_count = len(paths)
     else:

--- a/scripts/populate_states_reference_sheet.py
+++ b/scripts/populate_states_reference_sheet.py
@@ -47,12 +47,24 @@ STATUSES: list[tuple[str, str]] = [
         "Machine thought storefront photos look on‑brand. You review; promote to Shortlisted or choose AI: Enrich with contact / reject paths.",
     ),
     (
+        "AI: No fit signal",
+        "Site was crawled, no qualifying keywords (cacao ceremony / women's "
+        "circle / sound bath / etc.) found. Replaces the legacy "
+        "'AI: Photo rejected' state from 2026-05-03 onward. Recoverable: a "
+        "future re-crawl that finds keywords promotes this row back to "
+        "AI: Enrich with contact via the rescue path.",
+    ),
+    (
         "AI: Photo rejected",
-        "Machine flagged photos as a weak fit (from imagery). You confirm Rejected / Not Appropriate or override if you disagree.",
+        "LEGACY (pre-2026-05-03): the old photo+Grok rubric flagged this row "
+        "as a weak fit from imagery. The rubric is retired; rows still in this "
+        "state get re-evaluated by the site-crawl rescue path (or migrate to "
+        "AI: No fit signal once crawled).",
     ),
     (
         "AI: Photo needs review",
-        "Machine could not decide from photos. You look at images and pick the next status.",
+        "LEGACY (pre-2026-05-03): the photo rubric couldn't decide. No "
+        "automation reaches this state any more; manual triage only.",
     ),
     (
         "AI: Enrich with contact",

--- a/scripts/rename_legacy_photo_rejected_status.py
+++ b/scripts/rename_legacy_photo_rejected_status.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+One-off migration: rename Hit List rows with Status == 'AI: Photo rejected'
+to 'AI: No fit signal'.
+
+The photo+Grok rubric was retired in PR #101 (2026-05-03). The status name
+'AI: Photo rejected' is now misleading — it gets written by the
+site-crawl-no-signal path in detect_circle_hosting_retailers.py, and has
+nothing to do with photos. PR #102 (2026-05-03) renamed the canonical
+write target to 'AI: No fit signal' and added the legacy name to the
+rescue path's accepted-input set.
+
+This script does the one-time data migration to bring existing rows in
+line with the new name. Idempotent — already-renamed rows are skipped.
+
+Audit trail: every renamed row gets a DApp Remarks entry explaining the
+state-name migration with a stable reason code so it's distinguishable
+from any future Status flips.
+
+Usage:
+    cd market_research
+    python3 scripts/rename_legacy_photo_rejected_status.py --dry-run
+    python3 scripts/rename_legacy_photo_rejected_status.py             # do it
+    python3 scripts/rename_legacy_photo_rejected_status.py --limit 50  # batch
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import gspread
+from google.oauth2.service_account import Credentials
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply  # noqa: E402
+
+SPREADSHEET_ID = "1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc"
+HIT_LIST_WS = "Hit List"
+DAPP_REMARKS_WS = "DApp Remarks"
+SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+]
+
+LEGACY_STATUS = "AI: Photo rejected"
+NEW_STATUS = "AI: No fit signal"
+SUBMITTED_BY = "rename_legacy_photo_rejected_status"
+
+
+def gspread_client() -> gspread.Client:
+    creds_path = REPO / "google_credentials.json"
+    if not creds_path.is_file():
+        raise SystemExit(f"Missing service account JSON: {creds_path}")
+    creds = Credentials.from_service_account_file(str(creds_path), scopes=SCOPES)
+    return gspread.authorize(creds)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap rows renamed this run (default: all matching).")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would change without touching the sheet.")
+    p.add_argument("--sleep", type=float, default=0.3,
+                   help="Sleep between writes in seconds (default 0.3).")
+    args = p.parse_args(argv)
+
+    gc = gspread_client()
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    hit_ws = sh.worksheet(HIT_LIST_WS)
+    remark_ws = sh.worksheet(DAPP_REMARKS_WS)
+    rows = hit_ws.get_all_values()
+    if len(rows) < 2:
+        print("No data rows.")
+        return 0
+    header = [str(x or "").strip() for x in rows[0]]
+    if "Status" not in header or "Shop Name" not in header:
+        print("Hit List missing required columns.")
+        return 1
+    i_status = header.index("Status")
+    i_shop = header.index("Shop Name")
+
+    # Find rows currently at the legacy status.
+    targets: list[tuple[int, str]] = []
+    for ri, raw in enumerate(rows[1:], start=2):
+        row = list(raw) + [""] * (len(header) - len(raw))
+        if (row[i_status] or "").strip() == LEGACY_STATUS:
+            shop = (row[i_shop] or "").strip()
+            targets.append((ri, shop))
+
+    print(f"Hit List rows total: {len(rows) - 1}")
+    print(f"Rows at legacy '{LEGACY_STATUS}': {len(targets)}")
+    if args.limit is not None:
+        targets = targets[: args.limit]
+        print(f"Limiting to first {len(targets)} for this run.")
+
+    if not targets:
+        print("Nothing to migrate.")
+        return 0
+
+    renamed = 0
+    failures = 0
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for ri, shop in targets:
+        if args.dry_run:
+            print(f"  [dry] row {ri} {shop!r}: {LEGACY_STATUS!r} -> {NEW_STATUS!r}")
+            renamed += 1
+            continue
+
+        submission_id = str(uuid.uuid4())
+        submitted_at = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
+        remark = (
+            f"[status-rename {stamp}] outcome=rename_legacy_photo_rejected "
+            f"from={LEGACY_STATUS!r} to={NEW_STATUS!r} "
+            f"(photo+Grok rubric retired 2026-05-03; site crawl is canonical "
+            f"qualifier; new status name reflects evidence)"
+        )
+        try:
+            append_dapp_remark_and_apply(
+                hit_ws, remark_ws, ri, shop,
+                NEW_STATUS, remark,
+                SUBMITTED_BY, submitted_at, submission_id,
+            )
+            renamed += 1
+            print(f"  [rename] row {ri} {shop!r}: -> {NEW_STATUS}")
+        except Exception as e:
+            failures += 1
+            sys.stderr.write(f"  [fail] row {ri} {shop!r}: {e}\n")
+        time.sleep(max(0.0, args.sleep))
+
+    print()
+    print(f"Renamed:   {renamed}")
+    print(f"Failures:  {failures}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Per Gary 2026-05-03: *"feels like AI: Photo rejected is going to be legacy state once we are done doing a crawl on them isn't it?"*

The status name became misleading after PR #101 retired the photo+Grok rubric. The status is now produced exclusively by the site-crawl-no-signal path in \`detect_circle_hosting_retailers\`, which has nothing to do with photos. Renaming makes the evidence visible at a glance: the *site* showed no signal, not the photos.

## What changed

| File | Change |
|---|---|
| \`detect_circle_hosting_retailers.py\` | New \`REJECTED_STATUS\` + \`LEGACY_REJECTED_STATUSES\` constants. Rescue path reads BOTH names so legacy rows still get re-evaluated. Reject path writes the new name. CLI help + docstrings updated. \`PROMOTABLE_FROM_REJECTED\` aliased to new name for back-compat with any external import. |
| \`hit_list_research_photo_review.py\` | Manual-only path now writes the new name. Grok-rubric path remaps Grok's legacy output on the fly. |
| \`populate_states_reference_sheet.py\` | New canonical state added with description; legacy state kept with explanation. |
| \`HIT_LIST_CREDENTIALS.md\` | Updated. |
| **NEW** \`scripts/rename_legacy_photo_rejected_status.py\` | One-off bulk migration with DApp Remarks audit trail. Idempotent, \`--dry-run\`, \`--limit\`. |

## Operator actions after merge

1. \`python3 scripts/populate_states_reference_sheet.py\` — push new States tab definitions.
2. \`python3 scripts/rename_legacy_photo_rejected_status.py --dry-run\` — preview.
3. \`python3 scripts/rename_legacy_photo_rejected_status.py\` — execute the migration.
4. After ~1 month of zero new rows on the legacy name, drop the back-compat read.

## Oracle note (no action needed)

The Oracle's advisory snapshot path does NOT hard-code \`AI: Photo rejected\`. The pipeline_metrics_snapshot GAS reads status counts from the Pipeline Dashboard sheet, which auto-aggregates all distinct Status values. The new state appears in the funnel breakdown after the next sync — no GAS code change required.

## DApp UI

\`dapp/stores_nearby.html\`, \`store_interaction_history.html\`, \`stores_by_status.html\` hard-code the legacy name in dropdowns + filter checkboxes. Updated in companion dapp PR.

## Docs

\`agentic_ai_context/HIT_LIST_STATE_MACHINE.md\` and \`PLACES_API_CACHING.md\` updated in companion agentic_ai_context PR.

## Test plan

- [x] All four touched scripts compile (\`py_compile\`).
- [ ] Operator runs \`populate_states_reference_sheet.py\` — verify States tab has new entry + legacy entry.
- [ ] Operator runs \`rename_legacy_photo_rejected_status.py --dry-run\` — verify count of rows that would change.
- [ ] Operator runs the full migration — verify rows update + DApp Remarks audit entries appear.
- [ ] Next \`detect_circle_hosting\` cron tick (\`:50 *\`) writes new name for any new no-signal rows.