### PR TITLE
fix(reply-promotion): apply AI/Prospect Replied label to inbound thread

### DIFF
--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -437,6 +437,17 @@ def promote_warmup_replies(
     status_col = status_i + 1
     n = 0
 
+    # Resolve the AI/Prospect Replied label id once. Used to tag the inbound
+    # message so the Gmail-side state matches the Hit List Status flip — see
+    # HIT_LIST_STATE_MACHINE.md "AI: Prospect replied" row. Best-effort: a
+    # label-create failure logs and lets the Status flip proceed anyway.
+    replied_label_id: str | None = None
+    if not dry_run:
+        try:
+            replied_label_id = smf.ensure_user_label_id(gsvc, REPLIED_GMAIL_LABEL)
+        except Exception as e:
+            print(f"  WARNING: could not resolve {REPLIED_GMAIL_LABEL!r} label: {e}")
+
     for r, row in enumerate(values[1:], start=2):
         if smf.cell(row, status_i) != HIT_STATUS_WARMUP:
             continue
@@ -478,6 +489,21 @@ def promote_warmup_replies(
                     except Exception as e:
                         print(f"  WARNING: DApp Remarks append failed for row {r}: {e}")
                 hit_ws.update_cell(r, status_col, HIT_STATUS_REPLIED)
+
+                # Tag the inbound message with AI/Prospect Replied so Gmail-side
+                # state matches Hit List. Idempotent — Gmail no-ops on re-add.
+                inbound_msg_id = reply.get("message_id") or ""
+                if replied_label_id and inbound_msg_id:
+                    try:
+                        gsvc.users().messages().modify(
+                            userId="me",
+                            id=inbound_msg_id,
+                            body={"addLabelIds": [replied_label_id]},
+                        ).execute()
+                        if verbose:
+                            print(f"  label   row {r} msg {inbound_msg_id}: +{REPLIED_GMAIL_LABEL!r}")
+                    except Exception as e:
+                        print(f"  WARNING: label apply failed for row {r} msg {inbound_msg_id}: {e}")
             n += 1
     return n
 


### PR DESCRIPTION
## Summary
\`promote_warmup_replies()\` in \`suggest_warmup_prospect_drafts.py\` flipped Hit List Status to \`AI: Prospect replied\` and appended a DApp Remarks row, but **never applied the \`AI/Prospect Replied\` Gmail label to the inbound message**. Result: Hit List said replied, Gmail label said warm-up — the two surfaces diverged.

## Operator-visible bug
Operator opened a Gmail thread the system had already promoted (Hit List Status = \`AI: Prospect replied\`) and asked why it wasn't tagged \`AI/Prospect Replied\` in Gmail. Investigation showed the Status flip + remark were correct; the label-apply step was just missing from the code path.

## Fix
Resolve \`REPLIED_GMAIL_LABEL\` once before the loop (best-effort — a label-create failure logs and lets the Status flip proceed anyway), then call \`gsvc.users().messages().modify(addLabelIds=[id])\` on the inbound \`message_id\` we already have from \`inbound_reply_details\`. Idempotent — Gmail no-ops on re-add, so re-running \`--reply-promotion-only\` is safe.

## Backfill (already applied)
For the 6 existing rows promoted before this fix landed:
\`\`\`
Hit List rows at 'AI: Prospect replied': 6
Labeled:                                  6
No inbound match in Gmail:                0
\`\`\`
Threads: \`info@esalen.org\`, \`theastrologystore@gmail.com\`, \`michelle@carerituals.com\`, \`oneelliott@gmail.com\`, \`info@seagrapeapothecary.com\`, plus 1 promoted in this run.

## Companion
- \`dapp\` PR #205 — fixes 4 stale references in \`warmup_review.html\` after the single-API refactor (renderDraftCard typo + dead allDrafts var).