### PR TITLE
feat(outreach): wire farm taste profiles + field insights into reply and follow-up prompts

### DIFF
--- a/scripts/suggest_manager_followup_drafts.py
+++ b/scripts/suggest_manager_followup_drafts.py
@@ -107,6 +107,21 @@ GROK_ENDPOINT = "https://api.x.ai/v1/chat/completions"
 DEFAULT_GROK_MODEL = "grok-3"
 DEFAULT_GROK_MAX_MESSAGES = 50
 DEFAULT_GROK_MAX_CONTEXT_CHARS = 120_000
+
+_FARM_TASTE_REF = _REPO / "templates" / "farm_taste_profiles.md"
+_FIELD_INSIGHTS_REF = _REPO / "templates" / "field_insights_outreach.md"
+
+
+def _load_ref_text(path: Path) -> str:
+    if not path.is_file():
+        return ""
+    try:
+        t = path.read_text(encoding="utf-8").strip()
+        if len(t) > 8000:
+            t = t[:7999] + "…"
+        return t
+    except OSError:
+        return ""
 PER_MESSAGE_BODY_CAP = 14_000
 
 GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
@@ -883,6 +898,18 @@ def fetch_conversation_history(
 
 
 def grok_system_prompt() -> str:
+    farm = _load_ref_text(_FARM_TASTE_REF)
+    insights = _load_ref_text(_FIELD_INSIGHTS_REF)
+    farm_block = (
+        f"Farm & taste profile reference (use specific descriptors, never generic praise):\n\n{farm}\n\n"
+        if farm
+        else ""
+    )
+    insights_block = (
+        f"Field-tested qualitative insights from partner stores (reference when relevant):\n\n{insights}\n\n"
+        if insights
+        else ""
+    )
     return (
         "You draft polished, send-ready follow-up emails for Gary at Agroverse — ceremonial cacao, "
         "retail / consignment (friendly terms). The merchant should need only light editing.\n"
@@ -890,12 +917,18 @@ def grok_system_prompt() -> str:
         '- Output **only** valid JSON: one object with keys "subject" and "body" (plain text, use \\n for newlines).\n'
         "- No markdown fences, no preamble, no placeholders like [Name] — use real details from context or a natural generic greeting (e.g. Hi —, or Hello —).\n"
         "- **In-person meetings / another store visit to meet:** Do **not** propose or invite an in-person meeting, a return visit to the shop to connect, "
-        "\"stopping by\" again, or \"circling back\" in person. Gary often passes through and is **not** reliably available to come back for a sit-down. "
+        "'stopping by' again, or 'circling back' in person. Gary often passes through and is **not** reliably available to come back for a sit-down. "
         "Prefer: **reply by email**, a **scheduled phone or video call**, or **delivery / logistics / paperwork** next steps — never frame the ask as meeting them on-site.\n"
         "- **Who to address:** If Hit List notes, DApp remarks, or the **email thread** show that **staff** provided the **owner**, **buyer**, **decision-maker**, "
         "or their **name** or **this email** as the right person to speak with, the message must speak **to that person** (salutation + body). "
         "Do **not** write as if the front-desk or staff contact is the primary reader when context clearly routes follow-up to **owner/buyer** (you may still "
         "thank staff briefly if natural).\n"
+        "- **Farm & taste story — reference the taste profiles above:** Agroverse sources from multiple "
+        "regenerative farms across the Brazilian Amazon. When relevant to the follow-up (samples were "
+        "dropped, taste was mentioned, store owner asked about products), name 1–2 specific farms with "
+        "their taste descriptors. Different farms = different taste profiles = variety customers value. "
+        "If the DApp Remarks mention a farm by name, use that farm. If samples of both Oscar's and "
+        "Paulo's were dropped, mention both and their distinct profiles.\n"
         "- **Body** structure: brief warm opening → 1–2 concrete sentences tying to **visit/DApp remarks** and/or **email thread** → "
         "one clear **call to action** (email reply with timing, **phone or video** call, samples, or paperwork — **never** in-person meetup) → "
         "short **signature block** on separate lines:\n"
@@ -905,6 +938,8 @@ def grok_system_prompt() -> str:
         "- Sound human and specific; weave in **DApp visit remarks** and thread facts when provided. Do not invent numbers, legal terms, or deals not in the context.\n"
         "- Subject: specific and scannable (shop name + short hook), not spammy. Under ~90 characters.\n"
         "- Length: about 120–220 words in body unless context demands shorter.\n"
+        + farm_block
+        + insights_block
     )
 
 
@@ -1049,8 +1084,14 @@ def draft_body_template(shop_name: str, snippets: list[str]) -> str:
     lines = [
         f"Hi —",
         "",
-        f"Following up on Agroverse ceremonial cacao and next steps for {shop} (consignment-friendly terms). "
-        f"I’m happy to answer questions by email or on a quick call — and to line up samples or simple paperwork — "
+        f"Following up on the ceremonial cacao samples and next steps for {shop} "
+        f"(consignment-friendly terms). The samples you tried are from two distinct farms: "
+        f"Oscar's Farm in Bahia (deep European chocolate, buttery and smooth — ceremonial-grade) "
+        f"and Paulo's Farm in the Pará Amazon (smoky, earthy, unfolding into delicate floral notes). "
+        f"Each farm's cacao has a unique taste profile, so customers get a different experience "
+        f"with each bag — variety is what keeps a shelf interesting.",
+        "",
+        f"I'm happy to answer questions by email or on a quick call — and to line up samples or simple paperwork — "
         f"without needing another in-person meeting on my side.",
         "",
     ]

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -333,6 +333,18 @@ def find_warmup_thread_and_messages(
 
 
 def grok_reply_system_prompt() -> str:
+    farm = load_farm_taste_reference_text()
+    insights = load_field_insights_reference_text()
+    farm_block = (
+        f"Farm & taste profile reference (use specific descriptors, never generic praise):\n\n{farm}\n\n"
+        if farm
+        else ""
+    )
+    insights_block = (
+        f"Field-tested qualitative insights from partner stores (reference when relevant):\n\n{insights}\n\n"
+        if insights
+        else ""
+    )
     return (
         "You draft a **reply** to a prospect who responded to Gary's warm-up email about "
         "Agroverse ceremonial cacao. The merchant should need only light editing before sending.\n"
@@ -346,6 +358,11 @@ def grok_reply_system_prompt() -> str:
         "- **Lead with mission impact** when relevant: purchases support **restoration of the Amazon "
         "rainforest**; **each bag plants a new tree**, **directly traceable** via the **unique QR code "
         "on that bag**.\n"
+        "- **Farm & taste story — reference the taste profiles above:** If the prospect's reply is "
+        "positive or asks questions, use the opportunity to **name 1–2 specific farms** with their "
+        "taste descriptors (e.g. Oscar's deep European chocolate profile, Paulo's smoky-to-floral "
+        "journey). Different taste profiles = variety their customers will appreciate. **Do not** "
+        "say one farm is better than another — present them as distinct experiences.\n"
         "- **Commercial fit:** Agroverse is **flexible** and happy with **either** a "
         "**consignment-friendly** retail path **or** **wholesale / bulk** — present them as "
         "**parallel options**, not as a contrast.\n"
@@ -354,6 +371,10 @@ def grok_reply_system_prompt() -> str:
         "- If they ask about **pricing**, **paste vs block**, **licensing**, **shelf fit**, "
         "**samples**, or **delivery**, answer honestly using Agroverse's actual offerings. "
         "Do not invent prices, SKUs, or terms not in the context.\n"
+        "- If they ask about **samples**: mention we're happy to send ceremonial cacao samples. "
+        "The cacao is **pre-grated** (scoop-and-stir — no grater, no tools, no learning curve for "
+        "their customer). We can send Oscar's (ceremonial-grade) and Paulo's (smoky/floral) so "
+        "they can taste the difference.\n"
         "- **Body** ~120–220 words unless the reply naturally needs more. "
         "End with a short signature block:\n"
         "  Gary\n"
@@ -361,6 +382,8 @@ def grok_reply_system_prompt() -> str:
         "  garyjob@agroverse.shop\n"
         "- Subject: prepend 'Re:' if the original subject is known; otherwise a natural reply subject. "
         "Keep it scannable and under ~90 characters.\n"
+        + farm_block
+        + insights_block
     )
 
 
@@ -766,8 +789,14 @@ def create_reply_drafts_for_replied_prospects(
                 subj = latest_subj if latest_subj.lower().startswith("re:") else f"Re: {latest_subj}"
                 body = (
                     f"Hi —\n\n"
-                    f"Thanks for getting back to me. I'd love to keep the conversation going — "
-                    f"happy to answer any questions or jump on a quick call whenever works for you.\n\n"
+                    f"Thanks for getting back to me. Happy to answer your questions — "
+                    f"our cacao comes from multiple regenerative farms across the Brazilian Amazon "
+                    f"(Oscar's Farm in Bahia — deep European chocolate, buttery and smooth; "
+                    f"Paulo's Farm in the Pará Amazon — smoky, earthy, unfolding into floral notes). "
+                    f"Different taste profiles mean different experiences for your customers, "
+                    f"and we're flexible on either consignment or wholesale.\n\n"
+                    f"Let me know how you'd like to move forward — happy to send samples, "
+                    f"talk pricing, or set up a quick call.\n\n"
                     f"Gary\n"
                     f"Agroverse | ceremonial cacao for retail\n"
                     f"garyjob@agroverse.shop\n"
@@ -778,8 +807,14 @@ def create_reply_drafts_for_replied_prospects(
             subj = latest_subj if latest_subj.lower().startswith("re:") else f"Re: {latest_subj}"
             body = (
                 f"Hi —\n\n"
-                f"Thanks for getting back to me. I'd love to keep the conversation going — "
-                f"happy to answer any questions or jump on a quick call whenever works for you.\n\n"
+                f"Thanks for getting back to me. Happy to answer your questions — "
+                f"our cacao comes from multiple regenerative farms across the Brazilian Amazon "
+                f"(Oscar's Farm in Bahia — deep European chocolate, buttery and smooth; "
+                f"Paulo's Farm in the Pará Amazon — smoky, earthy, unfolding into floral notes). "
+                f"Different taste profiles mean different experiences for your customers, "
+                f"and we're flexible on either consignment or wholesale.\n\n"
+                f"Let me know how you'd like to move forward — happy to send samples, "
+                f"talk pricing, or set up a quick call.\n\n"
                 f"Gary\n"
                 f"Agroverse | ceremonial cacao for retail\n"
                 f"garyjob@agroverse.shop\n"


### PR DESCRIPTION
## Summary
Builds on #111 by wiring the new farm taste profiles and field insights reference files into the **reply** and **follow-up** Grok system prompts (not just warm-up). Previously only the warm-up first-touch drafts benefited from farm-specific language.

### Changes
- **Reply Grok prompt** (`grok_reply_system_prompt`): Now references `farm_taste_profiles.md` + `field_insights_outreach.md`. Added explicit rule to name 1-2 farms with taste descriptors when the prospect's reply is positive. Added sample-offer language noting pre-grated format (scoop-and-stir, no learning curve).
- **Follow-up Grok prompt** (`grok_system_prompt`): Wired both reference files. Added rule to reference specific farms when DApp Remarks mention them or when samples of both Oscar's and Paulo's were dropped.
- **Reply fallback template**: Updated from generic "Thanks for getting back" to include Oscar's (deep European chocolate) and Paulo's (smoky→floral) with "different taste profiles = different customer experiences"
- **Follow-up fallback template**: Updated to name both farms and their taste descriptors

All three draft types (warm-up, reply, follow-up) now benefit from the richer product story.

### Operations
- Discarded 5 pending drafts in Gmail + marked as discarded in Email Agent Drafts sheet
- Moved Seagrape Apothecary + Care Rituals to Rejected (both definitively declined)
- Next daily cron will regenerate Devine Wellness, Untamed Fire, and Third Eye drafts with richer context