### PR TITLE
refactor(extract_partner_addresses): look up by gid

### DIFF
--- a/scripts/extract_partner_addresses_from_repo.py
+++ b/scripts/extract_partner_addresses_from_repo.py
@@ -71,7 +71,11 @@ def extract_from_html_file(html_path: Path) -> str | None:
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--sheet', required=True)
-    ap.add_argument('--partners-tab', dest='partners_tab', default='Agroverse Partners')
+    ap.add_argument('--partners-tab', dest='partners_tab', default=None,
+                    help='Partners tab name (legacy). When omitted, looks up by --partners-gid.')
+    ap.add_argument('--partners-gid', dest='partners_gid', type=int, default=1983902109,
+                    help='Partners tab gid (stable across renames). Default is the current '
+                         'Main Ledger partners tab; only override for testing alternate workbooks.')
     ap.add_argument('--only', help='Comma-separated partner_id list to limit updates')
     ap.add_argument('--refresh-existing', action='store_true')
     ap.add_argument('--dry-run', action='store_true')
@@ -118,7 +122,13 @@ def main():
     creds = Credentials.from_service_account_file(sa_path, scopes=['https://www.googleapis.com/auth/spreadsheets'])
     gc = gspread.authorize(creds)
     sh = gc.open_by_key(args.sheet)
-    ws = sh.worksheet(args.partners_tab)
+    if args.partners_tab:
+        ws = sh.worksheet(args.partners_tab)
+    else:
+        ws = sh.get_worksheet_by_id(args.partners_gid)
+        if ws is None:
+            print(f'Partners tab not found by gid {args.partners_gid}', file=sys.stderr)
+            return 1
 
     rows = ws.get_all_values()
     if not rows:


### PR DESCRIPTION
Final cleanup before the queued tab rename. Mirrors the `--partners-gid` pattern from #128.