### PR TITLE
ci: quote step name with embedded colons (YAML parse fix)

### DIFF
--- a/.github/workflows/email-agent-sync-followup.yml
+++ b/.github/workflows/email-agent-sync-followup.yml
@@ -78,7 +78,7 @@ jobs:
             python scripts/sync_email_agent_followup.py --backfill-body-plain --backfill-only
           fi
 
-      - name: Promote warm-up replies (AI: Warm up prospect → AI: Prospect replied)
+      - name: "Promote warm-up replies (AI: Warm up prospect → AI: Prospect replied)"
         env:
           GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
           INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}


### PR DESCRIPTION
GitHub Actions was rejecting the workflow with "Invalid workflow file" on line 81. The step name `Promote warm-up replies (AI: Warm up prospect → AI: Prospect replied)` has unquoted colons inside the parens; YAML parses each `AI: ` as a nested mapping separator. Wrapping the value in double quotes fixes the parse. Verified locally with `yaml.safe_load`.