### PR TITLE
feat(outreach): auto-reply filtering, farm taste profiles, follow-up reply detection

### DIFF
--- a/.github/workflows/email-agent-sync-followup.yml
+++ b/.github/workflows/email-agent-sync-followup.yml
@@ -99,3 +99,14 @@ jobs:
           else
             python scripts/reconcile_orphan_reply_drafts.py
           fi
+
+      - name: Detect follow-up replies (Manager Follow-up / Bulk Info Requested)
+        env:
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
+            python scripts/suggest_manager_followup_drafts.py --reply-promotion-only --dry-run
+          else
+            python scripts/suggest_manager_followup_drafts.py --reply-promotion-only
+          fi

--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -1074,6 +1074,116 @@ def draft_subject(shop_name: str) -> str:
     return f"Following up — {s} & Agroverse cacao"
 
 
+def _detect_and_log_followup_replies(
+    *,
+    gsvc: Any,
+    hit_ws: Any,
+    remarks_ws: Any,
+    log_ws: Any,
+    dry_run: bool,
+    verbose: bool,
+) -> int:
+    """Detect inbound replies to Manager Follow-up / Bulk Info Requested emails.
+
+    Checks Gmail for replies from each recipient after the last logged send.
+    Auto-replies are filtered. Real replies are logged to DApp Remarks.
+    Returns number of replies detected.
+    """
+    # Lazy import to avoid circular dependency (warmup imports this module)
+    from suggest_warmup_prospect_drafts import inbound_reply_details, is_auto_reply
+    import uuid as _uuid
+
+    if log_ws is None:
+        print("WARNING: Email Agent Follow Up missing — skip follow-up reply detection.")
+        return 0
+
+    last_sent = last_sent_utctime_per_to_email(log_ws)
+    values = hit_ws.get_all_values()
+    if len(values) < 2:
+        return 0
+    hdr = header_map(values[0])
+    status_i = hdr.get("Status")
+    email_i = hdr.get("Email")
+    shop_i = hdr.get("Shop Name")
+    if status_i is None or email_i is None:
+        return 0
+
+    n = 0
+    followup_statuses = {"Manager Follow-up", "Bulk Info Requested"}
+
+    for r, row in enumerate(values[1:], start=2):
+        status = cell(row, status_i).strip()
+        if status not in followup_statuses:
+            continue
+        em = normalize_email(cell(row, email_i))
+        if not em:
+            continue
+        prev = last_sent.get(em)
+        if prev is None:
+            if verbose:
+                print(f"  detect-skip row {r} {em}: no logged sent for follow-up")
+            continue
+        after_ms = int(prev.timestamp() * 1000)
+        reply = inbound_reply_details(gsvc, partner_email=em, after_ms=after_ms)
+        if not reply:
+            continue
+
+        if is_auto_reply(reply.get("body", ""), reply.get("subject", "")):
+            if verbose:
+                print(f"  detect-auto-reply row {r} {em}: auto-reply, not logging")
+            # Still log auto-replies for audit but mark clearly
+            if not dry_run and remarks_ws is not None:
+                shop_name = cell(row, shop_i) if shop_i is not None else ""
+                try:
+                    append_dapp_remark_and_apply(
+                        hit_ws=hit_ws,
+                        remark_ws=remarks_ws,
+                        sheet_row=r,
+                        name=shop_name,
+                        ai_status=status,
+                        remarks=(
+                            f"Auto-reply detected to follow-up email (not a real response).\n\n"
+                            f"Reply subject: {reply['subject']}\n"
+                            f"Reply date: {reply['date']}\n"
+                            f"Reply body:\n{reply['body']}"
+                        ),
+                        submitted_by="followup_auto_reply_detected",
+                        submitted_at=reply["date"],
+                        submission_id=str(_uuid.uuid4()),
+                    )
+                except Exception as e:
+                    print(f"  WARNING: auto-reply DApp Remarks append failed for row {r}: {e}")
+            continue
+
+        n += 1
+        shop_name = cell(row, shop_i) if shop_i is not None else ""
+        print(f"  FOLLOW-UP REPLY row {r} {em}: {reply.get('subject','')[:80]}")
+
+        if not dry_run and remarks_ws is not None:
+            try:
+                append_dapp_remark_and_apply(
+                    hit_ws=hit_ws,
+                    remark_ws=remarks_ws,
+                    sheet_row=r,
+                    name=shop_name,
+                    ai_status=status,
+                    remarks=(
+                        f"Prospect replied to follow-up email.\n\n"
+                        f"Reply subject: {reply['subject']}\n"
+                        f"Reply date: {reply['date']}\n"
+                        f"Reply body:\n{reply['body']}\n\n"
+                        f"Action: operator review recommended — consider reply draft or status update."
+                    ),
+                    submitted_by="followup_reply_detected",
+                    submitted_at=reply["date"],
+                    submission_id=str(_uuid.uuid4()),
+                )
+            except Exception as e:
+                print(f"  WARNING: follow-up reply DApp Remarks append failed for row {r}: {e}")
+
+    return n
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Create Gmail follow-up drafts for Manager Follow-up leads.")
     parser.add_argument("--dry-run", action="store_true")
@@ -1140,6 +1250,14 @@ def main() -> None:
         default=DEFAULT_GROK_MAX_CONTEXT_CHARS,
         help="Max total characters of thread text sent to Grok.",
     )
+    parser.add_argument(
+        "--reply-promotion-only",
+        action="store_true",
+        help=(
+            "Only detect inbound replies to sent follow-up emails (Manager Follow-up + Bulk Info Requested). "
+            "Log to DApp Remarks; do not create any drafts. Use to catch replies between daily draft runs."
+        ),
+    )
     args = parser.parse_args()
 
     if args.max_drafts < 0:
@@ -1190,6 +1308,17 @@ def main() -> None:
         )
     latest_discard_utc = latest_discarded_utc_per_to_email(sugg_ws)
     now = datetime.now(timezone.utc)
+
+    if args.reply_promotion_only:
+        _detect_and_log_followup_replies(
+            gsvc=gsvc,
+            hit_ws=hit_ws,
+            remarks_ws=remarks_ws,
+            log_ws=log_ws,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+        )
+        return
 
     targets = load_hit_list_targets(hit_ws)
     if not targets:

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -57,6 +57,8 @@ from email_agent_tracking import plain_text_to_html_for_email_agent
 from gmail_plain_body import extract_plain_body_from_payload
 from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply
 _WARMUP_REF = _REPO / "templates" / "warmup_outreach_reference.md"
+_FARM_TASTE_REF = _REPO / "templates" / "farm_taste_profiles.md"
+_FIELD_INSIGHTS_REF = _REPO / "templates" / "field_insights_outreach.md"
 _DEFAULT_PDF = _REPO / "retail_price_list" / "agroverse_wholesale_price_list_2026.pdf"
 _DEFAULT_PACKAGING_FRONT = _REPO / "retail_price_list" / "agroverse_packaging_front.jpeg"
 _DEFAULT_PACKAGING_BACK = _REPO / "retail_price_list" / "agroverse_packaging_back.jpeg"
@@ -199,6 +201,82 @@ def inbound_reply_details(
 
 # Backward-compatible alias
 inbound_from_partner_after = inbound_reply_details
+
+
+# ── auto-reply detection ────────────────────────────────────────────────────
+
+_AUTO_REPLY_PATTERNS: list[re.Pattern] = [
+    # Out-of-office / vacation
+    re.compile(r"\bout of (the )?office\b", re.IGNORECASE),
+    re.compile(r"\bout of town\b", re.IGNORECASE),
+    re.compile(r"\bon (vacation|leave|holiday)\b", re.IGNORECASE),
+    re.compile(r"\b(away from|not in) the office\b", re.IGNORECASE),
+    re.compile(
+        r"\bwill (return|be back) (on|after|in|by)\b", re.IGNORECASE
+    ),
+    # Auto-responders
+    re.compile(
+        r"\b(thank you for (contacting|reaching out|your (email|message|inquiry))"
+        r"|we (have )?received your (message|email|inquiry))\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(24[-– ]?48|48[-– ]?72) (hours|hrs)\b", re.IGNORECASE),
+    re.compile(r"\brespond within \d+ (hours|business days)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(due to (high|unexpected) (volume|demand)|"
+        r"experiencing (higher|a high) (than )?(normal|usual|expected) volume)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(calls? (will be|are) returned (in order|as soon|within)|"
+        r"leave a (voicemail|message))\b",
+        re.IGNORECASE,
+    ),
+    # Gmail vacation responder header pattern in body
+    re.compile(r"\b(auto[- ]?(reply|response|responder|generated)|vacation (responder|reply))\b", re.IGNORECASE),
+    # Very short no-effort reply (< 30 chars stripped, no question marks)
+]
+_AUTO_REPLY_MIN_WORDS = 4  # fewer words than this → almost certainly auto/non-reply
+_AUTO_REPLY_MIN_UNIQUE_WORDS = 3  # unique words (strips quoted original message noise)
+
+
+def is_auto_reply(body: str, subject: str = "") -> bool:
+    """Return True if the message looks like an auto-reply / out-of-office."""
+    if not body or not body.strip():
+        return True
+
+    # Check subject for auto-reply markers
+    subj_lower = subject.lower().strip()
+    for marker in ("auto:", "out of office:", "unavailable", "vacation:"):
+        if subj_lower.startswith(marker):
+            return True
+
+    # Strip quoted original message (common Gmail reply wrapper: "On Sun, May 3...")
+    stripped = body.strip()
+    on_wrote = re.search(r"^\s*>?\s*On .+ wrote:\s*$", stripped, re.MULTILINE)
+    if on_wrote:
+        stripped = stripped[: on_wrote.start()].strip()
+    # Also strip signature blocks that start with --
+    sig_cut = stripped.rfind("\n-- ")
+    if sig_cut > 0:
+        stripped = stripped[:sig_cut].strip()
+
+    # Very short or single-line non-question → not a real engagement
+    words = [w for w in stripped.split() if len(w) > 1]
+    unique = set(w.lower() for w in words)
+    has_question = "?" in stripped
+    if len(words) < _AUTO_REPLY_MIN_WORDS and not has_question:
+        return True
+    # Flat rejection with no engagement (e.g. "we are not interested, thanks")
+    if len(unique) < _AUTO_REPLY_MIN_UNIQUE_WORDS and not has_question:
+        return True
+
+    # Pattern match
+    for pat in _AUTO_REPLY_PATTERNS:
+        if pat.search(body):
+            return True
+
+    return False
 
 
 def find_warmup_thread_and_messages(
@@ -462,6 +540,34 @@ def promote_warmup_replies(
         after_ms = int(prev.timestamp() * 1000)
         reply = inbound_reply_details(gsvc, partner_email=em, after_ms=after_ms)
         if reply:
+            # Suppress auto-replies so they don't clutter the Prospect Replied state
+            if is_auto_reply(reply.get("body", ""), reply.get("subject", "")):
+                if verbose:
+                    print(f"  auto-reply row {r} {em}: detected, NOT promoting")
+                # Log as DApp Remarks for audit but don't flip status
+                if not dry_run and remarks_ws is not None:
+                    shop_name = smf.cell(row, shop_i) if shop_i is not None else ""
+                    try:
+                        append_dapp_remark_and_apply(
+                            hit_ws=hit_ws,
+                            remark_ws=remarks_ws,
+                            sheet_row=r,
+                            name=shop_name,
+                            ai_status=HIT_STATUS_WARMUP,  # keep current status
+                            remarks=(
+                                f"Auto-reply detected (not a real prospect reply). Not promoted.\n\n"
+                                f"Reply subject: {reply['subject']}\n"
+                                f"Reply date: {reply['date']}\n"
+                                f"Reply body:\n{reply['body']}"
+                            ),
+                            submitted_by="warmup_auto_reply_detected",
+                            submitted_at=reply['date'],
+                            submission_id=str(uuid.uuid4()),
+                        )
+                    except Exception as e:
+                        print(f"  WARNING: auto-reply DApp Remarks append failed for row {r}: {e}")
+                continue  # skip promotion for auto-replies
+
             if verbose:
                 print(f"  promote row {r} {em}: inbound after last send → {HIT_STATUS_REPLIED!r}")
             if not dry_run:
@@ -769,10 +875,22 @@ def create_reply_drafts_for_replied_prospects(
 
 
 def load_warmup_reference_text() -> str:
-    if not _WARMUP_REF.is_file():
+    return _load_file_text(_WARMUP_REF)
+
+
+def load_farm_taste_reference_text() -> str:
+    return _load_file_text(_FARM_TASTE_REF)
+
+
+def load_field_insights_reference_text() -> str:
+    return _load_file_text(_FIELD_INSIGHTS_REF)
+
+
+def _load_file_text(path: Path) -> str:
+    if not path.is_file():
         return ""
     try:
-        t = _WARMUP_REF.read_text(encoding="utf-8").strip()
+        t = path.read_text(encoding="utf-8").strip()
         if len(t) > 8000:
             t = t[:7999] + "…"
         return t
@@ -782,9 +900,21 @@ def load_warmup_reference_text() -> str:
 
 def grok_warmup_system_prompt() -> str:
     ref = load_warmup_reference_text()
+    farm = load_farm_taste_reference_text()
+    insights = load_field_insights_reference_text()
     ref_block = (
         f"Style reference (paraphrase only; do not copy; synthesize tone and structure):\n\n{ref}\n\n"
         if ref
+        else ""
+    )
+    farm_block = (
+        f"Farm & taste profile reference (use specific descriptors, never generic praise):\n\n{farm}\n\n"
+        if farm
+        else ""
+    )
+    insights_block = (
+        f"Field-tested qualitative insights from partner stores (reference when relevant):\n\n{insights}\n\n"
+        if insights
         else ""
     )
     return (
@@ -798,6 +928,14 @@ def grok_warmup_system_prompt() -> str:
         "- **Lead with mission impact:** purchases support **restoration of the Amazon rainforest**; **each bag "
         "plants a new tree**, **directly traceable** via the **unique QR code on that bag** (keep this accurate "
         "and prominent — at least one clear sentence early in the body).\n"
+        "- **Farm & taste story — reference the taste profiles above:** Agroverse sources from multiple "
+        "regenerative farms across the Brazilian Amazon (Oscar's in Bahia, Paulo's in Pará, etc.). "
+        "Each farm has a **distinct taste profile** — use the specific descriptors from the farm "
+        "reference, never generic “high-quality.” **Multiple farms = a feature retailers value**: "
+        "different taste profiles mean different customer experiences. When the store's profile "
+        "suggests ceremonial use, lead with Oscar's (deep European chocolate, buttery). When "
+        "apothecary/earthy, lead with Paulo's (smoky→floral). **Mention 1–2 farms, not all of them.** "
+        "Frame as: offering their customers variety.\n"
         "- **Commercial fit:** say Agroverse is **flexible** and happy with **either** a **consignment-friendly** "
         "retail path **or** **wholesale / bulk** — present them as **parallel options**, not as a contrast "
         "(avoid lines like “while others choose wholesale for margins” or any implication that bulk is mainly "
@@ -825,6 +963,8 @@ def grok_warmup_system_prompt() -> str:
         "  garyjob@agroverse.shop\n"
         "- Subject: specific, warm, not spammy; include shop name if known. Under ~90 characters.\n"
         + ref_block
+        + farm_block
+        + insights_block
     )
 
 
@@ -955,18 +1095,22 @@ def warmup_body_template(shop_name: str) -> str:
     shop = shop_name or "your shop"
     return (
         f"Hi —\n\n"
-        f"I’m Gary with Agroverse (farm-linked ceremonial cacao). I’m reaching out to {shop} because our model ties "
-        f"every sale to **Amazon rainforest restoration**: **each bag plants a new tree**, and the **unique QR code "
-        f"on that bag** links to **direct traceability** for that planting.\n\n"
+        f"I'm Gary with Agroverse. We work with regenerative cacao farms across the Brazilian Amazon — "
+        f"Oscar's Farm in Bahia (deep European-chocolate profile, buttery and smooth) and Paulo's Farm in "
+        f"the heart of the Pará Amazon (smoky, earthy, unfolding into delicate floral notes). Every "
+        f"bag sold plants a new tree, directly traceable via the unique QR code on each bag.\n\n"
         f"30-second proof of the restoration in motion: https://www.instagram.com/p/DJqW8TRtJK3/ — watch on "
         f"your phone, see the actual tree planting and the satellite imagery the QR code unlocks for customers.\n\n"
-        f"We’re **flexible on structure** — **either** **consignment-friendly** retail **or** **wholesale / bulk** "
-        f"works on our side; I’ve attached our **wholesale price list PDF** so you can skim SKUs and tiers, "
-        f"plus **two photos of the packaging** (front and back) so you can picture how it sits on shelf. "
+        f"We're **flexible on structure** — **either** **consignment-friendly** retail **or** **wholesale / bulk** "
+        f"works on our side; I've attached our **wholesale price list PDF** so you can skim SKUs and tiers, "
+        f"plus **two photos of the packaging** (front and back) so you can picture how it sits on shelf.\n\n"
+        f"I'm reaching out to {shop} because we believe offering different taste profiles "
+        f"creates a richer experience for your customers — each farm's cacao is distinct, and variety "
+        f"is what keeps a shelf interesting.\n\n"
         f"For partner-shop shelf photos and the current U.S. stockist list, see "
         f"https://agroverse.shop/wholesale — that's the visual companion to the PDF.\n\n"
-        f"No need to meet in person on my side; happy to answer by email or on a quick call if that’s easier. "
-        f"If you tell me which path you’d rather explore first (consignment vs bulk), I can point you to the "
+        f"No need to meet in person on my side; happy to answer by email or on a quick call if that's easier. "
+        f"If you tell me which path you'd rather explore first (consignment vs bulk), I can point you to the "
         f"lightest next step.\n\n"
         f"Thanks,\n"
         f"Gary\n"

--- a/templates/farm_taste_profiles.md
+++ b/templates/farm_taste_profiles.md
@@ -1,0 +1,47 @@
+# Agroverse farm taste profiles (LLM reference)
+
+Reference for AI-generated outreach emails. Each farm has a distinct taste profile
+— this variety is a feature retailers value, not a complication.
+
+## Farms
+
+### Oscar's Farm — Bahia, Brazil
+- **URL:** https://agroverse.shop/farms/oscar-bahia/index.html
+- **Taste:** Deep, dark European chocolate profile with exceptionally buttery,
+  velvety mouthfeel. Intense chocolate notes with subtle undertones of earth and
+  wood. Smooth, low-acidity finish — ideal for ceremonial use and premium chocolate.
+- **Format:** 200g pre-grated bag (scoop-and-stir, no tools needed).
+
+### Paulo's La do Sitio Farm — Pará, Amazon Rainforest
+- **URL:** https://agroverse.shop/farms/paulo-la-do-sitio-para/index.html
+- **Taste:** Bold smoky and tobaccoy notes that unfold into a lush green floral
+  profile. Rich and earthy, transforming from bold earthiness to delicate floral
+  notes. Award-winning regenerative cacao from the heart of the Amazon.
+- **Format:** 200g pre-grated bag (scoop-and-stir, no tools needed).
+
+### Fazenda Santa Ana — Bahia, Brazil
+- **URL:** https://agroverse.shop/farms/fazenda-santa-ana-bahia/
+- **Note:** Second Bahia farm, different micro-climate, different flavor profile.
+  Also pre-grated 200g format.
+
+### Vivi's Jesus Do Deus Farm — Itacaré, Bahia
+- **URL:** https://agroverse.shop/farms/vivi-jesus-do-deus-itacare/index.html
+- **Note:** Top-grade organic cacao from cabruca agroforestry. Former cattle ranch
+  transformed into regenerative cacao forest.
+
+## How to use this in emails
+
+- Do NOT list every farm — pick 1-2 that fit the shop's vibe (e.g. Oscar's =
+  ceremonial / premium chocolate shops; Paulo's = adventurous / earthy /
+  apothecary shops).
+- Frame multiple farms as **different taste experiences**, not competing products.
+  Retailers have told us: "it's OK to have cacao from different regions in the
+  shop since each is different" (Lumin Earth Apothecary).
+- Mention the **pre-grated, scoop-and-stir** format — it removes friction for the
+  end customer (no grater, no special tools, no learning curve).
+- The **cacao tea** is also available from Paulo's Farm (bulk interest has been
+  noted by multiple store owners — underserved market).
+- If the shop hosts circles / ceremonies, lead with Oscar's (ceremonial-grade)
+  and mention that practitioners prefer pre-grated for portioning.
+- Never claim farms are "the best" or "the finest" — use the specific taste
+  descriptors above instead. Generic praise does not land with retailers.

--- a/templates/field_insights_outreach.md
+++ b/templates/field_insights_outreach.md
@@ -1,0 +1,95 @@
+# Qualitative insights from field visits & Partnered stores (LLM reference)
+
+Extracted from DApp Remarks and field-agent visits to Partnered stores. Use as
+context for drafting outreach emails — reference specific insights when they
+match the store's profile or the prospect's reply.
+
+## What lands with retailers
+
+### Emotional hooks that convert
+- **"A single sale plants a tree."** This line has visibly moved store owners
+  (Liza at RAVEN things collected). Lead with this early in the body.
+- **Traceability.** The unique QR code on each bag that links to tree-planting
+  data resonates — it's concrete proof, not vague mission language.
+- **30-second Instagram reel** (https://www.instagram.com/p/DJqW8TRtJK3/) showing
+  actual tree planting + satellite imagery the QR code unlocks. Frame as "watch
+  on your phone, 30 seconds."
+
+### Taste profiles = feature, not complication
+- Multiple farms with different taste profiles is a **selling point**, not
+  confusion. Lumin Earth Apothecary explicitly said: "it's OK to have cacao from
+  different regions in the shop since each is different."
+- Taste-profile language matters. Descriptors from the San Francisco cacao
+  circle (Christine and the chocolate tears) have been used successfully:
+  Oscar's = deep European chocolate, buttery mouthfeel. Paulo's = smoky,
+  tobaccoy, unfolding floral. Use these specific terms, never generic "it's
+  high-quality."
+- Frame as **different experiences** for customers, not competing SKUs.
+
+### The multi-farm story
+- Agroverse supports multiple regenerative farms across the Brazilian Amazon
+  (Bahia, Pará, Itacaré). This means retailers can offer **variety** — a
+  customer who connects with Oscar's deep chocolate profile may also love Paulo's
+  smoky-to-floral journey.
+- Several Partnered stores already stock our cacao alongside other brands
+  (Kakao Laboratory, Pacha Mama) — the presence of other cacao on their shelf
+  is not a blocker.
+
+### Consignment framing
+- The #1 objection about consignment: "are you just starting out?" The
+  field-tested response: "We've been operating for years. Consignment is how
+  we onboard shopkeepers through turbulent economic conditions."
+- Never frame consignment as "we're new" or "testing the market." Frame it as a
+  deliberate partner-onboarding strategy.
+- QR-code checkout demo (scan-to-pay, transparent $17 split) has repeatedly
+  broken through skepticism. Do this live when possible. In email, link to
+  https://agroverse.shop/wholesale for shelf-proof and stockist examples.
+
+### Price guidance
+- Cost: $17/bag. Suggested retail: $25–$35.
+- Walk through the split math transparently — retailers appreciate it.
+
+## What retailers worry about / objections
+
+| Concern | Field-tested response |
+|---------|----------------------|
+| "Why consignment?" | Years of operation; consignment = deliberate partner onboarding for turbulent economy. |
+| "We already have a cacao supplier" | Different farms, different taste profiles — our cacao complements, doesn't compete. |
+| "Allergies" | All cacao is lab-tested; offer to share lab reports. Field-tested: this defuses the conversation. |
+| "Payment reliability" | QR code traceability + transparent split. Demo the flow. |
+| "Is it produced in the US?" | Honest: Brazilian Amazon, name the farms. |
+| "Other stores nearby?" | Give honest answer using the dapp store map. |
+| "How to prepare?" | Pre-grated — scoop into hot water/milk, stir. No grater, no tools, no learning curve. |
+
+## Circle-hosting stores (high-intent signal)
+
+- Stores that host women's circles, moon circles, sound baths, cacao ceremonies,
+  or breathwork are demonstrably higher-conversion prospects (Lumin Earth, The
+  Way Home Shop both explicitly mention circles).
+- For these stores: lead with the ceremonial aspect. Mention that Oscar's Farm
+  cacao is ceremonial-grade, pre-grated for easy portioning at group ceremonies.
+- The correlation "Hosts Circles=Yes" → higher sell-through is a working
+  hypothesis tracked at `OPEN_FOLLOWUPS.md` ("Validate the circle-hosting →
+  cacao-velocity hypothesis").
+
+## What to avoid in outreach
+
+- Don't say "Farm X's cacao is our flagship / our best." Present them as
+  distinct choices, not a ranked list.
+- Don't assume the store has shelf space for cacao — ask, don't tell.
+- Don't frame the Instagram reel as a marketing video — frame it as a 30-second
+  mission proof (tree planting + QR traceability).
+- Don't use words like "premium," "top-shelf," or "highest quality" without the
+  specific taste descriptor. Generic superlatives erode trust.
+- Don't bring up bulk/industrial logistics in a first-touch retail email.
+- Don't improvise governmental / political claims about the Amazon. Say "I'll
+  send you the whitepaper" if pressed.
+
+## Cacao tea opportunity
+
+- Multiple store owners (Pilar's Wellness Collective, Secrets of the Garden)
+  have independently asked about bulk cacao tea and said they cannot find
+  suppliers.
+- When the store is tea-forward or herbal-forward, mention cacao tea
+  availability alongside ceremonial cacao. It may be a larger wedge than
+  ceremonial cacao for some regions.


### PR DESCRIPTION
## Summary
- Adds `is_auto_reply()` detection to filter out-of-office/auto-responder messages from warm-up reply promotion — prevents auto-replies like Esalen's and Elliott's from being promoted to "AI: Prospect replied"
- Creates two new Grok prompt reference files: `farm_taste_profiles.md` (Oscar's/Paulo's/Fazenda Santa Ana/Vivi's with specific taste descriptors) and `field_insights_outreach.md` (field-tested conversion patterns, objection responses, things to avoid)
- Wires both reference files into the warm-up Grok system prompt so drafts now include specific farm names and taste-profile language instead of generic "ceremonial cacao"
- Updates the fallback warm-up template to name Oscar's (deep European chocolate, buttery) and Paulo's (smoky→floral)
- Adds `--reply-promotion-only` mode to `suggest_manager_followup_drafts.py` to detect inbound replies to follow-up emails (Manager Follow-up + Bulk Info Requested states)
- Adds follow-up reply detection step to the hourly `email-agent-sync-followup.yml` workflow

## Testing
- Both scripts compile cleanly
- Dry-run compatible — all reply detection paths log to DApp Remarks without changing status for review visibility