### PR TITLE
fix(sync): close two recurring drift loops in the Outbound Review pipeline

### DIFF
--- a/scripts/reconcile_orphan_reply_drafts.py
+++ b/scripts/reconcile_orphan_reply_drafts.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Detect Gmail reply drafts that bypass ``suggest_warmup_prospect_drafts.py
+--create-reply-drafts`` (i.e., the operator started the reply manually
+in Gmail by hitting **Reply** on a prospect's inbound message), and
+reconcile them so the DApp Outbound Review **Prospects** tab surfaces
+them like any other staged reply:
+
+  1. Apply the **AI/Prospect Replied** label to the draft message — it
+     usually starts as ``[DRAFT]`` only because Gmail's reply UI doesn't
+     carry the parent thread's labels onto the new outbound draft.
+  2. Append a row to **Email Agent Drafts** (status=``pending_review``,
+     label=``AI/Prospect Replied``, kind=``warmup_reply``,
+     source=``manual_orphan``) so the GAS read endpoint can surface it.
+
+Detection rule: any Gmail draft whose thread contains an inbound message
+already wearing **AI/Prospect Replied**, AND whose own message id has no
+matching row in Email Agent Drafts (or has a row whose label is empty
+/ not yet AI/Prospect Replied) — that's an orphan reply draft.
+
+Idempotent — re-runs are no-ops on drafts that have already been
+reconciled (label present + sheet row exists).
+
+Usage::
+
+    cd market_research
+    python3 scripts/reconcile_orphan_reply_drafts.py --dry-run
+    python3 scripts/reconcile_orphan_reply_drafts.py
+    python3 scripts/reconcile_orphan_reply_drafts.py --limit 5
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import gspread
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import suggest_manager_followup_drafts as smf  # noqa: E402
+from gmail_plain_body import extract_plain_body_from_payload  # noqa: E402
+
+PROSPECT_REPLIED_LABEL = "AI/Prospect Replied"
+PENDING_STATUS = "pending_review"
+WARMUP_REPLY_PROTOCOL = "PARTNER_OUTREACH_PROTOCOL v0.1 warmup_reply"
+BODY_PREVIEW_MAX = 500
+
+
+def _email_from_to_header(to_hdr: str) -> str:
+    if not to_hdr:
+        return ""
+    s = to_hdr.strip()
+    if "<" in s and ">" in s:
+        s = s.split("<", 1)[1].split(">", 1)[0]
+    return s.strip().lower()
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print what would change without touching Gmail or the sheet.")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap drafts processed this run (default: all orphans).")
+    p.add_argument("--sleep", type=float, default=0.15,
+                   help="Sleep between writes in seconds (default 0.15).")
+    args = p.parse_args(argv)
+
+    creds = smf.get_gmail_creds()
+    service = build("gmail", "v1", credentials=creds, cache_discovery=False)
+    sa = smf.get_sheets_client()
+    sh = sa.open_by_key(smf.SPREADSHEET_ID)
+    drafts_ws = sh.worksheet(smf.SUGGESTIONS_WS)
+    hit_ws = sh.worksheet(smf.HIT_LIST_WS)
+
+    label_id = smf.ensure_user_label_id(service, PROSPECT_REPLIED_LABEL)
+
+    # Build sheet-side index of Email Agent Drafts by gmail_message_id so we
+    # can detect orphan drafts (no row) + drafts whose row has no label set.
+    drafts_values = drafts_ws.get_all_values()
+    if len(drafts_values) < 2:
+        sheet_by_msgid: dict[str, tuple[int, dict]] = {}
+        drafts_hdr: dict[str, int] = {}
+    else:
+        drafts_hdr = smf.header_map(drafts_values[0])
+        i_msg = drafts_hdr.get("gmail_message_id")
+        if i_msg is None:
+            sys.stderr.write("Email Agent Drafts missing gmail_message_id column.\n")
+            return 1
+        sheet_by_msgid = {}
+        for r_idx, row in enumerate(drafts_values[1:], start=2):
+            mid = smf.cell(row, i_msg)
+            if mid:
+                sheet_by_msgid[mid] = (r_idx, row)
+
+    # Build Hit List index by email so we can populate store_key / shop_name
+    # / hit_list_row when creating a fresh row.
+    hit_values = hit_ws.get_all_values()
+    hit_hdr = smf.header_map(hit_values[0])
+    hi_email = hit_hdr["Email"]
+    hi_shop = hit_hdr["Shop Name"]
+    hi_storekey = hit_hdr["Store Key"]
+    hit_by_email: dict[str, tuple[int, str, str]] = {}
+    for hr_idx, hrow in enumerate(hit_values[1:], start=2):
+        em = smf.normalize_email(smf.cell(hrow, hi_email))
+        if em and em not in hit_by_email:
+            hit_by_email[em] = (
+                hr_idx,
+                smf.cell(hrow, hi_shop),
+                smf.cell(hrow, hi_storekey),
+            )
+
+    # Walk every Gmail draft. For each, fetch full content + thread metadata
+    # to decide if this is a reply-to-prospect-replied scenario.
+    page_token: str | None = None
+    seen = 0
+    orphans_found = 0
+    label_applied = 0
+    rows_appended = 0
+    while True:
+        req = service.users().drafts().list(
+            userId="me",
+            maxResults=100,
+            pageToken=page_token,
+        )
+        resp = req.execute()
+        for d in resp.get("drafts") or []:
+            if args.limit is not None and orphans_found >= args.limit:
+                break
+            seen += 1
+            draft_id = d.get("id") or ""
+            if not draft_id:
+                continue
+            try:
+                full = service.users().drafts().get(userId="me", id=draft_id, format="full").execute()
+            except HttpError as e:
+                if smf.is_missing_draft_http_error(e):
+                    continue
+                raise
+            msg = full.get("message") or {}
+            msg_id = str(msg.get("id") or "")
+            thread_id = str(msg.get("threadId") or "")
+            if not msg_id or not thread_id:
+                continue
+
+            draft_label_ids = msg.get("labelIds") or []
+            already_labeled = label_id in draft_label_ids
+
+            # Check the parent thread for an inbound AI/Prospect Replied message.
+            try:
+                thread = service.users().threads().get(
+                    userId="me", id=thread_id, format="metadata"
+                ).execute()
+            except HttpError:
+                continue
+            thread_msgs = thread.get("messages") or []
+            thread_has_replied = any(
+                label_id in (m.get("labelIds") or []) for m in thread_msgs if m.get("id") != msg_id
+            )
+            if not thread_has_replied:
+                continue  # not a reply to a prospect-replied thread
+
+            # We're in scope. Decide whether this draft needs reconciling.
+            in_sheet = msg_id in sheet_by_msgid
+            if already_labeled and in_sheet:
+                continue  # already reconciled
+            orphans_found += 1
+
+            # Pull recipient + subject + body for sheet row + logging.
+            pl = msg.get("payload") or {}
+            hdrs = {h.get("name", "").lower(): h.get("value", "") for h in pl.get("headers") or []}
+            to_addr = _email_from_to_header(hdrs.get("to", ""))
+            subject = hdrs.get("subject", "")
+            body = extract_plain_body_from_payload(pl, max_total=20_000).strip()
+            preview = body.replace("\n", " ")[:BODY_PREVIEW_MAX]
+
+            print(f"orphan draft msg={msg_id[:16]}… → {to_addr}")
+            print(f"  thread={thread_id}  draft_id={draft_id}")
+            print(f"  subject={subject[:80]}")
+            print(f"  in_sheet={in_sheet}  already_labeled={already_labeled}")
+
+            if args.dry_run:
+                continue
+
+            # 1. Apply AI/Prospect Replied label to the draft message.
+            if not already_labeled:
+                try:
+                    service.users().messages().modify(
+                        userId="me",
+                        id=msg_id,
+                        body={"addLabelIds": [label_id]},
+                    ).execute()
+                    label_applied += 1
+                    print(f"  applied {PROSPECT_REPLIED_LABEL!r} label")
+                except Exception as e:
+                    print(f"  WARNING: label apply failed: {e}")
+
+            # 2. Append Email Agent Drafts row if missing.
+            if not in_sheet:
+                hit = hit_by_email.get(to_addr)
+                if hit is None:
+                    print(f"  WARNING: no Hit List row for {to_addr} — skipping sheet row append")
+                else:
+                    hit_row, shop, store_key = hit
+                    new_row = [
+                        str(uuid.uuid4()),
+                        datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S"),
+                        store_key, shop, to_addr, str(hit_row),
+                        draft_id, subject, preview,
+                        PENDING_STATUS, PROSPECT_REPLIED_LABEL,
+                        WARMUP_REPLY_PROTOCOL,
+                        f"kind=warmup_reply; source=manual_orphan; thread_id={thread_id}; reconciled by reconcile_orphan_reply_drafts.",
+                        "0", "0", msg_id,
+                    ]
+                    try:
+                        drafts_ws.append_row(new_row, value_input_option="USER_ENTERED")
+                        rows_appended += 1
+                        print(f"  appended Email Agent Drafts row (hit_list_row={hit_row}, shop={shop!r})")
+                    except Exception as e:
+                        print(f"  WARNING: sheet append failed: {e}")
+
+            time.sleep(max(0.0, args.sleep))
+
+        if args.limit is not None and orphans_found >= args.limit:
+            break
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+
+    print()
+    print(f"Drafts scanned:        {seen}")
+    print(f"Orphans detected:      {orphans_found}")
+    print(f"Labels applied:        {label_applied}")
+    print(f"Sheet rows appended:   {rows_appended}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_email_agent_followup.py
+++ b/scripts/sync_email_agent_followup.py
@@ -748,6 +748,52 @@ def pick_store_shop(target_rows: list[dict], to_email: str) -> tuple[str, str]:
     return "", ""
 
 
+def reconcile_drafts_status_to_sent(sa, sent_message_ids: set[str]) -> int:
+    """Flip Email Agent Drafts ``status`` from ``pending_review`` to ``sent``
+    for any row whose ``gmail_message_id`` is in ``sent_message_ids`` (the set
+    of all message ids logged as sent in Email Agent Follow Up after this run).
+
+    Why: Gmail-side label swap (review → sent) already happens in main(),
+    but the Email Agent Drafts row's ``status`` cell stays at
+    ``pending_review`` until the next ``suggest_warmup_prospect_drafts.py``
+    cron tick reconciles via Gmail-draft existence check. Closing that gap
+    here means every cron run keeps the sheet consistent with reality.
+
+    Idempotent — non-pending rows are skipped, no-op if nothing matches.
+    Returns the number of rows updated.
+    """
+    if not sent_message_ids:
+        return 0
+    sh = sa.open_by_key(SPREADSHEET_ID)
+    try:
+        ws = sh.worksheet(SUGGESTIONS_WS)
+    except gspread.WorksheetNotFound:
+        return 0
+    values = ws.get_all_values()
+    if len(values) < 2:
+        return 0
+    hdr = header_map(values[0])
+    i_status = hdr.get("status")
+    i_msg = hdr.get("gmail_message_id")
+    if i_status is None or i_msg is None:
+        return 0
+
+    status_col_a1 = gspread.utils.rowcol_to_a1(2, i_status + 1).rstrip("0123456789")  # column letter
+    cells_to_update: list[gspread.Cell] = []
+    for r_idx, row in enumerate(values[1:], start=2):
+        if cell(row, i_status) != "pending_review":
+            continue
+        mid = cell(row, i_msg)
+        if not mid or mid not in sent_message_ids:
+            continue
+        cells_to_update.append(gspread.Cell(r_idx, i_status + 1, "sent"))
+    if not cells_to_update:
+        return 0
+    # Single batch update keeps API calls low even when many rows drift.
+    ws.update_cells(cells_to_update, value_input_option="USER_ENTERED")
+    return len(cells_to_update)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sync Gmail sent mail into Email Agent Follow Up.")
     parser.add_argument("--dry-run", action="store_true", help="Do not write to Sheets.")
@@ -956,6 +1002,16 @@ def main() -> None:
             swapped += 1
     if swapped:
         print(f"Label swaps completed: {swapped}")
+
+    # Reconcile Email Agent Drafts row status to match reality. Walks all
+    # pending_review rows whose gmail_message_id appears in Email Agent
+    # Follow Up (known_ids includes both pre-existing rows and the ones
+    # we just appended above) and flips them to ``sent``. Without this,
+    # rows drift indefinitely until suggest_warmup_prospect_drafts.py
+    # next runs its own Gmail-draft reconcile.
+    flipped = reconcile_drafts_status_to_sent(sa, known_ids)
+    if flipped:
+        print(f"Reconciled Email Agent Drafts: {flipped} row(s) pending_review → sent.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Two systemic gaps that made today's manual reconciles necessary — both close with this PR.

### Gap 1: Email Agent Drafts row \`status\` didn't flip on manual Gmail send
\`sync_email_agent_followup.py\` already detected sent messages and swapped Gmail labels (\`AI/Warm-up\` → \`AI/Sent Warm-up\`), but **never updated the matching Email Agent Drafts row's \`status\` cell** from \`pending_review\` to \`sent\`. The sheet drifted until the next \`suggest_warmup_prospect_drafts.py\` cron tick reconciled via Gmail-draft existence check — and that cron only fires manually. Result this morning: a **93-row reconcile** (76 warm-ups + 17 follow-ups) to fix yesterday's drift.

**Patch:** new \`reconcile_drafts_status_to_sent(sa, sent_message_ids)\`. Walks Email Agent Drafts once, finds \`pending_review\` rows whose \`gmail_message_id\` is in \`known_ids\` (the set of all sent message ids in Email Agent Follow Up after this sync run), batch-flips them to \`sent\`. \`main()\` calls it right after the existing label-swap step. **Idempotent** — non-pending rows skipped, no-op when nothing matches.

### Gap 2: Manual reply drafts orphaned the sheet + skipped the label
When the operator hits **Reply** in Gmail UI (instead of running \`suggest_warmup_prospect_drafts.py --create-reply-drafts\`), no Email Agent Drafts row gets created and the new outbound draft doesn't inherit the parent thread's \`AI/Prospect Replied\` label — so the DApp Prospects tab silently drops it.

Care Rituals was the first observed instance today (Gmail thread \`19de928617afc457\`). Manual fix worked but the gap recurs with every operator-initiated reply.

**New script: \`reconcile_orphan_reply_drafts.py\`.** Walks every Gmail draft; for each whose parent thread contains an \`AI/Prospect Replied\` inbound message (the trigger condition for "this is a reply to a prospect-replied thread"), ensures (a) the draft message itself wears the \`AI/Prospect Replied\` label, and (b) an Email Agent Drafts row exists (\`status=pending_review\`, \`label=AI/Prospect Replied\`, \`notes=kind=warmup_reply; source=manual_orphan\`). **Idempotent** — re-runs no-op on already-reconciled drafts.

Smoke-tested live: \`110 drafts scanned, 0 orphans detected\` (Care Rituals was fixed manually earlier today; future manual replies will be caught).

## Recommended cron addition
Add \`reconcile_orphan_reply_drafts.py\` alongside the existing \`sync_email_agent_followup.py\` cron tick — it's cheap (one drafts list + one threads-metadata fetch per draft) and means the Prospects tab stays clean without operator intervention.

## Companion PR
- \`sentiment_importer\` [#1046](https://github.com/TrueSightDAO/sentiment_importer/pull/1046) — fixes Edgar \`/proxy/gas\` returning 401 (missing \`skip_before_action :require_login\`).

## Test plan
- [x] \`python3 -c 'import ast; ast.parse(...)'\` — both files parse.
- [x] Dry-run of orphan detector against live mailbox: 110 drafts scanned, 0 orphans (correct: Care Rituals already fixed).
- [ ] After next \`sync_email_agent_followup.py\` run, verify any pending_review row with msgid in Follow Up is auto-flipped to \`sent\`.