### PR TITLE
ci(email-agent): add orphan-reply reconcile step to hourly sync

### DIFF
--- a/.github/workflows/email-agent-sync-followup.yml
+++ b/.github/workflows/email-agent-sync-followup.yml
@@ -1,8 +1,14 @@
-# Gmail sent → "Email Agent Follow Up" tab + warm-up reply promotion.
+# Gmail sent → "Email Agent Follow Up" tab + warm-up reply promotion + orphan-draft reconcile.
 # Schedule: every hour (`cron: '0 * * * *'`).
 #   1. sync_email_agent_followup.py — refreshes Email Agent Follow Up from Gmail sent mail
+#      (also flips Email Agent Drafts row status pending_review → sent for any row whose
+#      gmail_message_id is in Follow Up — closes the manual-Gmail-send drift loop).
 #   2. suggest_warmup_prospect_drafts.py --reply-promotion-only — promotes AI: Warm up prospect →
-#      AI: Prospect replied when Gmail shows inbound from the prospect after the last logged send
+#      AI: Prospect replied when Gmail shows inbound from the prospect after the last logged send.
+#      Also tags the inbound message with the AI/Prospect Replied Gmail label.
+#   3. reconcile_orphan_reply_drafts.py — for any Gmail draft on a thread that already wears
+#      AI/Prospect Replied (operator hit Reply manually in Gmail UI), apply the label to the
+#      outbound draft + append an Email Agent Drafts row so the DApp Prospects tab surfaces it.
 # Code path: `scripts/sync_email_agent_followup.py` on the **default branch** — merge PRs that
 # change that script before expecting new columns (e.g. body_plain).
 # Optional one-time: run locally or add workflow_dispatch input `backfill_body_plain` to fill empty body_plain.
@@ -81,4 +87,15 @@ jobs:
             python scripts/suggest_warmup_prospect_drafts.py --reply-promotion-only --dry-run
           else
             python scripts/suggest_warmup_prospect_drafts.py --reply-promotion-only
+          fi
+
+      - name: Reconcile orphan reply drafts (manual Gmail Reply → AI/Prospect Replied label + sheet row)
+        env:
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
+            python scripts/reconcile_orphan_reply_drafts.py --dry-run
+          else
+            python scripts/reconcile_orphan_reply_drafts.py
           fi


### PR DESCRIPTION
## Summary
Wires \`reconcile_orphan_reply_drafts.py\` (added in [#109](https://github.com/TrueSightDAO/go_to_market/pull/109)) into the existing hourly \`Email Agent Follow Up sync\` workflow as a third job step.

## What the workflow does now (top to bottom)
1. **\`sync_email_agent_followup.py\`** — refreshes Email Agent Follow Up from Gmail sent mail. As of #109, also flips Email Agent Drafts row \`status: pending_review → sent\` for any row whose \`gmail_message_id\` is in Follow Up.
2. **\`suggest_warmup_prospect_drafts.py --reply-promotion-only\`** — promotes \`AI: Warm up prospect → AI: Prospect replied\` when Gmail shows inbound after the last logged send + applies the \`AI/Prospect Replied\` label to the inbound message ([go_to_market#108](https://github.com/TrueSightDAO/go_to_market/pull/108)).
3. **\`reconcile_orphan_reply_drafts.py\`** *(new step)* — for any Gmail draft on a thread already wearing \`AI/Prospect Replied\` (operator hit Reply manually in Gmail UI), apply the label to the outbound draft + append an Email Agent Drafts row so the DApp Prospects tab surfaces it.

Together the three steps self-heal three drift loops that previously required ad-hoc one-off reconciles.

## Honors existing workflow_dispatch
The new step honors the existing \`dry_run\` input — manual triggers with dry-run on will scan but not write.

## Test plan
- [x] Smoke-tested \`reconcile_orphan_reply_drafts.py\` locally: 110 drafts scanned, 0 orphans (Care Rituals already fixed manually).
- [ ] Next hourly cron tick fires — verify the new step shows up in the GitHub Actions run log.