### PR TITLE
refactor(scripts): look up Agroverse Partners by gid

### DIFF
--- a/scripts/scrape_partner_addresses.py
+++ b/scripts/scrape_partner_addresses.py
@@ -76,7 +76,11 @@ def extract_address_from_html(html):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--sheet', required=True, help='Main Ledger spreadsheet ID')
-    ap.add_argument('--partners-tab', dest='partners_tab', default='Agroverse Partners')
+    ap.add_argument('--partners-tab', dest='partners_tab', default=None,
+                    help='Partners tab name (legacy). When omitted, looks up by --partners-gid.')
+    ap.add_argument('--partners-gid', dest='partners_gid', type=int, default=1983902109,
+                    help='Partners tab gid (stable across renames). Default is the current '
+                         'Main Ledger partners tab; only override for testing alternate workbooks.')
     ap.add_argument('--base-url', default='https://agroverse.shop/partners/')
     ap.add_argument('--refresh-existing', action='store_true')
     ap.add_argument('--only', help='Comma-separated partner_id list to limit updates')
@@ -106,7 +110,13 @@ def main():
         return 1
 
     sh = gc.open_by_key(args.sheet)
-    ws = sh.worksheet(args.partners_tab)
+    if args.partners_tab:
+        ws = sh.worksheet(args.partners_tab)
+    else:
+        ws = sh.get_worksheet_by_id(args.partners_gid)
+        if ws is None:
+            print(f'Partners tab not found by gid {args.partners_gid}', file=sys.stderr)
+            return 1
 
     rows = ws.get_all_values()
     if not rows:

--- a/scripts/sync_agroverse_store_inventory.py
+++ b/scripts/sync_agroverse_store_inventory.py
@@ -40,7 +40,13 @@ MAIN_SPREADSHEET_ID = "1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU"
 SKUS_SHEET_NAME = "Agroverse SKUs"
 CURRENCIES_SHEET_NAME = "Currencies"
 CONTRIBUTORS_SHEET_NAME = "Contributors contact information"
-PARTNERS_SHEET_NAME = "Agroverse Partners"
+PARTNERS_SHEET_NAME = "Agroverse Partners"  # display name only; the gid below is the stable key
+# Look up the partners tab by gid (stable) — the display name is queued for
+# rename to "DAO Partners" (see agentic_ai_context/OPEN_FOLLOWUPS.md) since
+# rows now include Operator/Supplier/Freight Provider entries beyond just
+# Agroverse retail. Other gid lookups in this file should follow this
+# pattern as they migrate.
+PARTNERS_SHEET_GID = 1983902109
 OFFCHAIN_ASSET_LOCATION_SHEET_NAME = "offchain asset location"
 SHIPMENT_LEDGER_SHEET_NAME = "Shipment Ledger Listing"
 BALANCE_SHEET_NAME = "Balance"
@@ -287,7 +293,9 @@ def calculate_sku_inventory(
 def read_partners_by_contributor(sh: gspread.Spreadsheet) -> dict[str, list[str]]:
     """Map contributor_contact_id -> [partner_id, ...] from Agroverse Partners."""
     try:
-        ws = sh.worksheet(PARTNERS_SHEET_NAME)
+        ws = sh.get_worksheet_by_id(PARTNERS_SHEET_GID)
+        if ws is None:
+            return {}
     except Exception:
         return {}
     rows = _gspread_retry(lambda: ws.get_all_values())

--- a/scripts/sync_partners_velocity.py
+++ b/scripts/sync_partners_velocity.py
@@ -200,7 +200,11 @@ def read_partner_metadata(sh: gspread.Spreadsheet) -> dict[str, dict[str, str]]:
     unset / unknown values default to `Consignment` per the 2026-04-27
     operator-defined default.
     """
-    ws = sh.worksheet(inv.PARTNERS_SHEET_NAME)
+    ws = sh.get_worksheet_by_id(inv.PARTNERS_SHEET_GID)
+    if ws is None:
+        raise SystemExit(
+            f"Partners sheet (gid {inv.PARTNERS_SHEET_GID}) not found in workbook"
+        )
     rows = inv._gspread_retry(lambda: ws.get_all_values())
     if not rows:
         return {}


### PR DESCRIPTION
## Summary

Phase 1 of the rename migration logged in [agentic_ai_context OPEN_FOLLOWUPS](https://github.com/TrueSightDAO/agentic_ai_context/blob/main/OPEN_FOLLOWUPS.md). Switches the three market_research scripts that read the Main Ledger \`Agroverse Partners\` tab to look up by gid (\`1983902109\`) so the eventual tab rename is a safe no-op.

- \`sync_agroverse_store_inventory.py\` — adds \`PARTNERS_SHEET_GID\`, \`read_partners_by_contributor()\` uses \`get_worksheet_by_id\`.
- \`sync_partners_velocity.py\` — re-exports via \`inv.PARTNERS_SHEET_GID\`.
- \`scrape_partner_addresses.py\` — \`--partners-tab\` is now optional; default is gid lookup via new \`--partners-gid\` (default \`1983902109\`).

## Test plan

- [ ] Spot-run \`sync_agroverse_store_inventory.py\` against the real workbook and confirm partner inventory aggregation still emits the same partner_id keys.
- [ ] Spot-run \`sync_partners_velocity.py\` against the real workbook and confirm \`partners-velocity.json\` numbers match the last refresh.

Sister PRs (same migration, other repos):
- dao_client: TrueSightDAO/dao_client#29
- tokenomics: pending