### PR TITLE
fix(hit-list): refuse to promote rows with placeholder filler@godaddy.com

### DIFF
--- a/scripts/hit_list_promote_status.py
+++ b/scripts/hit_list_promote_status.py
@@ -67,6 +67,13 @@ STATUS_WARMUP = "AI: Warm up prospect"
 STATUS_CONTACT_FORM = "AI: Contact Form found"
 STATUS_MANAGER_FOLLOWUP = "Manager Follow-up"
 
+# Placeholder address written by hit_list_enrich_contact when a website crawl
+# returns no real address. Treat as "no email present" for promotion gating —
+# otherwise rows get promoted to AI: Warm up prospect with no working address,
+# the warmup draft script then can't send, and the row sits in the bucket
+# forever as an unactionable false-positive (see audit 2026-05-09).
+FILLER_EMAIL = "filler@godaddy.com"
+
 PLACE_ID_IN_NOTES = re.compile(
     r"(?i)place[_\s-]*id\s*:\s*([A-Za-z0-9_-]{12,})",
 )
@@ -250,6 +257,10 @@ def run_email_to_warmup(
         email = (cells[i_email] or "").strip()
         if not email:
             continue
+        if email.lower() == FILLER_EMAIL:
+            # Placeholder address — promotion would land in AI: Warm up prospect
+            # with no actionable email; warmup draft would fail.
+            continue
         if shop_filter and shop_filter.strip().lower() not in cells[i_shop].lower():
             continue
         candidates.append((ri, cells))
@@ -288,6 +299,9 @@ def run_email_to_warmup(
         live_email = (ws.cell(ri, i_email + 1).value or "").strip()
         if not live_email:
             print(f"  skip row {ri} {shop!r}: Email now empty", flush=True)
+            continue
+        if live_email.lower() == FILLER_EMAIL:
+            print(f"  skip row {ri} {shop!r}: Email is placeholder {FILLER_EMAIL!r}", flush=True)
             continue
         print(f"  row {ri} {shop!r} email={live_email!r}", flush=True)
         if dry_run:


### PR DESCRIPTION
## Summary

- \`hit_list_promote_status.py\` now skips rows whose \`Email\` is the literal placeholder \`filler@godaddy.com\` (written by \`hit_list_enrich_contact\` when a website crawl yields no real address).
- Both promotion paths guarded: candidate collection (line 250) and post-lock live re-check (line 288).

## Why

Three rows currently in \`AI: Warm up prospect\` carry \`Email = filler@godaddy.com\` (Mossy Tonic row 373, Cascadia Crystals row 540, Avebury Mystikals row 605). The \`email-to-warmup\` promoter's previous check was \`if not email: continue\` — a literal-empty test. Placeholder addresses cleared the gate.

Effects observed downstream:
- The warm-up draft script either skips them silently OR creates a Gmail draft addressed to \`filler@godaddy.com\` that wedges into the same thread as other stores sharing the placeholder. Existing \`scripts/output/warmup_batch_preview/warmup_preview_*.html\` artifacts show this happening for Pan's Apothika (multiple Hit List rows joined into one draft body, all addressed to \`filler@godaddy.com\`).
- The advisory funnel showed these rows as \"AI: Warm up prospect\" (operator-actionable bucket), inflating the apparent backlog.

Audit chain that surfaced this: 2026-05-09 advisory verification — true AU=0 warm-up prospects break down 3 placeholder-email, 1 duplicate Hit List row, 1 legitimately uncontacted new location.

## Test plan

- [x] \`python3 -c \"import ast; ast.parse(open('scripts/hit_list_promote_status.py').read())\"\` — syntax clean.
- [ ] \`python3 scripts/hit_list_promote_status.py email-to-warmup --limit 5 --dry-run\` — confirm no row with \`Email == filler@godaddy.com\` appears in the candidate list.
- [ ] After merge, the next hourly cron run leaves the 3 placeholder-email rows at \`AI: Email found\` instead of advancing them.

## Follow-ups

- \`suggest_warmup_prospect_drafts.py\` should ALSO refuse to draft against \`filler@godaddy.com\` — preview HTML proves drafts were being created. Tracking as a separate PR so this one stays scoped.
- Consider demoting the existing 3 affected rows (373, 540, 605) back to \`AI: Enrich with contact\` so they re-enter the email-discovery queue.

## Related

- Companion PR in \`tokenomics\` hardens \`pipeline_metrics_snapshot\` against the TIME-cast cell bug that caused these rows to look like \"50 of 79 with zero sends\" in \`ADVISORY_SNAPSHOT.md\`.