### PR TITLE
fix(bulk): capture thread_id and body on bulk info drafts

### DIFF
--- a/scripts/suggest_bulk_info_drafts.py
+++ b/scripts/suggest_bulk_info_drafts.py
@@ -306,6 +306,7 @@ def main() -> None:
         draft_id = draft.get("id", "") or ""
         msg = draft.get("message") or {}
         msg_id = msg.get("id", "") or ""
+        thread_id = msg.get("threadId", "") or ""
 
         if label_id and msg_id:
             try:
@@ -338,6 +339,9 @@ def main() -> None:
             notes,
             "0",
             "0",
+            msg_id,
+            thread_id,
+            body,
         ]
         created_rows.append(row)
         n_made += 1


### PR DESCRIPTION
Bulk info draft creation was missing msg_id, thread_id, and body columns. Added to match the schema used by warmup and follow-up scripts.