### PR TITLE
feat(email-agent): persist gmail_message_id on draft creation

### DIFF
--- a/scripts/backfill_email_agent_drafts_message_id.py
+++ b/scripts/backfill_email_agent_drafts_message_id.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+One-off backfill: populate ``gmail_message_id`` for ``pending_review``
+rows in the **Email Agent Drafts** tab where the column was added after
+the row was created (PR added the column 2026-05-03).
+
+Why this exists: the DApp warm-up review page constructs deep-links of
+the form ``https://mail.google.com/mail/u/0/#drafts/<message_id>`` so a
+single tap from a phone jumps directly to the right draft. Existing
+rows only have ``gmail_draft_id`` (an opaque draft-API handle), not the
+underlying ``message.id`` Gmail's UI uses in URLs. Both ids are
+available at draft-creation time — we just weren't persisting it.
+
+Reads each row's ``gmail_draft_id``, fetches the draft via Gmail API,
+extracts ``draft.message.id``, writes it to the new
+``gmail_message_id`` cell. Skips rows where:
+
+- The cell is already populated (idempotent re-runs).
+- The Gmail draft no longer exists (deleted or sent — those rows will
+  get reconciled to ``discarded`` by the next cron tick anyway).
+- The row's status is not ``pending_review`` (sent / discarded rows
+  don't need the deep-link).
+
+Run this once after deploying the schema change. Future drafts get
+``gmail_message_id`` populated at creation time by
+``suggest_warmup_prospect_drafts.py`` and
+``suggest_manager_followup_drafts.py``.
+
+Usage::
+
+    cd market_research
+    python3 scripts/backfill_email_agent_drafts_message_id.py --dry-run
+    python3 scripts/backfill_email_agent_drafts_message_id.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import gspread
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import suggest_manager_followup_drafts as smf  # noqa: E402
+
+PENDING_STATUS = "pending_review"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would change without touching the sheet.")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap rows updated this run (default: all needing backfill).")
+    p.add_argument("--sleep", type=float, default=0.15,
+                   help="Sleep between writes in seconds (default 0.15).")
+    args = p.parse_args(argv)
+
+    gc = smf.get_sheets_client()
+    sh = gc.open_by_key(smf.SPREADSHEET_ID)
+    ws = sh.worksheet(smf.SUGGESTIONS_WS)
+    values = ws.get_all_values()
+    if len(values) < 2:
+        print("No data rows.")
+        return 0
+
+    hdr = smf.header_map(values[0])
+    for col in ("status", "gmail_draft_id", "gmail_message_id"):
+        if col not in hdr:
+            sys.stderr.write(f"Email Agent Drafts missing column: {col}\n")
+            sys.stderr.write("Run scripts/ensure_email_agent_suggestions_sheet.py first.\n")
+            return 1
+    i_status = hdr["status"]
+    i_draft = hdr["gmail_draft_id"]
+    i_msg = hdr["gmail_message_id"]
+
+    targets: list[tuple[int, str]] = []
+    for ri, raw in enumerate(values[1:], start=2):
+        row = list(raw) + [""] * (len(values[0]) - len(raw))
+        if (row[i_status] or "").strip() != PENDING_STATUS:
+            continue
+        if (row[i_msg] or "").strip():
+            continue
+        draft_id = (row[i_draft] or "").strip()
+        if not draft_id:
+            continue
+        targets.append((ri, draft_id))
+
+    print(f"Total rows: {len(values) - 1}")
+    print(f"Pending rows missing gmail_message_id: {len(targets)}")
+    if args.limit is not None:
+        targets = targets[: args.limit]
+        print(f"Limiting to first {len(targets)}.")
+
+    if not targets:
+        print("Nothing to backfill.")
+        return 0
+
+    creds = smf.get_gmail_creds()
+    service = build("gmail", "v1", credentials=creds, cache_discovery=False)
+
+    filled = 0
+    missing = 0
+    failures = 0
+    for ri, draft_id in targets:
+        try:
+            dr = service.users().drafts().get(userId="me", id=draft_id, format="metadata").execute()
+        except HttpError as e:
+            if smf.is_missing_draft_http_error(e):
+                missing += 1
+                print(f"  [skip] row {ri} draft {draft_id!r}: missing in Gmail (will be reconciled to discarded)")
+                continue
+            failures += 1
+            sys.stderr.write(f"  [fail] row {ri} draft {draft_id!r}: {e}\n")
+            continue
+        msg = dr.get("message") or {}
+        msg_id = str(msg.get("id") or "").strip()
+        if not msg_id:
+            failures += 1
+            sys.stderr.write(f"  [fail] row {ri} draft {draft_id!r}: no message.id in response\n")
+            continue
+        if args.dry_run:
+            print(f"  [dry] row {ri} draft {draft_id!r} -> message_id={msg_id}")
+            filled += 1
+            continue
+        try:
+            ws.update_cell(ri, i_msg + 1, msg_id)
+            filled += 1
+            print(f"  [ok ] row {ri}: message_id={msg_id}")
+        except Exception as e:
+            failures += 1
+            sys.stderr.write(f"  [fail] row {ri} write: {e}\n")
+        time.sleep(max(0.0, args.sleep))
+
+    print()
+    print(f"Filled:    {filled}")
+    print(f"Missing in Gmail (skipped): {missing}")
+    print(f"Failures:  {failures}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ensure_email_agent_suggestions_sheet.py
+++ b/scripts/ensure_email_agent_suggestions_sheet.py
@@ -47,10 +47,13 @@ SUGGESTIONS_HEADERS = [
     "notes",
     "Open",
     "Click through",
+    "gmail_message_id",
 ]
 
-# Before engagement columns (matches prior script revision).
-SUGGESTIONS_HEADERS_LEGACY = SUGGESTIONS_HEADERS[:-2]
+# Before gmail_message_id (the 15-column generation that added Open / Click through).
+SUGGESTIONS_HEADERS_PRE_MSG_ID = SUGGESTIONS_HEADERS[:-1]
+# Before engagement columns (the 13-column original).
+SUGGESTIONS_HEADERS_LEGACY = SUGGESTIONS_HEADERS_PRE_MSG_ID[:-2]
 
 # Canonical label name to apply via Gmail API when creating drafts (future script).
 DEFAULT_GMAIL_LABEL = "Email Agent suggestions"
@@ -103,6 +106,41 @@ def migrate_drafts_add_open_click(ws: gspread.Worksheet, header_row: list[str]) 
     return True
 
 
+def migrate_drafts_add_message_id(ws: gspread.Worksheet, header_row: list[str]) -> bool:
+    """Append **gmail_message_id** at end of row 1 if missing.
+
+    Existing rows are left blank — `backfill_email_agent_drafts_message_id.py`
+    walks pending_review rows and fills them by hitting Gmail draft API.
+    """
+    hm = header_map(header_row)
+    if hm.get("gmail_message_id") is not None:
+        return False
+
+    col_count_before = len(header_row)
+    ws.spreadsheet.batch_update(
+        {
+            "requests": [
+                {
+                    "appendDimension": {
+                        "sheetId": ws.id,
+                        "dimension": "COLUMNS",
+                        "length": 1,
+                    }
+                }
+            ]
+        }
+    )
+    c_msg = col_count_before + 1
+    ws.update_cell(1, c_msg, "gmail_message_id")
+    print(
+        "Migrated Email Agent Drafts: appended column 'gmail_message_id' "
+        f"(1-based column {c_msg}). Existing rows left blank — run "
+        "scripts/backfill_email_agent_drafts_message_id.py to populate "
+        "pending_review rows from Gmail."
+    )
+    return True
+
+
 def get_client():
     if not _SA_CREDS.is_file():
         sys.stderr.write(f"Missing service account {_SA_CREDS}\n")
@@ -140,14 +178,23 @@ def main() -> None:
         print(f"{SUGGESTIONS_WS!r} already has the expected header row.")
         return
 
+    if first == SUGGESTIONS_HEADERS_PRE_MSG_ID:
+        migrate_drafts_add_message_id(ws, vals[0])
+        print(f"{SUGGESTIONS_WS!r} migrated to include gmail_message_id.")
+        return
+
     if first == SUGGESTIONS_HEADERS_LEGACY:
         migrate_drafts_add_open_click(ws, vals[0])
-        print(f"{SUGGESTIONS_WS!r} migrated to include Open / Click through.")
+        # Re-read header after first migration, then chain the next.
+        vals = ws.get_all_values()
+        migrate_drafts_add_message_id(ws, [c.strip() for c in vals[0]])
+        print(f"{SUGGESTIONS_WS!r} migrated to current schema (Open/Click + gmail_message_id).")
         return
 
     sys.stderr.write(
         f"{SUGGESTIONS_WS!r} row 1 does not match expected headers.\n"
         f"Expected (new): {SUGGESTIONS_HEADERS}\n"
+        f"Or pre-msg-id (15 cols): {SUGGESTIONS_HEADERS_PRE_MSG_ID}\n"
         f"Or legacy (13 cols): {SUGGESTIONS_HEADERS_LEGACY}\n"
         f"Found:    {first}\n"
         "Fix manually or rename the tab if this is a different sheet.\n"

--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -131,6 +131,7 @@ SUGGESTIONS_HEADERS = [
     "notes",
     "Open",
     "Click through",
+    "gmail_message_id",
 ]
 
 
@@ -1411,6 +1412,7 @@ def main() -> None:
             notes,
             "0",
             "0",
+            msg_id,
         ]
         created_rows.append(row)
         n_made += 1

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -729,6 +729,7 @@ def create_reply_drafts_for_replied_prospects(
             notes,
             "0",
             "0",
+            msg_id,
         ]
         created_rows.append(row_data)
         n_created += 1
@@ -1306,6 +1307,7 @@ def main() -> None:
             notes,
             "0",
             "0",
+            msg_id,
         ]
         created_rows.append(row)
         n_made += 1


### PR DESCRIPTION
## Summary
- Adds a new \`gmail_message_id\` column to the **Email Agent Drafts** schema and populates it at draft creation time (warmup, reply, and manager follow-up drafts all participate).
- Adds \`scripts/backfill_email_agent_drafts_message_id.py\` for the one-off population of existing pending rows.

## Why
The upcoming \`dapp/warmup_review.html\` mobile page needs the **underlying Gmail message id** (not the opaque draft-API handle) to build deep-links of the form \`https://mail.google.com/.../drafts/<message_id>\` so a single tap on a phone jumps straight to the draft in Gmail mobile. Gmail's \`drafts().create()\` response already returns \`message.id\` alongside the draft id at creation — we just weren't persisting it.

## Schema migration path
- \`ensure_email_agent_suggestions_sheet.py\` now appends \`gmail_message_id\` at the end of the header row if missing. Chains cleanly with the existing 13→15-col Open/Click migration so older sheets upgrade in a single run.
- \`scripts/backfill_email_agent_drafts_message_id.py\` walks \`pending_review\` rows missing the column and fetches each draft via the Gmail API. Idempotent — already-populated rows are skipped, and rows whose Gmail draft no longer exists (deleted or sent) are gracefully skipped (they get reconciled to \`discarded\` by the next cron tick anyway).

## Verified live (2026-05-03)
\`\`\`
$ python3 scripts/ensure_email_agent_suggestions_sheet.py
Migrated Email Agent Drafts: appended column 'gmail_message_id' (1-based column 16). Existing rows left blank — run scripts/backfill_email_agent_drafts_message_id.py to populate pending_review rows from Gmail.

$ python3 scripts/backfill_email_agent_drafts_message_id.py
Pending rows missing gmail_message_id: 99
Filled:    96
Missing in Gmail (skipped): 3
Failures:  0
\`\`\`

## Companion PRs
- \`tokenomics\` — GAS endpoint \`getWarmupReviewQueue\` + \`apply_warmup_send\` handlers (already deployed @v21).
- \`sentiment_importer\` — Edgar dispatcher branch for \`[WARMUP SEND EVENT]\` (needs \`./deploy.sh\` after merge).
- \`treasury-cache\` — \`warmup.send\` action in \`permissions.json\`.
- \`dapp\` — \`warmup_review.html\` (mobile-first triage + Send button).

## Test plan
- [x] Schema migration is idempotent (verified — second run no-ops).
- [x] Backfill is idempotent (verified — 96 filled, 3 skipped missing-in-gmail, 0 failures, repeatable).
- [x] Future drafts created via \`suggest_warmup_prospect_drafts.py\` populate the column at creation time (positional row builder updated; no schema drift risk).
- [x] \`preview_warmup_drafts.py\` (local HTML triage view) still works — it reads via \`header_map\` so column position doesn't matter.