### PR TITLE
ci: fix beer-hall-digest-daily step indent (YAML parse fix)

### DIFF
--- a/.github/workflows/beer-hall-digest-daily.yml
+++ b/.github/workflows/beer-hall-digest-daily.yml
@@ -117,7 +117,7 @@ jobs:
           python3 scripts/generate_beer_hall_preview.py --no-stdout --output /tmp/beer_hall_preview.md
           ls -la /tmp/beer_hall_preview.md
 
-       - name: Draft Message 1 + Message 2 via BigModel GLM-4.6
+      - name: Draft Message 1 + Message 2 via BigModel GLM-4.6
         working-directory: repos/market_research
         env:
           BIGMODEL_CN_API: ${{ secrets.BIGMODEL_CN_API }}


### PR DESCRIPTION
Line 120's `Draft Message 1 + Message 2 via BigModel GLM-4.6` step was indented at 7 spaces instead of 6, breaking the steps list parse. GitHub flagged it at line 36 (the `steps:` header) but the actual issue was the mis-indented child. Dropped the leading space; verified with `yaml.safe_load`.