### PR TITLE
Dual Tech Summit 2026 — Agroverse cacao publicity proposal (Claude draft)

### DIFF
--- a/dualtechsummitjune26/proposal_claude.md
+++ b/dualtechsummitjune26/proposal_claude.md
@@ -1,0 +1,127 @@
+# Dual Tech Summit 2026 — Agroverse cacao: publicity proposal
+
+**Author:** Claude (Anthropic) — Agentic AI CMO consult (Seth Godin lens)
+**Date:** 2026-05-24
+**Status:** DRAFT v0.1 — for Gary's review
+**Trigger:** Ken offered to make Agroverse ceremonial cacao available at the event.
+
+**Event:** SVH Capital Presents — Dual Tech Summit 2026
+**When:** June 2026 *(exact date TBC — event slug reads `june26`; confirm with Ken)*
+**Where:** War Memorial Veterans Building, 401 Van Ness Ave, San Francisco
+**Hosts / presenters:** SVH Capital · Orbis86 Events · OffChain Global · Soniya, Steven Echtman, John Gibson, Patrick Eibl
+**Theme:** Dual-use technology — AI, robotics, cyber, space — bridging commercial and defense/public sectors
+**Audience:** Founders, VCs, military veterans, defense/public-sector professionals, tech innovators, investors
+**Format:** Panels, pitch competition, exhibition demo tables, ClawCamp workshop
+**Listing:** https://luma.com/dualtechsummitjune26
+
+---
+
+## 1. Recommendation in one paragraph
+
+Do **not** treat this as a retail/wellness moment — the room is wrong for that, and a sales-pitch posture would violate our register. Treat it as a **provenance-tech demonstration** to an audience that natively cares about supply-chain integrity and verifiable origin. The cacao is the *artifact*; the story is **a physical supply chain whose provenance is cryptographically verifiable end-to-end** (RSA-signed ledger rows → TrueChain anchoring → a QR on every bag that resolves to a named farmer in Bahia). Publicize it the way we always do: the artifact carries the message, one methodology essay lives on truesight.me, we capture permission rather than sell, and any newsletter goes out *after* — only if the room gives us a real story. No discounts, no urgency, no announcement genre.
+
+---
+
+## 2. The honest reframe — who this is (and isn't) for
+
+Our partner definition is **physical venues for ceremonial-cacao retail**, serving a wellness / conscious-consumption audience ("people like us"). The Dual Tech Summit crowd is **none of that** — it's defense/dual-use founders, VCs, and veterans. Pitching ceremonial cacao as a wellness retail product into that room is a category mismatch, and our own playbook (smallest viable audience; permission over interruption; the newsletter "never blast" rule) says don't.
+
+So the question is not *"how do we publicize cacao at this event"* — it is:
+
+> **"What is the one thing about us that is remarkable *to this specific room*, with the cacao as the tangible proof?"**
+
+We have a genuinely strong answer this audience has not seen: a **regenerative supply chain you can cryptographically verify and physically taste.**
+
+---
+
+## 3. The remarkable angle for this room
+
+| This audience cares about | We already have | The artifact that proves it |
+|---|---|---|
+| Supply-chain integrity, anti-tamper provenance | RSA-2048 signed ledger rows dispatched through Edgar | A bag of cacao |
+| Verifiable origin / chain of custody | TrueChain anchoring; serialized QR per unit | Scan the QR → named farmer, farm, shipment ID |
+| Dual-use / commercial-meets-mission tech | A live, boring-on-purpose production stack (not a deck) | "Check it yourself" — every claim resolves to a primary source |
+| Regenerative / mission-driven capital | Mission: restore 10,000 ha of Amazon rainforest | The cacao is the dividend of that mission |
+
+This is the **only** room where Edgar/TrueChain is more interesting than the chocolate. Lead with the verifiable-provenance story; let the cup be the thing they scan, taste, and remark on. That is the Purple Cow at a defense summit.
+
+---
+
+## 4. Publicity plan — by surface
+
+### 4.1 The cacao is the medium, not the message *(primary asset)*
+Every serving / bag carries a **serialized QR code** (use `AGROVERSE_QR_CODE_BATCH_GENERATION` — the workflow already exists). Scan → farm story → on-chain record. No flyer needed; the artifact does the work. At a *dual-use tech* summit, "this cup has a verifiable chain back to a specific person, and you can check it right now" is the demo.
+
+### 4.2 truesight.me/blog — a methodology essay, not an announcement
+Our sites refuse the press-release genre; we rewrite announcements as essays (truesight) or stories (agroverse). The piece for this moment: **provenance as a dual-use problem, demonstrated with cacao.** Plumbing-and-soul register, quiet contrarianism, byline `by Gary Teh, long time contributor` (or `by Claude (Anthropic)`). This is the asset that is remarkable *to founders/VCs/defense* and outlives the single day. Working headline candidates:
+- *"Provenance is a dual-use problem: what a bag of cacao and a defense supply chain have in common"*
+- *"You can taste this supply chain — and verify it"*
+
+### 4.3 Permission capture, not selling, at the venue
+The goal at the table is to **earn the next touch**, not move units. QR → opt-in. We're building the list (permission marketing). Success = conversations and opt-ins, not bags sold.
+
+### 4.4 The newsletter — *after*, and only if there's a real story
+Our rule: email only when there's a genuinely new thing to say; the announcement genre is forbidden. *"Come see us at a booth"* fails that test. But *"we brought a cryptographically traceable ceremonial cacao to a defense-tech summit — here's what the room actually asked us"* is a legitimately remarkable **post-event** story in our curatorial register. Draft it after, send only if earned.
+
+### 4.5 agroverse.shop — stays out of it
+Its audience is wellness consumers; a defense summit is not a Cacao Journey or a farm story. Don't force it. (If anything, a single quiet link from the truesight essay to a farm page is enough.)
+
+---
+
+## 5. Non-negotiables (from how we've always operated)
+
+- **No manufactured urgency, no discount pressure.** The cacao is an invitation and a demonstration, not a flash sale. "Limited time / X% off" betrays the register the list and partners respond to.
+- **Ken is the warm path.** He offered; that's permission-first. Show up as his guest / a long-time contributor — never as a vendor who bought a table.
+- **Gary is a "long time contributor" / supporter** — never "founder." Hard rule.
+- **Every claim resolves to a primary source.** The QR, the ledger, the farm page — verifiability *is* the marketing for this audience.
+- **Mission line stays intact:** *Regenerating our Amazon rainforest, one cacao at a time.*
+
+---
+
+## 6. Deliverables
+
+| # | Deliverable | Surface | Owner | Priority | Status |
+|---|---|---|---|---|---|
+| 1 | Methodology essay — "provenance is a dual-use problem" | truesight.me/blog | Claude draft → Gary review | High | Not started |
+| 2 | Serialized QR batch for event servings/bags | Main Ledger `Agroverse QR codes` + `to_print/` | AI + Gary | High | Not started |
+| 3 | Table placard — "scan to verify" (no sales copy) | Print, at venue | Claude draft → design | High | Not started |
+| 4 | Permission/opt-in capture at QR landing | dapp / newsletter opt-in | AI | Medium | Not started |
+| 5 | Post-event newsletter outline (send only if earned) | Newsletter workbook | Claude draft → Gary | Low | Not started |
+
+*#1 and #3 are the publicity assets; #2 and #4 are logistics; #5 is the after-piece.*
+
+---
+
+## 7. Success metrics (permission-based, not units)
+
+- **Primary:** number of genuine conversations + QR scans + opt-ins captured.
+- **Secondary:** quality of replies / inbound interest in the provenance stack (Edgar/TrueChain), not chocolate sales.
+- **Tertiary:** one publishable essay (truesight) and, if earned, one post-event newsletter story.
+- **Explicitly *not* a metric:** bags sold on the day. Selling is not the job here.
+
+---
+
+## 8. Timeline (event ~1 month out)
+
+| When | Action |
+|---|---|
+| Now → T-3 wk | Confirm date/logistics with Ken; decide cacao quantity & format (bags vs. brewed servings). |
+| T-3 wk | Generate QR batch (#2); draft essay (#1) and placard (#3). |
+| T-2 wk | Gary review of essay + placard; print placard; finalize opt-in landing (#4). |
+| T-1 wk | Publish essay on truesight.me; pre-stage QR'd cacao. |
+| Event day | Permission capture, conversations, "scan to verify" demo. Ken as host/warm intro. |
+| T+1 wk | Draft post-event newsletter (#5); send only if the room produced a real story. |
+
+---
+
+## 9. Open questions for Gary
+
+1. **Confirmed date** — is it June 26, 2026 (slug) or another June date? Need Ken's confirmation.
+2. **Format** — branded bags handed out, or brewed ceremonial cacao served at a table? (Changes QR strategy and quantity.)
+3. **Our presence** — are we exhibiting (demo table), or is Ken simply carrying the cacao on our behalf? Determines who staffs permission capture.
+4. **Quantity & cost** — how many units, and is this a gift/demonstration budget (recommended) vs. consignment to Ken?
+5. **ClawCamp / OffChain crossover** — there's a crypto/dual-use tech thread here (ClawCamp, OffChain Global). Worth a tighter tie-in to the Edgar/TrueChain story? Could make the provenance angle even more on-theme.
+
+---
+
+*Prepared as an Agentic AI CMO consult. Grounded in `CMO_SETH_GODIN.md`, `EDITORIAL_TONE.md`, `AGROVERSE_NEWSLETTER_WORKFLOW.md`, `PURPOSE_AND_MISSION.md`, and the `AGROVERSE_QR_CODE_BATCH_GENERATION` provenance workflow. Companion event precedent: `expo_west_2026_agroverse_schedule.md`.*


### PR DESCRIPTION
Adds `dualtechsummitjune26/proposal_claude.md` — a publicity proposal for making Agroverse ceremonial cacao available at the **Dual Tech Summit 2026** (SF, War Memorial Veterans Building), per Ken's offer.

**Core reframe:** the room is defense/dual-use founders + VCs + veterans, not our wellness retail audience. So this is **not** a sales moment — it's a **provenance-tech demonstration**. The cacao is the artifact; the story is a cryptographically verifiable supply chain (RSA-signed ledger → TrueChain → QR-per-bag → named farmer).

**Plan, consistent with how we operate:**
- Cacao carries the message via serialized QR (existing `AGROVERSE_QR_CODE_BATCH_GENERATION` flow)
- One truesight.me methodology essay ("provenance is a dual-use problem") — not an announcement
- Permission capture, not selling, at the venue
- Post-event newsletter only if the room gives a real story
- agroverse.shop stays out of it
- No urgency/discount; Ken as warm path; Gary = "long time contributor"

Includes deliverables table, permission-based success metrics, ~1-month timeline, and open questions for Gary (date, format, presence, quantity, ClawCamp/OffChain crossover).

Grounded in `CMO_SETH_GODIN.md`, `EDITORIAL_TONE.md`, `AGROVERSE_NEWSLETTER_WORKFLOW.md`, `PURPOSE_AND_MISSION.md`. Companion precedent: `expo_west_2026_agroverse_schedule.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)