### PR TITLE
sell_through: exclude non-retail partner types from trees/mo accounting

### DIFF
--- a/scripts/sync_sell_through_report.py
+++ b/scripts/sync_sell_through_report.py
@@ -121,11 +121,23 @@ def build_sell_through_report() -> dict:
     # Per-partner list
     partners_list: list[dict] = []
 
+    # Trees-financed / sell-through accounting counts ONLY retail-distribution
+    # partner types — partners whose inventory leaving their facility represents
+    # an actual end-consumer sale (Consignment + Wholesale). Inventory leaving
+    # a warehouse Operator (e.g. Matheus in Ilhéus) or a Freight Provider
+    # (e.g. Omega Services) is in-transit movement, not sell-through, and
+    # double-counts trees if included. See agentic_ai_context/
+    # PARTNER_CHECK_IN_IMPLEMENTATION.md §"Dual-use" for the partner_type taxonomy.
+    RETAIL_PARTNER_TYPES = {"Consignment", "Wholesale"}
+
     all_ids = set(sales_by_partner) | set(restocks_by_partner)
     for pid in all_ids:
         meta = partner_metadata.get(pid, {})
         location = meta.get("location", "")
         if not _is_usa(location):
+            continue
+        ptype = meta.get("partner_type", "Consignment")
+        if ptype not in RETAIL_PARTNER_TYPES:
             continue
 
         partner_total_s = 0.0


### PR DESCRIPTION
Matheus (Operator) and Omega Services (Freight Provider) now sit in the Partner Check-in surface as legit follow-up targets. They MUST be excluded from trees/mo totals on truesight.me — inventory leaving their facility is in-transit movement to retail distribution, not sell-through. Including them would double-count trees.

Adds a partner_type allow-list (Consignment | Wholesale) alongside the existing USA-location filter at the per-partner aggregation loop. Summary totals stay internally consistent.

**Operator next step after merge:** re-run `scripts/sync_sell_through_report.py` and commit the refreshed `sell-through-report.json` to the agroverse-inventory repo.

Companion defensive JS filter to land in truesight_me so a stale JSON snapshot (from before the script runs) doesn't briefly leak non-retail entries.