### PR TITLE
events: machine-readable index (index.json) for LLM ingestion

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -1,0 +1,20 @@
+# Events
+
+Agroverse cacao **event activations** — one folder per event.
+
+## For machines (LLMs): start here
+- **[`index.json`](index.json)** — the aggregated, date-sorted index of every event. Read this first; it embeds each event's full metadata (date, venue, host, format, QR codes, status, next milestone, doc paths).
+
+## How it's structured
+- Each event lives in `events/<slug>/` (e.g. `sftechfestjune26/`).
+- **`<slug>/event.json`** is the per-event source of truth (machine-readable twin of the checklist header).
+- **`index.json`** is generated — **never hand-edit it**. Edit the per-event `event.json`, then run:
+
+  ```bash
+  python3 events/build_index.py
+  ```
+
+Each event folder also holds the human docs: `EXECUTION_CHECKLIST.md` (phased, the working surface), `proposal*.md` (plan-of-record), `implementation_roadmap.md`, and sometimes `field_assets.md` (placard/sticker copy).
+
+## Convention / playbook
+The full "how to run a cacao event activation" playbook — `event.json` schema, the phase convention, QR naming (`PREFIX_CC/CT_YYYY → agl4/agl8`), and the Apple Reminder/Calendar check-in convention — lives in **`agentic_ai_context/EVENTS.md`**.

--- a/events/build_index.py
+++ b/events/build_index.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regenerate events/index.json from every events/<slug>/event.json.
+
+A machine-readable index of Agroverse cacao event activations, meant to be
+the first file an LLM (or human) reads to understand the event portfolio.
+
+Source of truth = each `events/<slug>/event.json`. This script just
+aggregates them (sorted by date) into `events/index.json` — never hand-edit
+index.json, edit the per-event file and re-run this.
+
+    python3 build_index.py        # run from anywhere; paths are self-relative
+
+Schema + conventions: agentic_ai_context/EVENTS.md
+"""
+import datetime
+import glob
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def main() -> None:
+    events = []
+    for path in sorted(glob.glob(os.path.join(HERE, "*", "event.json"))):
+        with open(path, encoding="utf-8") as f:
+            ev = json.load(f)
+        ev["path"] = os.path.basename(os.path.dirname(path))
+        events.append(ev)
+
+    events.sort(key=lambda e: e.get("date") or "9999-12-31")
+
+    index = {
+        "schema_version": 1,
+        "description": (
+            "Index of Agroverse cacao event activations. Source of truth = each "
+            "events/<slug>/event.json; regenerate with build_index.py. "
+            "Convention doc: agentic_ai_context/EVENTS.md"
+        ),
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+        "generated_by": "build_index.py",
+        "count": len(events),
+        "events": events,
+    }
+
+    out = os.path.join(HERE, "index.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(f"wrote {out} ({len(events)} events)")
+
+
+if __name__ == "__main__":
+    main()

--- a/events/dualtechsummitjune26/event.json
+++ b/events/dualtechsummitjune26/event.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "slug": "dualtechsummitjune26",
+  "name": "Dual Tech Summit 2026",
+  "status": "planning",
+  "status_note": "Venue + Kirsten pre-brew confirmed; date/table/ClawCamp timing pending with Ken (check-in May 27).",
+  "date": "2026-06-26",
+  "end_date": "2026-06-26",
+  "start_time": null,
+  "end_time": null,
+  "timezone": "America/Los_Angeles",
+  "venue": "War Memorial Veterans Building, San Francisco, CA",
+  "city": "San Francisco, CA",
+  "host": { "name": "Ken", "org": "Orbis86 / ClawCamp (SVH Capital Dual Tech Summit)" },
+  "format": "Two flasks — Oscar's ceremonial cacao + Paulo's cacao tea — 3 oz cups, poured at a table Ken provides.",
+  "products": ["Oscar's ceremonial cacao (Bahia)", "Paulo's cacao tea (Pará)"],
+  "qr_codes": [
+    { "id": "DTS_CC_20260626_1", "landing": "agl4", "product": "Oscar's ceremonial cacao", "status": "minted" },
+    { "id": "DTS_CT_20260626_1", "landing": "agl8", "product": "Paulo's cacao tea", "status": "minted" }
+  ],
+  "owner": "Gary",
+  "next_milestone": { "phase": 0, "due": "2026-05-31", "what": "Confirm date / table / ClawCamp timing with Ken" },
+  "reminders": { "apple_reminder": true, "apple_calendar": "Work", "check_in_date": "2026-05-27" },
+  "docs": {
+    "checklist": "EXECUTION_CHECKLIST.md",
+    "proposal": "proposal_finalized.md",
+    "roadmap": "implementation_roadmap.md",
+    "field_assets": "field_assets.md"
+  },
+  "links": { "luma": "https://luma.com/dualtechsummitjune26" }
+}

--- a/events/index.json
+++ b/events/index.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": 1,
+  "description": "Index of Agroverse cacao event activations. Source of truth = each events/<slug>/event.json; regenerate with build_index.py. Convention doc: agentic_ai_context/EVENTS.md",
+  "generated_at": "2026-05-26T21:14:47Z",
+  "generated_by": "build_index.py",
+  "count": 3,
+  "events": [
+    {
+      "schema_version": 1,
+      "slug": "sftechfestjune26",
+      "name": "SF Tech Fest 2026",
+      "status": "planning",
+      "status_note": "Date/venue confirmed; Phase 0 host confirmations (snack table, self-serve, shoutout, passes) pending with Soniya.",
+      "date": "2026-06-12",
+      "end_date": "2026-06-12",
+      "start_time": "11:00",
+      "end_time": "17:00",
+      "timezone": "America/Los_Angeles",
+      "venue": "ICC, 525 Los Coches St, Milpitas, CA 95035",
+      "city": "Milpitas, CA",
+      "host": {
+        "name": "Soniya",
+        "org": "SF Tech Fest"
+      },
+      "format": "Two flasks — Oscar's ceremonial cacao + Paulo's cacao tea — 3 oz cups, self-serve at the snack table.",
+      "products": [
+        "Oscar's ceremonial cacao (Bahia)",
+        "Paulo's cacao tea (Pará)"
+      ],
+      "qr_codes": [
+        {
+          "id": "SFTF_CC_2026",
+          "landing": "agl4",
+          "product": "Oscar's ceremonial cacao",
+          "status": "pending"
+        },
+        {
+          "id": "SFTF_CT_2026",
+          "landing": "agl8",
+          "product": "Paulo's cacao tea",
+          "status": "pending"
+        }
+      ],
+      "owner": "Gary",
+      "next_milestone": {
+        "phase": 0,
+        "due": "2026-06-05",
+        "what": "Confirm snack table / self-serve / stage shoutout / passes with Soniya"
+      },
+      "reminders": {
+        "apple_reminder": true,
+        "apple_calendar": "Work",
+        "check_in_date": "2026-05-27"
+      },
+      "docs": {
+        "checklist": "EXECUTION_CHECKLIST.md",
+        "proposal": "proposal.md",
+        "roadmap": "implementation_roadmap.md"
+      },
+      "links": {},
+      "path": "sftechfestjune26"
+    },
+    {
+      "schema_version": 1,
+      "slug": "onsenglobalforumjune23",
+      "name": "Onsen Global Leaders Forum 2026",
+      "status": "planning",
+      "status_note": "Format set (≈20 sealed co-branded cacao-tea bags in a basket, no pour); Phase 0 pending with Tiffine (logo, table placement, registration).",
+      "date": "2026-06-23",
+      "end_date": "2026-06-23",
+      "start_time": "17:30",
+      "end_time": "19:30",
+      "timezone": "America/Los_Angeles",
+      "venue": "Japan Innovation Campus, Palo Alto, CA",
+      "city": "Palo Alto, CA",
+      "host": {
+        "name": "Tiffine",
+        "org": "Onsen Global"
+      },
+      "format": "≈20 individually sealed cacao-tea bags in a small basket on the snack table, each label co-branded Onsen Global × Agroverse with a provenance QR. No flasks, no pour, no booth.",
+      "products": [
+        "Paulo's cacao tea (Pará)"
+      ],
+      "qr_codes": [
+        {
+          "id": "OGLF_CT_20260623_1",
+          "landing": "agl8",
+          "product": "Paulo's cacao tea",
+          "status": "pending"
+        }
+      ],
+      "owner": "Gary",
+      "next_milestone": {
+        "phase": 0,
+        "due": "2026-06-16",
+        "what": "Confirm logo / table placement / registration with Tiffine"
+      },
+      "reminders": {
+        "apple_reminder": false,
+        "apple_calendar": null,
+        "check_in_date": null
+      },
+      "docs": {
+        "checklist": "EXECUTION_CHECKLIST.md",
+        "proposal": "proposal.md",
+        "roadmap": "implementation_roadmap.md"
+      },
+      "links": {},
+      "path": "onsenglobalforumjune23"
+    },
+    {
+      "schema_version": 1,
+      "slug": "dualtechsummitjune26",
+      "name": "Dual Tech Summit 2026",
+      "status": "planning",
+      "status_note": "Venue + Kirsten pre-brew confirmed; date/table/ClawCamp timing pending with Ken (check-in May 27).",
+      "date": "2026-06-26",
+      "end_date": "2026-06-26",
+      "start_time": null,
+      "end_time": null,
+      "timezone": "America/Los_Angeles",
+      "venue": "War Memorial Veterans Building, San Francisco, CA",
+      "city": "San Francisco, CA",
+      "host": {
+        "name": "Ken",
+        "org": "Orbis86 / ClawCamp (SVH Capital Dual Tech Summit)"
+      },
+      "format": "Two flasks — Oscar's ceremonial cacao + Paulo's cacao tea — 3 oz cups, poured at a table Ken provides.",
+      "products": [
+        "Oscar's ceremonial cacao (Bahia)",
+        "Paulo's cacao tea (Pará)"
+      ],
+      "qr_codes": [
+        {
+          "id": "DTS_CC_20260626_1",
+          "landing": "agl4",
+          "product": "Oscar's ceremonial cacao",
+          "status": "minted"
+        },
+        {
+          "id": "DTS_CT_20260626_1",
+          "landing": "agl8",
+          "product": "Paulo's cacao tea",
+          "status": "minted"
+        }
+      ],
+      "owner": "Gary",
+      "next_milestone": {
+        "phase": 0,
+        "due": "2026-05-31",
+        "what": "Confirm date / table / ClawCamp timing with Ken"
+      },
+      "reminders": {
+        "apple_reminder": true,
+        "apple_calendar": "Work",
+        "check_in_date": "2026-05-27"
+      },
+      "docs": {
+        "checklist": "EXECUTION_CHECKLIST.md",
+        "proposal": "proposal_finalized.md",
+        "roadmap": "implementation_roadmap.md",
+        "field_assets": "field_assets.md"
+      },
+      "links": {
+        "luma": "https://luma.com/dualtechsummitjune26"
+      },
+      "path": "dualtechsummitjune26"
+    }
+  ]
+}

--- a/events/index.json
+++ b/events/index.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "description": "Index of Agroverse cacao event activations. Source of truth = each events/<slug>/event.json; regenerate with build_index.py. Convention doc: agentic_ai_context/EVENTS.md",
-  "generated_at": "2026-05-26T21:14:47Z",
+  "generated_at": "2026-05-26T21:18:16Z",
   "generated_by": "build_index.py",
   "count": 3,
   "events": [
@@ -55,7 +55,8 @@
       "docs": {
         "checklist": "EXECUTION_CHECKLIST.md",
         "proposal": "proposal.md",
-        "roadmap": "implementation_roadmap.md"
+        "roadmap": "implementation_roadmap.md",
+        "field_assets": "field_assets.md"
       },
       "links": {},
       "path": "sftechfestjune26"

--- a/events/onsenglobalforumjune23/EXECUTION_CHECKLIST.md
+++ b/events/onsenglobalforumjune23/EXECUTION_CHECKLIST.md
@@ -1,0 +1,136 @@
+# Onsen Global Leaders Forum 2026 — Execution checklist
+
+**Companion to:** `proposal.md` (plan-of-record) · `implementation_roadmap.md` (phasing)
+**Event:** June 23, 2026 (Tuesday) · 5:30 PM – 7:30 PM · Palo Alto, CA (Japan Innovation Campus)
+**Format:** small basket of 20 sealed cacao tea bags on the snack table — each bag labeled with provenance QR + Onsen Global x Agroverse co-branding. No flasks, no pour, no booth.
+**How to use:** check items as done; each phase is time-bounded.
+
+Legend: `[x]` done · `[ ]` open · `[~]` drafted, pending review · 🔒 blocked on a dependency
+
+---
+
+## Phase 0 — Confirm with Tiffine · now → Jun 16 · Gary
+
+- [ ] **0.1** Request Onsen Global logo — single-color (black), vector or high-res PNG, for the tea bag labels
+- [ ] **0.2** Confirm snack table placement — small basket, unobtrusive; any venue-specific notes?
+- [ ] **0.3** Confirm Gary's registration is approved (registered May 21)
+- [ ] **0.4** Confirm tea bags are in sealed packaging — meets Japanese venue's sealed-package policy
+- [ ] **0.5** (Optional) Ask Tiffine's preference: mention Gary + cacao verbally, or just word-of-mouth at the snack table?
+
+> **Draft message to Tiffine** *(send now)*:
+>
+> Hi Tiffine — excited for the forum on the 23rd! Locking in the cacao tea logistics:
+>
+> - We're doing ~20 individually sealed cacao tea bags in a small basket on the snack table — each bag labeled with the farm story + provenance QR so people can trace it back to the tree. No pour, no cups — clean and sealed per the venue's preference.
+> - If you have a single-color (black) version of Onsen Global's logo, we'd love to include it on the label. If not, no worries — we'll typeset it.
+>
+> Anything else I should know about the snack table setup or venue?
+>
+> Really looking forward to it! 🍵
+
+---
+
+## Phase 1 — QR code + label design · Jun 1–16 · Claude
+
+- [ ] **1.1** Generate provenance QR code `OGLF_CT_20260623_1` via `AGROVERSE_QR_CODE_BATCH_GENERATION.md`:
+  - Target: agl8 (Paulo's cacao tea)
+  - UTM: `?utm_source=event&utm_medium=qr&utm_campaign=oglf-2026`
+- [ ] **1.2** Publish QR PNG + manifest to `TrueSightDAO/lineage-assets` repo
+- [ ] **1.3** Verify provenance QR resolves correctly (agl8 landing page with consent + subscribe)
+- [ ] **1.4** Design tea bag label template (`label_template_OGLF.svg`):
+  - Onsen Global logo (top band) — or typeset "ONSEN GLOBAL" wordmark if logo unavailable
+  - Event name: *Global Expansion & Cross-Border Leaders Forum · June 23, 2026*
+  - Farm name: *Paulo's Farm — Pará, Brazil*
+  - Taste note: *Light, gently fruity, low-stimulant cacao-fruit tea*
+  - Provenance QR (center)
+  - Footer: *agroverse.shop*
+- [ ] **1.5** Draft basket card copy: *"Cacao tea from the Brazilian Amazon. Take one. Scan the QR to meet the farmer."* → `field_assets.md`
+
+---
+
+## Phase 2 — DRY RUN · Jun 16–19 · Claude  ← gate
+
+- [ ] **2.1** Print **one** test tea bag label with QR
+- [ ] **2.2** Scan provenance QR → confirm it resolves to the correct agl8 page (no dead link / CORS)
+- [ ] **2.3** Scan opt-in (subscribe checkbox on agl8 page) → fill test signup → confirm it lands in `Agroverse News Letter Subscribers` tab (check `subscribed:true`)
+- [ ] **2.4** Confirm `send_newsletter.py` reads the subscribers tab + dedup works on the test entry
+- [ ] **2.5** Confirm QR is scannable at tea bag label size (~40mm) — not too dense
+- [ ] **2.6** Clean up test entry from subscribers tab
+- [ ] **2.7** Fix any issues found
+- [ ] **✅ Dry run passed → printing is unblocked**
+
+---
+
+## Phase 3 — Print + assemble · Jun 19–22 · Gary
+
+- [ ] **3.1** Print 20 tea bag labels + 5 spares (black-and-white label printer)
+- [ ] **3.2** Affix labels to 20 sealed Paulo's cacao tea bags
+- [ ] **3.3** Pull 20 Paulo's cacao tea bags from inventory
+- [ ] **3.4** Log `[INVENTORY MOVEMENT]` for the 20 tea bags
+- [ ] **3.5** Verify each tea bag packaging is sealed (Japanese venue policy)
+- [ ] **3.6** Print or hand-write basket card
+- [ ] **3.7** Assemble basket: 20 labeled tea bags + basket card
+- [ ] **3.8** Pack: basket, a few spare tea bags, phone (for photos)
+- [ ] **3.9** Final confirm with Tiffine (arrival time, snack table location) — 📞 Tiffine check-in
+
+---
+
+## Phase 4 — Event day · Jun 23 · Gary
+
+### 4.1 Setup
+- [ ] **4.1.1** Arrive ~5:15 PM — find Tiffine, locate the snack table
+- [ ] **4.1.2** Place basket on snack table — visible but not center-stage
+- [ ] **4.1.3** Place basket card beside or in the basket
+- [ ] **4.1.4** Take a quick photo of the basket setup
+
+### 4.2 During event
+- [ ] **4.2.1** Network as an attendee — don't hover near the snack table
+- [ ] **4.2.2** If someone picks up a tea bag near you → tell the story: *"That's single-estate cacao tea from a farmer named Paulo in the Brazilian Amazon. Scan the QR — it shows you his farm."*
+- [ ] **4.2.3** Note any conversations: who, what they asked, any retail/partnership interest
+- [ ] **4.2.4** Tiffine introductions → pay attention to anyone she connects you with
+- [ ] **4.2.5** Mid-event check (~7:00 PM): count remaining tea bags in the basket
+
+### 4.3 End of event
+- [ ] **4.3.1** Count remaining tea bags (if any) — rough metrics
+- [ ] **4.3.2** Retrieve basket from snack table (leave nothing behind)
+- [ ] **4.3.3** Mental notes → jot down before you forget: names, conversations, what people asked about
+- [ ] **4.3.4** Drop a send-time note re: "what happened" — it's easy data
+
+---
+
+## Phase 5 — Immediate post-event · Jun 24–25 · Claude + Gary
+
+- [ ] **5.1** Check QR scan count for `OGLF_CT_20260623_1` *(Claude)*
+- [ ] **5.2** Verify any opt-in signups landed in `Agroverse News Letter Subscribers` tab *(Claude)*
+- [ ] **5.3** Count new subscribers → note delta *(Claude)*
+- [ ] **5.4** Add warm leads to Hit List (`Source: Onsen Global Leaders Forum 2026`, `Status: Research`, Notes: what they said/tasted) *(Gary)*
+- [ ] **5.5** Verify `suggest_manager_followup_drafts.py` picked up new leads *(Claude)*
+- [ ] **5.6** Log activation as a **DApp Remark** — date, tea bags taken, notable conversations, what landed/didn't, photo *(Gary)*
+- [ ] **5.7** Thank-you to Tiffine (warm, non-transactional) *(Gary)*
+
+---
+
+## Phase 6 — Follow-up · Jun 26–30
+
+- [ ] **6.1** Manager Follow-up drafts for event leads *(Grok → Gary sends)*
+- [ ] **6.2** Personal 1:1 follow-ups with any contacts made *(Gary)*
+- [ ] **6.3** **No full-list newsletter** — skip entirely. This audience doesn't match the wellness list.
+- [ ] **6.4** Optional truesight.me essay if the evening produced a real observation *(Claude drafts → Gary publishes)*
+
+---
+
+## Reminders — per-phase follow-ups
+
+| Phase | Target date | Follow-up due |
+|---|---|---|
+| 0 | ASAP (by Jun 16) | Request Onsen Global logo, confirm snack table, confirm sealed packaging |
+| 1 | Jun 1–16 | QR code minted, label designed |
+| 2 | Jun 16–19 | Dry run passes |
+| 3 | Jun 19–22 | Labels printed, tea bags labeled, basket assembled |
+| 4 | Jun 23 | Basket on snack table, Gary networks |
+| 5 | Jun 24–25 | Signups verified, leads in Hit List, thank-you to Tiffine |
+| 6 | Jun 26–30 | Follow-ups, essay (if warranted) |
+
+---
+
+*Created 2026-05-26 by Claude (Anthropic). Mirrors `implementation_roadmap.md`; update both if phasing changes.*

--- a/events/onsenglobalforumjune23/event.json
+++ b/events/onsenglobalforumjune23/event.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "slug": "onsenglobalforumjune23",
+  "name": "Onsen Global Leaders Forum 2026",
+  "status": "planning",
+  "status_note": "Format set (≈20 sealed co-branded cacao-tea bags in a basket, no pour); Phase 0 pending with Tiffine (logo, table placement, registration).",
+  "date": "2026-06-23",
+  "end_date": "2026-06-23",
+  "start_time": "17:30",
+  "end_time": "19:30",
+  "timezone": "America/Los_Angeles",
+  "venue": "Japan Innovation Campus, Palo Alto, CA",
+  "city": "Palo Alto, CA",
+  "host": { "name": "Tiffine", "org": "Onsen Global" },
+  "format": "≈20 individually sealed cacao-tea bags in a small basket on the snack table, each label co-branded Onsen Global × Agroverse with a provenance QR. No flasks, no pour, no booth.",
+  "products": ["Paulo's cacao tea (Pará)"],
+  "qr_codes": [
+    { "id": "OGLF_CT_20260623_1", "landing": "agl8", "product": "Paulo's cacao tea", "status": "pending" }
+  ],
+  "owner": "Gary",
+  "next_milestone": { "phase": 0, "due": "2026-06-16", "what": "Confirm logo / table placement / registration with Tiffine" },
+  "reminders": { "apple_reminder": false, "apple_calendar": null, "check_in_date": null },
+  "docs": {
+    "checklist": "EXECUTION_CHECKLIST.md",
+    "proposal": "proposal.md",
+    "roadmap": "implementation_roadmap.md"
+  },
+  "links": {}
+}

--- a/events/onsenglobalforumjune23/implementation_roadmap.md
+++ b/events/onsenglobalforumjune23/implementation_roadmap.md
@@ -1,0 +1,166 @@
+# Onsen Global Leaders Forum 2026 — Implementation roadmap
+
+**Companion to:** `proposal.md` (plan-of-record)
+**Event:** Global Expansion & Cross-Border Leaders Forum · June 23, 2026 · 5:30–7:30 PM · Palo Alto, CA
+**Format (confirmed):** small basket of 20 sealed cacao tea bags on the snack table — each labeled with provenance QR + Onsen Global x Agroverse co-branding. No flasks, no pour, no booth.
+**Lead:** Claude (QR pipeline + label design) · **On the ground:** Gary · **Follow-up:** Grok
+
+---
+
+## Critical path (the chain the event rises and falls on)
+
+```
+Request Onsen Global logo from Tiffine (or settle on wordmark fallback)
+        ↓
+Generate provenance QR code (OGLF_CT_20260623_1) + publish to lineage-assets
+        ↓
+Design tea bag label template (Onsen logo, farm name, QR)
+        ↓
+DRY RUN: print one test label, scan QR, confirm signup lands   ← gate
+        ↓
+Print 20+ labels → affix to tea bags → assemble basket
+        ↓
+Event day: place basket on snack table → Gary networks
+        ↓
+Post-event: verify scans → Hit List → DApp Remark → thank-you to Tiffine
+```
+
+**Gate rule:** nothing gets printed until the dry run in Phase 2 passes.
+
+---
+
+## Phase 0 — Confirm logistics with Tiffine (now → Jun 16, T-1wk)  · Owner: Gary
+
+**Already confirmed:** small basket of sealed cacao tea bags on the snack table. Gary registered (May 21).
+
+| # | Task | Output | Blocks |
+|---|---|---|---|
+| 0.1 | Request Onsen Global logo (black, single-color) from Tiffine | Logo file [or wordmark fallback] | Label design |
+| 0.2 | Confirm snack table placement — any venue-specific notes? | Setup plan | — |
+| 0.3 | Confirm Gary's registration is approved | Entry confirmed | — |
+| 0.4 | Confirm tea bag packaging is sealed (meets JIC policy) | Compliance check | — |
+| 0.5 | (Optional) preference on verbal mention vs word-of-mouth | Tone guide | — |
+
+**Exit criteria:** logo received (or wordmark fallback chosen), snack table placement confirmed. → unblocks Phase 1.
+
+---
+
+## Phase 1 — Build QR code + label design (now → Jun 16, T-1wk)  · Owner: Claude
+
+| # | Task | Output |
+|---|---|---|
+| 1.1 | Generate QR batch `OGLF_CT_20260623_1` (Paulo's cacao tea) via existing pipeline; publish to `lineage-assets` repo | QR PNG + `qrs_index.json` entry |
+| 1.2 | Provenance QR target = agl8 landing page (consent + subscribe) — reuse existing page, no new build | Working QR → signup pipeline |
+| 1.3 | Add UTM: `?utm_source=event&utm_medium=qr&utm_campaign=oglf-2026` | Scan attribution |
+| 1.4 | Design tea bag label (`label_template_OGLF.svg`): Onsen logo, event name, farm, taste note, QR, agroverse.shop footer | Print-ready label template |
+| 1.5 | Draft basket card copy → `field_assets.md` | Basket card text |
+
+**Register guardrails:** label copy stays curatorial — no prices, no urgency, no blockchain jargon. Taste notes from `AGROVERSE_PRICE_LIST_AND_ASSETS.md`. Only one QR per label (provenance; subscribe rides on the landing page).
+
+---
+
+## Phase 2 — DRY RUN (Jun 16–19)  · Owner: Claude  ← gate
+
+| # | Task | Output |
+|---|---|---|
+| 2.1 | **Dry run:** print one test label, scan QR, confirm agl8 page resolves | Pass/fail |
+| 2.2 | Fill test signup on agl8 page → confirm it lands in `Agroverse News Letter Subscribers` tab | Pass/fail |
+| 2.3 | Confirm `send_newsletter.py` can address the new test subscriber | Pass/fail |
+| 2.4 | Confirm QR is scannable at tea bag label size (~40mm) | Pass/fail |
+| 2.5 | Fix any issues | Green pipeline |
+
+**⛔ Gate:** Phase 3 printing proceeds **only when 2.1–2.4 pass.**
+
+---
+
+## Phase 3 — Print + assemble kit (Jun 19–22)  · Owner: Gary
+
+| # | Task | Output |
+|---|---|---|
+| 3.1 | Print 20 tea bag labels + 5 spares (black-and-white label printer) | Labeled bags |
+| 3.2 | Affix labels to 20 sealed Paulo's cacao tea bags | Finished tea bags |
+| 3.3 | Pull 20 tea bags from inventory; log `[INVENTORY MOVEMENT]` | Stock + ledger entry |
+| 3.4 | Verify each bag is sealed (JIC policy) | Compliance check |
+| 3.5 | Print or write basket card | Basket card |
+| 3.6 | Assemble basket: 20 labeled tea bags + basket card | Event-ready basket |
+
+---
+
+## Phase 4 — Event day (Jun 23)  · Owner: Gary
+
+- **Arrive ~5:15 PM.** Find Tiffine, confirm the snack table location.
+- **Place basket on snack table.** Visible but unobtrusive. Basket card beside it.
+- **Quick photo** of the basket setup before people arrive.
+- **The basket is the whole presence.** No signage, no banner, no standing at the table.
+- **Gary networks** — registered attendee, not on shift.
+- **If someone picks up a tea bag / mentions it** → tell the one-line story (§2.3 of proposal).
+- **Don't initiate** the cacao conversation unprompted. Let the basket pull.
+- **Mid-event (~7:00 PM):** glance at the basket, note how many bags remain.
+- **End of event:** collect basket, count remaining bags, jot notes.
+- **If Tiffine introduces you to anyone** → pay attention, note names and context.
+
+---
+
+## Phase 5 — Immediate post-event (Jun 24–25)  · Owner: Claude
+
+| # | Task | Output |
+|---|---|---|
+| 5.1 | Check QR scan count for `OGLF_CT_20260623_1` | Scan metrics |
+| 5.2 | Verify any opt-in signups landed in `Agroverse News Letter Subscribers` tab | Confirmed list |
+| 5.3 | Count new subscribers → note delta | Subscriber delta |
+| 5.4 | Add warm leads to Hit List (`Source: Onsen Global Leaders Forum 2026`, Notes) | Pipeline input |
+| 5.5 | Verify `suggest_manager_followup_drafts.py` picks up any new leads | Queued drafts |
+| 5.6 | Log activation as a **DApp Remark** (date, tea bags taken, notable conversations, photo) | Training data |
+| 5.7 | Thank-you to Tiffine (warm, non-transactional) *(Gary)* | Relationship |
+
+---
+
+## Phase 6 — Follow-up (Jun 26–30)
+
+| # | Task | Owner | Output |
+|---|---|---|---|
+| 6.1 | Manager Follow-up drafts for event leads | Grok (existing pipeline) → Gary sends | Warm-up touches |
+| 6.2 | Personal 1:1 follow-ups with any contacts Gary made | Gary | Relationship |
+| 6.3 | **No full-list newsletter** — skip entirely. Wrong audience for the wellness list. | — | — |
+| 6.4 | Optional truesight.me essay if the evening produced an observation | Claude (draft) → Gary (review/publish) | Essay |
+
+---
+
+## Milestone checklist (one-glance)
+
+- [ ] **M0** — Logo received (or wordmark fallback), snack table confirmed *(Gary)*
+- [ ] **M1** — QR code minted + label template designed *(Claude)*
+- [ ] **M2** — ✅ **Dry run passes** ← gate
+- [ ] **M3** — Labels printed, tea bags labeled, basket assembled *(Gary)*
+- [ ] **M4** — Event executed: basket on snack table, Gary networks *(Gary)*
+- [ ] **M5** — Signups verified, leads in Hit List, thank-you to Tiffine, DApp Remark logged *(Claude/Gary)*
+- [ ] **M6** — Follow-ups sent, essay (if warranted) *(Grok/Claude)*
+
+---
+
+## Decision points for Gary
+
+1. **Tea bags** — Paulo's cacao tea (Pará) only, or include a few Oscar's ceremonial cacao bags too? *Recommended: Paulo's only — tea format, lighter, lower-stimulant for an evening event. Oscar's is a drink, not a tea-bag product.*
+2. **Label branding** — wait for Onsen Global logo or proceed with wordmark fallback? *Recommended: request logo now, set a Jun 14 deadline. If no response by then, proceed with typeset wordmark.*
+3. **Quantity** — 20 tea bags for ~50 people. Enough? *Recommended: yes. Scarcity is signal. If all 20 get taken, that's a 40% conversion rate from room to scan — excellent. If only 10 get taken, that's still 25% and no wasted inventory.*
+4. **Newsletter** — skip full-list entirely. *Yes.*
+5. **Post-event essay** — worth writing? *Recommended: decide after the event. A quiet tea-bag basket at a private forum may or may not generate a publishable observation. No pressure.*
+
+---
+
+## Differences from DTS / SFTF — why this event is simpler
+
+| Factor | DTS / SFTF | This event |
+|---|---|---|
+| Format | Pour (flasks + cups) | Sealed tea bags in a basket |
+| Venue constraint | Standard (confirm with host) | Japanese venue — sealed packages only |
+| Setup time | Flasks pre-brewed, cups stacked, placard placed | Basket dropped on snack table |
+| Staffing | Gary pours or it's self-serve | Zero staffing — basket is fully unattended |
+| Artifact | QR placard + cup stickers | QR on the tea bag label itself |
+| Scale | Dozens of pours | 20 sealed bags |
+| Co-branding | Agroverse only | Onsen Global + Agroverse on the label |
+| Duration | All-day | 2-hour evening |
+
+---
+
+*Roadmap authored 2026-05-26 by Claude (Anthropic).*

--- a/events/onsenglobalforumjune23/proposal.md
+++ b/events/onsenglobalforumjune23/proposal.md
@@ -1,0 +1,259 @@
+# Onsen Global x JIC Leaders Forum 2026 — Agroverse cacao activation proposal
+
+**Status:** DRAFT v0.1 — plan-of-record
+**Date:** 2026-05-26
+**Author:** Claude (Anthropic)
+
+**Event:** Global Expansion & Cross-Border Leaders Forum
+**Date:** Tuesday, June 23, 2026 · 5:30 PM – 7:30 PM
+**Where:** Palo Alto, CA (Japan Innovation Campus)
+**Host:** Onsen Global (Tiffine Wang) · Japan Innovation Campus (JIC)
+**Audience:** ~40–50 curated founders, corporates, investors — invitation-only, approval required
+**Listing:** https://luma.com/tw8r8xp3
+
+---
+
+## 0. Trigger & confirmation
+
+Gary connected with Tiffine Wang after she shared the Luma invite on May 21. Key conversation moments (May 21–24, 2026):
+
+> **Gary:** *"Happy to bring two flask[s] of cacao and some cups to offer there."*
+
+> **Tiffine:** *"No need =) I think the Japanese has strict policies on what to bring/serve. Whole sealed packages are okay."*
+
+> **Gary:** *"How many guests? Perhaps small bags of cacao tea? ... produce 50 bags as a gift each with a QR code which shows them the farm the cacao came from? Do you have a logo for Onsen Global we could use?"*
+
+> **Tiffine:** *"Don't need to bring so many, we can just add a small basket of them and add it to the snack table — and you can talk about it when people go grab their snacks."*
+
+> **Gary:** *"Perfect! Let's do that."*
+
+**Format confirmed:** a small basket of individually sealed cacao tea bags on the snack table. Gary talks about it organically when people approach the snack table. No flasks, no pour, no booth. Sealed packages only (Japanese venue policy).
+
+---
+
+## 1. Recommendation in one paragraph
+
+Place a small basket of 20 individually sealed cacao tea bags on the snack table — each bag labeled with the farm name, taste notes, Onsen Global x Agroverse co-branding, and a provenance QR code. This is the quietest activation yet: no pouring, no table staffing, no placard — the tea bag **is** the artifact. At a 40–50 person invitation-only forum on cross-border expansion, the frame writes itself: *"Built a supply chain that routes from Bahia to Palo Alto — and here it is, sealed in a tea bag you can hold and trace."* Let curiosity do the work. Gary attends as a guest and talks story only when someone picks up a bag. No full-list blast, no selling. Just a basket, a QR code, and a farmer's name.
+
+---
+
+## 2. The frame — why this audience, why this format
+
+### 2.1 Audience fit
+
+This room is founders, family-office investors, and corporate operators focused on **cross-border expansion**. The core narrative bridge:
+
+| Room theme | Agroverse bridge |
+|---|---|
+| Global expansion & market entry | "Same challenges they're discussing — we solved them for a physical commodity. Every tea bag crossed a border with cryptographic proof." |
+| Cross-border operations | "Supply chain logistics from Bahia to San Francisco — documented on-chain, not in spreadsheets." |
+| Japan Innovation Campus (JIC) | Japanese startup culture values craft, precision, and provenance. A single-estate Brazilian cacao tea bag — traceable to the tree — speaks that language. |
+| Onsen Global's venture platform | "We deployed AI agents to route agricultural commodities. The same pattern scales to fintech, healthcare, supply chain." |
+
+### 2.2 Why tea bags work here
+
+- **Japanese venue policy** — sealed packages only. Tea bags are self-contained, shelf-stable, no food-handling liability. This is the only format the venue allows.
+- **20 tea bags for 50 people** — scarcity is signal. Not everyone gets one. The people who do carry the physical artifact home.
+- **Each bag is the flyer** — no placard, no banner, no "scan here!" sign. The QR is on the bag itself. The bag is the provenance device.
+- **Gary's role: guest, not vendor** — he registered as an attendee. He talks about the cacao naturally when people approach the snack table, not from a booth.
+
+### 2.3 The one-line story — what Gary says when someone picks up a bag
+
+> "That's single-estate cacao tea from a farmer named Paulo in the Brazilian Amazon. Scan the QR — it shows you his farm, his trees, and the journey from Bahia to here."
+
+No prices. No "buy now." No blockchain jargon. Farm name, place, and an invitation to scan. If they ask about the "how": *"Same AI agent patterns you'd use to route any cross-border supply chain."*
+
+---
+
+## 3. What we do NOT do
+
+- **No flasks, no pour, no cups.** The venue forbids it. The tea bag format is cleaner anyway — each bag travels home in a pocket.
+- **No booth, no backdrop, no placard.** The basket on the snack table is the whole footprint.
+- **No dedicated pourer / staffer.** Gary attends as a registered guest. He's in the room, not on shift.
+- **No full-list newsletter blast.** Wrong register. This audience doesn't live in the wellness newsletter.
+- **No promotional discount codes / urgency.** Breaks the curatorial register.
+- **No selling.** The tea bag is a gift. If someone wants to carry cacao, they'll scan and find their way.
+
+> **Operating principle:** *20 sealed tea bags, one basket, no pitch. The bag does the work. Gary tells the story when asked.*
+
+---
+
+## 4. On-the-day execution
+
+### 4.1 Placement — snack table basket
+
+| Forum moment | Cacao role |
+|---|---|
+| 5:30 PM — Arrival & mingling | Basket on snack table; people discover during initial networking |
+| 6:00 PM — Panel & moderated discussion | Basket remains; snack-table visitors pick up a bag |
+| 7:00 PM — Audience Q&A + closing mingling | Last bags get taken; natural conversation starter |
+
+### 4.2 Format — 20 sealed tea bags in a basket
+
+- **20 individually sealed cacao tea bags** (Paulo's cacao tea, Pará) — no more than 40% of expected attendance.
+- **Each bag labeled** with:
+  - Farm name: *Paulo's Farm — Pará, Brazil*
+  - Taste note: *Light, gently fruity, low-stimulant cacao-fruit tea*
+  - Co-branding: Onsen Global logo (top) + Agroverse mark (bottom)
+  - Provenance QR code (scan → lineage asset)
+  - Onsen Global event tagline: *Global Expansion & Cross-Border Leaders Forum · June 23, 2026*
+- **Basket:** small, unobtrusive, placed on the snack table. A simple card beside it: *"Cacao tea from the Brazilian Amazon. Take one. Scan the QR to meet the farmer."*
+- **No cups, no hot water, no brewing on site.** The bag is the gift. Recipients brew at home.
+
+### 4.3 Gary's role — attendee who brought tea
+
+- Gary attends as a registered guest with an approved invitation.
+- He does not staff the snack table — he networks.
+- When someone mentions the tea or picks up a bag, he tells the story (§2.3).
+- He does not initiate the cacao conversation unprompted. Let the basket pull.
+
+---
+
+## 5. Tea bag design & QR strategy
+
+### 5.1 What's on the label
+
+Each tea bag label (black-and-white, printed via existing label printer):
+
+```
+┌─────────────────────────────────┐
+│  [Onsen Global logo]            │
+│  Global Expansion &             │
+│  Cross-Border Leaders Forum     │
+│  June 23, 2026                  │
+│                                 │
+│  PAULO'S FARM                   │
+│  Cacao-Fruit Tea · Pará, Brazil │
+│  Light, gently fruity,          │
+│  low-stimulant infusion         │
+│                                 │
+│  [ provenance QR ]              │
+│  Scan to meet the farmer        │
+│                                 │
+│  agroverse.shop                 │
+└─────────────────────────────────┘
+```
+
+### 5.2 QR codes
+
+| QR | Destination | Purpose |
+|---|---|---|
+| **Provenance / traceability** | `truesight.me/qr/?id=OGLF_CT_20260623_1` → agl8 landing page (Paulo's cacao tea) | "Meet the farmer who grew this" |
+| Opt-in (optional — skip if too busy a label) | agl8 consent + subscribe | Permission capture; `utm_source=event&utm_medium=qr&utm_campaign=oglf-2026` |
+
+**Decision:** one QR per bag. Two QRs overcrowds a small tea bag label. The provenance QR + a soft subscribe CTA on the landing page is sufficient. The provenance destination page *includes* the subscribe checkbox.
+
+- **Tracking:** event-unique code `OGLF_CT_20260623_1` + UTM `?utm_source=event&utm_medium=qr&utm_campaign=oglf-2026`
+- **QR generation:** reuse existing `AGROVERSE_QR_CODE_BATCH_GENERATION.md` pipeline. Publish to `TrueSightDAO/lineage-assets`.
+
+### 5.3 Onsen Global logo
+
+- Tiffine indicated openness: *"do you have a logo for Onsen Global we could use?"*
+- Gary: *"I wonder if its possible to have the logo all Black?"* — black-and-white label printer constraint.
+- **Action:** request Onsen Global's logo in single-color (black) vector or high-res PNG from Tiffine. If unavailable, use a typeset "ONSEN GLOBAL" wordmark in the label's top band.
+
+---
+
+## 6. Post-event loop
+
+- **Verify QR scans** — check redirect counter for `OGLF_CT_20260623_1`.
+- **Verify opt-in signups** — any subscribes through agl8 landing page.
+- **No newsletter to the full list.** 1:1 follow-up only.
+- **Hit List:** if anyone expressed retail interest → `Source: Onsen Global Leaders Forum 2026`.
+- **DApp Remark:** log the activation (date, tea bags placed, number taken, notable conversations).
+- **Thank-you to Tiffine** — warm, non-transactional, after the event.
+- **Optional truesight.me essay** — only if the evening produced a genuine observation (e.g., "What 40 cross-border operators asked about a tea bag from the Amazon").
+
+---
+
+## 7. Materials & logistics
+
+| Item | Source | Notes |
+|---|---|---|
+| 20 cacao tea bags (Paulo's cacao tea, Pará) | Inventory / Kirsten prep | Individually sealed |
+| Tea bag labels (black-and-white) | Label printer + `label_template_OGLF.svg` | Print 20 labels (plus 5 spares) |
+| Onsen Global logo (black, single-color) | Request from Tiffine | Fallback: typeset wordmark |
+| QR code PNG (provenance) | `AGROVERSE_QR_CODE_BATCH_GENERATION.md` → `lineage-assets` | Code: `OGLF_CT_20260623_1` |
+| Small basket | Home/office | Unobtrusive, fits 20 tea bags |
+| Basket card (small, handwritten or printed) | Print | "Cacao tea from the Brazilian Amazon. Take one." |
+
+**Not needed:** flasks, cups, kettle, placard, backdrop, booth, banner. Zero on-site setup beyond placing a basket.
+
+---
+
+## 8. Cost
+
+| Item | Estimate |
+|---|---|
+| 20 cacao tea bags (from inventory) | Low — cost basis only |
+| Label printing | Near zero (existing printer + stock) |
+| Basket | $0 (reuse existing) |
+| Gary's attendance | Free (registered attendee) |
+
+No new tooling. No paid sponsorship. The tea bags are a gift, not a cost center.
+
+---
+
+## 9. Measurement
+
+| Signal | How |
+|---|---|
+| Tea bags taken | Count remaining basket at end of event |
+| QR scans (unique + total) | `OGLF_CT_20260623_1` redirect counter + UTM |
+| Newsletter opt-ins | `Agroverse News Letter Subscribers` row delta |
+| Retail interest | Hit List rows tagged `Onsen Global Leaders Forum 2026` |
+| Qualitative | DApp Remark: what people asked, who Tiffine introduced Gary to |
+
+**Explicitly not a metric:** bags sold. This is a gift at a private forum. The only conversion is curiosity → scan.
+
+---
+
+## 10. Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Label printer produces unreadable QRs | Low | Test-print one label, scan it before printing all 20 |
+| Onsen Global doesn't provide logo in time | Medium | Fallback: typeset "ONSEN GLOBAL" wordmark; still clean, still co-branded |
+| Tea bags not sealed? (venue policy) | Low | Confirm existing Paulo's tea packaging is sealed; if not, heat-seal in small clear bags |
+| QR → landing page breaks | Low | Pre-event dry run: scan test label, confirm it resolves |
+| Basket gets overlooked on snack table | Low | 20 tea bags with labels are visually distinct; the forum is small enough that people find the snack table |
+| Tiffine's date/venue changes | Low | Keep an eye on the Luma listing |
+
+---
+
+## 11. Open questions / asks for Tiffine
+
+1. **Onsen Global logo** — can you share a single-color (black) version for the tea bag label? If not, we'll use a typeset "ONSEN GLOBAL" wordmark.
+2. **Snack table confirmation** — the basket will be small and unobtrusive. Just confirming placement is fine.
+3. **Gary's registration** — already registered (May 21). Any additional confirmation needed?
+4. **Acknowledgment** — prefer Gary mentioned as a guest who brought cacao tea, or prefer it stays word-of-mouth at the snack table? (No strong preference — both work.)
+
+---
+
+## 12. Division of labor
+
+```
+PRE-EVENT (now → Jun 16)
+  Proposal + execution checklist ................... Claude (this doc)
+  Request Onsen Global logo from Tiffine .......... Gary
+  Design tea bag label template ................... Claude
+  Generate provenance QR code ..................... Claude (existing pipeline)
+  Print labels + affix to tea bags ................ Gary
+  Assemble basket + basket card ................... Gary
+  Dry run: scan test label, verify QR resolves .... Claude
+
+DURING EVENT (Jun 23)
+  Place basket on snack table ..................... Gary
+  Attend, network, talk story when asked .......... Gary
+
+POST-EVENT (Jun 24–30)
+  Verify QR scans + signups ....................... Claude
+  Add leads to Hit List ........................... Gary
+  Thank-you note to Tiffine ....................... Gary
+  DApp Remark ..................................... Gary
+  Optional truesight.me essay ..................... Claude (draft) → Gary (publish)
+```
+
+---
+
+*Proposal authored 2026-05-26 by Claude (Anthropic). Grounded in `CMO_SETH_GODIN.md`, `EDITORIAL_TONE.md`, `PURPOSE_AND_MISSION.md`, and `AGROVERSE_QR_CODE_BATCH_GENERATION.md`. Implementation steps in `implementation_roadmap.md` (same folder).*

--- a/events/sftechfestjune26/EXECUTION_CHECKLIST.md
+++ b/events/sftechfestjune26/EXECUTION_CHECKLIST.md
@@ -1,0 +1,126 @@
+# SF Tech Fest 2026 — Execution checklist
+
+**Companion to:** `proposal.md` (plan-of-record) · `implementation_roadmap.md` (phasing)
+**Event:** June 12, 2026 (Friday) · ICC, 525 Los Coches St, Milpitas, CA 95035 · 11:00 AM – 5:00 PM PT
+**Format:** two flasks — **Oscar's ceremonial cacao + Paulo's cacao tea** — in 3 oz cups, self-serve at the snack table. Placard does the talking.
+**How to use:** check items as done; each phase is time-bounded.
+
+Legend: `[x]` done · `[ ]` open · `[~]` drafted, pending review · 🔒 blocked on a dependency
+
+---
+
+## Phase 0 — Confirm with Soniya · now → ~Jun 5 · Gary
+
+- [ ] **0.1** Confirm **snack table location** — is it accessible to all attendees? Where in the venue?
+- [ ] **0.2** Confirm **self-serve** is approved — no dedicated pourer, no one staffing the table
+- [ ] **0.3** Confirm **stage shoutout** — still offered? Preferred timing? *(Suggested: Sponsors Acknowledgement at 3:00 PM, or before a break)*
+- [ ] **0.4** Confirm **Gary + friend passes** — logistics (names, how to get in, any registration needed)
+- [ ] **0.5** Confirm any venue restrictions (outside food/beverage, alcohol policy, setup time)
+
+> **Draft message to Soniya** *(send soon)*:
+>
+> Hi Soniya — circling back on the cacao for Tech Fest (June 12!). Just locking in a few logistics when you get a sec:
+>
+> - Where's the **snack table** located — is it in the main hall or a separate area? We'll just drop two flasks + cups + a small placard, fully self-serve, no one staffing it.
+> - Is the **stage shoutout** still on? If so, happy to do ~30 seconds whenever fits the flow — Sponsors Acknowledgement or right before a break.
+> - **Passes for me + my friend** — anything we need to do to get registered?
+>
+> Thanks for making space for this! 🍫
+
+---
+
+## Phase 1 — QR codes + placard · now → Jun 5 · Claude
+
+- [ ] **1.1** Generate QR codes via `AGROVERSE_QR_CODE_BATCH_GENERATION.md`:
+  - `SFTF_CC_2026` → agl4 (Oscar's ceremonial cacao)
+  - `SFTF_CT_2026` → agl8 (Paulo's cacao tea)
+- [ ] **1.2** Publish QR PNGs + manifests to `TrueSightDAO/lineage-assets` repo
+- [ ] **1.3** Verify provenance QR resolves correctly (agl4/agl8 landing pages with consent + subscribe)
+- [ ] **1.4** Add UTM parameters: `?utm_source=event&utm_medium=qr&utm_campaign=sftf-2026`
+- [ ] **1.5** Draft placard copy → `field_assets.md` (farm names, taste notes, two QRs, footer)
+- [ ] **1.6** Design placard layout (5x7, print-ready)
+
+---
+
+## Phase 2 — DRY RUN · Jun 5–7 · Claude  ← gate
+
+- [ ] **2.1** Print **test placard** with both QRs
+- [ ] **2.2** Scan provenance QR → confirm it resolves to the correct agl4/agl8 page (no dead link / CORS)
+- [ ] **2.3** Scan opt-in QR → fill test signup → confirm it lands in `Agroverse News Letter Subscribers` tab (check `subscribed:true`)
+- [ ] **2.4** Confirm `send_newsletter.py` reads the subscribers tab + dedup works on the test entry
+- [ ] **2.5** Clean up test entry from subscribers tab
+- [ ] **2.6** Fix any issues found
+- [ ] **✅ Dry run passed → printing is unblocked**
+
+---
+
+## Phase 3 — Print + prep (Jun 8–11) · Gary
+
+- [ ] **3.1** Print **2 copies** of the placard (5x7) — one for the table, one backup
+- [ ] **3.2** Pull cacao for two flasks from inventory:
+  - Oscar's Farm ceremonial cacao (Bahia) — enough for 1 full thermal flask
+  - Paulo's cacao tea (Pará) — enough for 1 full thermal flask
+- [ ] **3.3** Log `[INVENTORY MOVEMENT]` for the cacao pulled
+- [ ] **3.4** Gather cups (3 oz, compostable) + napkins — enough for ~50 servings
+- [ ] **3.5** Day-of: pre-brew both flasks (Kirsten or Gary). Hot, ready to go. No kettle needed.
+- [ ] **3.6** Pack kit: 2 flasks (sealed tight), cups, napkins, placard x2, tape (to secure placard if needed)
+- [ ] **3.7** Final confirm with Soniya (time to arrive, snack table location) — 📞 Soniya check-in
+
+---
+
+## Phase 4 — Event day · Jun 12 · Gary
+
+### 4.1 Setup
+- [ ] **4.1.1** Arrive early — check in with Soniya, find the snack table
+- [ ] **4.1.2** Place two flasks + cups (stacked) + napkins + placard at the snack table
+- [ ] **4.1.3** Place the second placard copy in your bag (backup)
+- [ ] **4.1.4** Take a photo of the setup before attendees arrive
+
+### 4.2 During event
+- [ ] **4.2.1** Midday check: is a flask empty? Is the placard still visible and in place?
+- [ ] **4.2.2** Note any conversations about the cacao (who, what they asked, any retail interest)
+- [ ] **4.2.3** If Soniya does the stage shoutout: pay attention, note the timing
+- [ ] **4.2.4** Network. You're an attendee, not on shift.
+
+### 4.3 End of event
+- [ ] **4.3.1** Collect flasks and any remaining cups (leave the table clean)
+- [ ] **4.3.2** Quick photo of the setup at end-of-day (for contrast)
+- [ ] **4.3.3** Mental notes → jot down before you forget: names, conversations, what people said
+
+---
+
+## Phase 5 — Immediate post-event · Jun 13–14 · Claude + Gary
+
+- [ ] **5.1** Verify opt-in signups landed in `Agroverse News Letter Subscribers` tab *(Claude)*
+- [ ] **5.2** Count new subscribers → note delta *(Claude)*
+- [ ] **5.3** Add warm leads to Hit List (`Source: SF Tech Fest 2026`, `Status: Research`, Notes: what they tasted, what they said) *(Gary)*
+- [ ] **5.4** Verify `suggest_manager_followup_drafts.py` picked up new leads *(Claude)*
+- [ ] **5.5** Log activation as a **DApp Remark** — date, servings, farms served, notable conversations, what landed/didn't, photos *(Gary)*
+
+---
+
+## Phase 6 — Follow-up + story · Jun 15–26
+
+- [ ] **6.1** Manager Follow-up drafts for event leads *(Grok → Gary sends)*
+- [ ] **6.2** Personal 1:1 follow-ups with any contacts Gary made *(Gary)*
+- [ ] **6.3** Thank-you note to Soniya (warm, not transactional) *(Gary)*
+- [ ] **6.4** **No full-list newsletter** — skip unless a compelling story emerged *(decision: Gary)*
+- [ ] **6.5** Optional truesight.me reflection essay — if the day produced a real observation *(Claude drafts → Gary publishes)*
+
+---
+
+## Reminders — per-phase follow-ups
+
+| Phase | Target date | Follow-up due |
+|---|---|---|
+| 0 | ASAP (by Jun 5) | Confirm snack table, self-serve, shoutout, passes |
+| 1 | Jun 1–5 | QR codes minted, placard designed |
+| 2 | Jun 5–7 | Dry run passes |
+| 3 | Jun 8–11 | Placard printed, kit assembled |
+| 4 | Jun 12 | Setup, midday check, teardown |
+| 5 | Jun 13–14 | Signups verified, leads in Hit List |
+| 6 | Jun 15+ | Thank-you to Soniya, follow-ups |
+
+---
+
+*Created 2026-05-26 by Claude (Anthropic). Mirrors `implementation_roadmap.md`; update both if phasing changes.*

--- a/events/sftechfestjune26/event.json
+++ b/events/sftechfestjune26/event.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "slug": "sftechfestjune26",
+  "name": "SF Tech Fest 2026",
+  "status": "planning",
+  "status_note": "Date/venue confirmed; Phase 0 host confirmations (snack table, self-serve, shoutout, passes) pending with Soniya.",
+  "date": "2026-06-12",
+  "end_date": "2026-06-12",
+  "start_time": "11:00",
+  "end_time": "17:00",
+  "timezone": "America/Los_Angeles",
+  "venue": "ICC, 525 Los Coches St, Milpitas, CA 95035",
+  "city": "Milpitas, CA",
+  "host": { "name": "Soniya", "org": "SF Tech Fest" },
+  "format": "Two flasks — Oscar's ceremonial cacao + Paulo's cacao tea — 3 oz cups, self-serve at the snack table.",
+  "products": ["Oscar's ceremonial cacao (Bahia)", "Paulo's cacao tea (Pará)"],
+  "qr_codes": [
+    { "id": "SFTF_CC_2026", "landing": "agl4", "product": "Oscar's ceremonial cacao", "status": "pending" },
+    { "id": "SFTF_CT_2026", "landing": "agl8", "product": "Paulo's cacao tea", "status": "pending" }
+  ],
+  "owner": "Gary",
+  "next_milestone": { "phase": 0, "due": "2026-06-05", "what": "Confirm snack table / self-serve / stage shoutout / passes with Soniya" },
+  "reminders": { "apple_reminder": true, "apple_calendar": "Work", "check_in_date": "2026-05-27" },
+  "docs": {
+    "checklist": "EXECUTION_CHECKLIST.md",
+    "proposal": "proposal.md",
+    "roadmap": "implementation_roadmap.md"
+  },
+  "links": {}
+}

--- a/events/sftechfestjune26/event.json
+++ b/events/sftechfestjune26/event.json
@@ -24,7 +24,8 @@
   "docs": {
     "checklist": "EXECUTION_CHECKLIST.md",
     "proposal": "proposal.md",
-    "roadmap": "implementation_roadmap.md"
+    "roadmap": "implementation_roadmap.md",
+    "field_assets": "field_assets.md"
   },
   "links": {}
 }

--- a/events/sftechfestjune26/field_assets.md
+++ b/events/sftechfestjune26/field_assets.md
@@ -1,0 +1,79 @@
+# SF Tech Fest 2026 — field assets (placard copy)
+
+**Status:** DRAFT v0.1 for Gary's review
+**Register:** agroverse.shop voice — place-first, people-named, warm, **no price, no urgency, no heavy blockchain/DAO jargon.** The placard is the "silent ambassador" — it does all the talking since no one is pouring actively.
+**Print after the dry run** (the QR must resolve before anything is printed).
+
+---
+
+## 1. The placard — "scan to verify" *(the single card on the snack table)*
+
+> ### Taste it. Then trace it.
+>
+> **Oscar's Farm** ceremonial cacao — Bahia, Brazil
+> Deep, dark European chocolate. Buttery, velvety, smooth.
+>
+> **Paulo's Farm** cacao tea — Pará, the Amazon
+> Brewed from the cacao fruit. Bright, gently fruity, low-stimulant.
+>
+> Every cup traces back to a single farmer in Brazil.
+> **Scan to follow the bean from farm to cup** ↓
+>
+> `[ provenance QR ]` &nbsp;&nbsp;&nbsp; `[ keep in touch QR ]`
+> &nbsp;&nbsp; *see the tree* &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; *harvest notes, once a season*
+>
+> *Regenerating rainforest, one cacao at a time.* · agroverse.shop
+
+---
+
+## 2. Smaller placard variant (backup / if space is tight)
+
+> **Brazilian Amazon, in a cup.**
+>
+> Oscar's Farm · ceremonial cacao (Bahia)
+> Paulo's Farm · cacao tea (Pará)
+>
+> Traceable to the farmer. Scan to see the tree ↓
+>
+> `[ provenance QR ]` &nbsp; `[ keep in touch QR ]`
+>
+> agroverse.shop
+
+---
+
+## 3. The one-line story — what Gary says if asked *(not on the placard, for conversation)*
+
+> **"Single-estate cacao from Brazil. Every cup traces back to the farmer who grew it — the QR shows you exactly which tree."**
+
+Compression variants:
+- **5-second:** *"Single-farm cacao from the Amazon — you can trace it back to the tree."*
+- **If they ask about the tech:** *"The supply chain routing this from Bahia to your cup runs on the same AI agent patterns they're discussing on stage."* → gesture toward the Agentic AI panel room.
+- **Tree-planting (political-literacy guardrail):** lead with **indigenous inclusion and land restoration in the Xingu corridor** — not a bare "plant a tree" line. *(See `RETAILER_ONBOARDING_PLAYBOOK.md` §14, Brasil Kiss lesson.)*
+
+---
+
+## 4. What to leave OFF the placard *(register guardrails)*
+
+- ❌ Prices / "buy now" / order forms
+- ❌ "Limited time," countdowns, discount codes
+- ❌ Blockchain, Edgar, ledger terminology — keep it human
+- ❌ Agroverse branding as a logo-heavy presence — the domain `agroverse.shop` is enough
+- ❌ Any language that implies you should buy something
+- ✅ Farmer names, place names, taste, one invitation to scan
+
+---
+
+## 5. QR code references
+
+| Code | Farm | Destination |
+|---|---|---|
+| `SFTF_CC_2026` | Oscar's Farm (Bahia) — ceremonial cacao | agl4 landing page (consent + subscribe) |
+| `SFTF_CT_2026` | Paulo's Farm (Pará) — cacao tea | agl8 landing page (consent + subscribe) |
+
+UTM: `?utm_source=event&utm_medium=qr&utm_campaign=sftf-2026`
+
+Canonical artifacts in `TrueSightDAO/lineage-assets` repo: `qrs/<id>.json` + `pngs/<id>.png` + `qrs_index.json`.
+
+---
+
+*Drafted 2026-05-26 by Claude (Anthropic). Taste notes from `AGROVERSE_PRICE_LIST_AND_ASSETS.md`.*

--- a/events/sftechfestjune26/implementation_roadmap.md
+++ b/events/sftechfestjune26/implementation_roadmap.md
@@ -1,0 +1,142 @@
+# SF Tech Fest 2026 — Implementation roadmap
+
+**Companion to:** `proposal.md` (plan-of-record)
+**Event:** TECH FEST 2026 — Silicon Valley · India Community Center (ICC), Milpitas, CA
+**Date:** June 12, 2026 (Friday) · 11:00 AM – 5:00 PM PT
+**Format (confirmed):** two flasks — **Oscar's ceremonial cacao + Paulo's cacao tea** — + 3 oz cups + placard, self-serve at the snack table. No booth, no dedicated pourer, no selling.
+**Lead:** Claude (infra + narrative + QR pipeline) · **On the ground:** Gary · **Follow-up:** Grok
+
+---
+
+## Critical path (the chain the event rises and falls on)
+
+```
+Confirm date / venue / snack-table placement with Soniya
+        ↓
+Build placard copy + generate QR codes (provenance + opt-in)
+        ↓
+DRY RUN: scan a test QR, confirm signup lands + send_newsletter.py can address it   ← do NOT skip
+        ↓
+Print placard + assemble kit (flasks, cups, napkins)
+        ↓
+Event day: place flasks at snack table, placard visible → self-serve
+        ↓
+Post-event: verify signups → Hit List → DApp Remark
+```
+
+**Gate rule:** nothing gets printed until the dry run in Phase 2 passes.
+
+---
+
+## Phase 0 — Confirm remaining logistics with Soniya (now → Jun 5, T-1wk)  · Owner: Gary
+
+**Already confirmed:** two flasks + 3 oz cups + placard by the snack table. Gary + friend get free passes. **Date confirmed:** June 12, 2026 (Fri), 11:00 AM – 5:00 PM PT, ICC Milpitas.
+
+| # | Task | Output | Blocks |
+|---|---|---|---|
+| 0.1 | ~~Confirm date~~ → **June 12, 2026 confirmed** (from Luma schema + sftechfest.com) | Done | — |
+| 0.2 | Confirm **snack table location** — where is it relative to the main hall? Can we place the flasks there? | Setup plan | Placard placement |
+| 0.3 | Confirm **self-serve** is fine (no dedicated pourer) | Format lock | — |
+| 0.4 | Confirm **stage shoutout** — still on? Suggested timing? | Yes/no + when | Placard urgency (less needed if announced) |
+| 0.5 | Confirm **Gary + friend passes** — logistics | Entry plan | — |
+
+**Exit criteria:** snack table location, self-serve approval, and pass logistics locked. → unblocks Phase 1–2.
+
+---
+
+## Phase 1 — Build QR codes + placard (now → Jun 5, T-1wk)  · Owner: Claude
+
+| # | Task | Output |
+|---|---|---|
+| 1.1 | Generate QR batch `SFTF_CC_2026` (Oscar's ceremonial) + `SFTF_CT_2026` (Paulo's tea) via existing pipeline; publish to `lineage-assets` repo | QR PNGs + `qrs_index.json` entries |
+| 1.2 | Produce provenance QR targets (agl4/agl8 landing pages with consent + subscribe) — reuse existing pages, no new build | Working QR → signup pipeline |
+| 1.3 | Draft placard copy: farm names, taste notes, provenance QR, opt-in QR, agroverse.shop footer | Placard text (→ `field_assets.md`) |
+| 1.4 | Design placard layout (5x7, print-ready, two QRs + copy) | Placard PDF/PNG |
+
+**Register guardrails:** placard copy stays curatorial — no prices, no urgency, no blockchain jargon. Taste notes from `AGROVERSE_PRICE_LIST_AND_ASSETS.md`.
+
+---
+
+## Phase 2 — DRY RUN (Jun 5–7)  · Owner: Claude  ← gate
+
+| # | Task | Output |
+|---|---|---|
+| 2.1 | **Dry run:** print one test QR placard, scan both codes, confirm signup lands in `Agroverse News Letter Subscribers` tab | Pass/fail |
+| 2.2 | Confirm `send_newsletter.py` can address the new test subscriber | Pass/fail |
+| 2.3 | Verify provenance QR resolves to the correct lineage-assets page (no dead link / CORS) | Pass/fail |
+| 2.4 | Fix any issues | Green pipeline |
+
+**⛔ Gate:** Phase 3 printing proceeds **only when 2.1–2.3 pass.**
+
+---
+
+## Phase 3 — Print + assemble kit (Jun 8–11)  · Owner: Gary
+
+| # | Task | Output |
+|---|---|---|
+| 3.1 | Print the placard (5x7) — 2 copies (backup) | Physical placard |
+| 3.2 | Pull cacao for two flasks; log `[INVENTORY MOVEMENT]` | Stock + ledger entry |
+| 3.3 | Assemble kit: 2 flasks, cups, napkins, placard x2 | Event kit |
+| 3.4 | Day-of: pre-brew both flasks (Kirsten or Gary) | Flasks ready to go |
+
+**No kettle needed** — flasks arrive pre-brewed and hot.
+
+---
+
+## Phase 4 — Event day (Jun 12)  · Owner: Gary
+
+- **Arrive early.** Find Soniya, confirm the snack table location.
+- **Place two flasks + cups + napkins + placard** at the snack table. Self-serve. Visible. Unfussy.
+- **The placard is the whole presence.** No backdrop, no banner, no standing at the table.
+- **Gary networks** — free passes, full attendee.
+- **If Soniya does the stage shoutout:** great. If not, the placard handles it.
+- **Note conversations:** anyone who specifically mentions the cacao → mental note (name, what they asked, next step).
+- **Check midday:** is a flask empty? Reposition the placard if it got moved.
+- **3-5 photos** of the setup (for DApp Remark + internal record).
+
+---
+
+## Phase 5 — Immediate post-event (Jun 13–14)  · Owner: Claude
+
+| # | Task | Output |
+|---|---|---|
+| 5.1 | Verify opt-in signups landed in subscribers tab | Confirmed list |
+| 5.2 | Add warm leads to Hit List (`Source: SF Tech Fest 2026`, Notes) | Pipeline input |
+| 5.3 | Verify `suggest_manager_followup_drafts.py` picks up any new leads | Queued drafts |
+| 5.4 | Log activation as a **DApp Remark** (date, servings, farms, notable conversations, photos) | Training data |
+
+---
+
+## Phase 6 — Follow-up (Jun 15–26)
+
+| # | Task | Owner | Output |
+|---|---|---|---|
+| 6.1 | Manager Follow-up drafts for event leads | Grok (existing pipeline) → Gary sends | Warm-up touches |
+| 6.2 | Personal 1:1 follow-up with any contacts Gary made | Gary | Relationship |
+| 6.3 | **No full-list newsletter** — skip unless there's a specific story worth telling (Gary's call) | — | — |
+| 6.4 | Optional truesight.me essay if the day produced an observation | Claude (draft) → Gary (review/publish) | Essay |
+
+---
+
+## Milestone checklist (one-glance)
+
+- [ ] **M0** — Date, snack table, self-serve, passes confirmed with Soniya *(Gary)*
+- [ ] **M1** — QR codes minted + placard copy ready *(Claude)*
+- [ ] **M2** — ✅ **Dry run passes** ← gate
+- [ ] **M3** — Placard printed, kit assembled, flasks pre-brewed *(Gary)*
+- [ ] **M4** — Event executed: flasks at snack table, self-serve, Gary networks *(Gary)*
+- [ ] **M5** — Signups verified, leads in Hit List, DApp Remark logged *(Claude/Gary)*
+- [ ] **M6** — Follow-ups sent, essay (if warranted) *(Grok/Claude)*
+
+---
+
+## Decision points for Gary
+
+1. **Flasks** — Oscar's ceremonial + Paulo's tea (same pairing as Dual Tech Summit)? *Recommended: yes — proven combination, different taste registers.*
+2. **Stage shoutout** — push for it or let it go? *Recommended: ask Soniya gently, but don't press. The placard works either way.*
+3. **Newsletter** — skip full-list entirely? *Recommended: yes. This audience doesn't match the wellness list. 1:1 follow-ups only.*
+4. **Post-event essay** — worth writing? *Recommended: decide after the event based on what actually happened.*
+
+---
+
+*Roadmap authored 2026-05-26 by Claude (Anthropic). Date confirmed June 12, 2026 from Luma schema + sftechfest.com.*

--- a/events/sftechfestjune26/proposal.md
+++ b/events/sftechfestjune26/proposal.md
@@ -1,0 +1,222 @@
+# SF Tech Fest 2026 — Agroverse cacao activation proposal
+
+**Status:** DRAFT v0.1 — plan-of-record
+**Date:** 2026-05-26
+**Author:** Claude (Anthropic) — lead
+
+**Event:** TECH FEST 2026 — Silicon Valley
+**Date:** June 12, 2026 (Friday) · 11:00 AM – 5:00 PM PT
+**Where:** India Community Center (ICC), 525 Los Coches St, Milpitas, CA 95035
+**Host:** Orbis86 (Soniya Ahuja) · OffChain Global · Strategism Inc
+**Audience:** 500+ tech professionals, founders, decision-makers, Google/Oracle/IBM/Microsoft/OpenAI execs
+**Listing:** https://luma.com/sftechfest26
+**Website:** https://sftechfest.com/
+
+---
+
+## 0. Trigger & confirmation
+
+Gary reached out to Soniya (May 2026) after seeing the invitation, offering two flasks of cacao + cups. The conversation:
+
+> **Gary:** *"Happy to bring and offer two flask[s] of cacao along with some cups during the event."*
+
+> **Soniya:** *"The event has a bunch of attendees so two flasks won't really help but I can get you and a friend free passes perhaps? ... I can ask about placing these flask in the VIP/Speakers lounge though with your banner next to it. But I don't think I'll be able to have you guys setup and stay there. But you could leave your cards and we could do a shoutout on stage."*
+
+> **Gary:** *"I was thinking more like 2 flasks, some 3 oz cups and a small placard by the snack table. The placard will have details of our community efforts and a QR code on it for folks who are keen to find out more about it."*
+
+> **Soniya:** *"That would be very helpful."*
+
+**Format confirmed:** two flasks + 3 oz cups + a placard, placed at the snack table. Self-serve. Gary gets free passes for himself + a friend. Shoutout on stage is on the table (confirm with Soniya).
+
+---
+
+## 1. Recommendation in one paragraph
+
+Place two flasks of single-estate cacao by the snack table with a small placard — **no booth, no dedicated pourer, no selling.** This is a "silent ambassador" activation: the cacao and the placard do the work. At an event where Google's Chief AI Strategist keynotes and panels cover AI trust, agentic AI, and Web3, the hook writes itself: *"The supply chain they're architecting on stage? We built one too — and it ends in this cup."* Let the cacao be the non-alcoholic, mind-focusing counterpoint to an afternoon of high tea and happy hour. Capture curiosity through the QR code; let Gary network with the free passes. No full-list blast, no pre-event hype — just a quiet, taste-first presence that earns attention through what it is, not what it claims.
+
+---
+
+## 2. The frame — why this audience, why this format
+
+### 2.1 Audience fit
+
+| Speaker / Panel | Natural narrative bridge |
+|---|---|
+| Gopi Kallayil (Google, Chief AI Strategist) | "The supply chain routing your cacao from Bahia to Milpitas runs on AI agents." |
+| Panel 4: AI 2.0 — Building Trust Across the Stack | "You can verify every link in this cup's journey — not because we say so, because the ledger does." |
+| Panel 6: Agentic AI | "Same agent patterns they're discussing — we deployed them to route single-estate cacao from the Amazon." |
+| Panel 5: Can Web3 Still Matter? | "Here's a real asset, cryptographically traceable to a specific farmer in Brazil." |
+| OpenClaw Workshop (5:00 PM) | "The supply chain infrastructure that moves this cacao is built on the same multi-agent orchestration ClawCamp teaches." |
+
+### 2.2 Why passive / self-serve works here
+
+This is a **500+ person, all-day summit with gourmet lunch, high tea, and happy hour.** There's already food and beverage in the room. Cacao isn't competing — it's offering a different register entirely:
+
+- **Non-alcoholic, mind-enhancing** → the focused alternative during an afternoon of drinking
+- **Self-serve, no pitch** → the placard is the only "salesperson"; taste does the rest
+- **Placed at the snack table** → ambient discovery, not a destination booth
+- **Gary in the room (with free pass)** → can connect with anyone who tries the cacao and wants to talk, but isn't tethered to a table
+
+### 2.3 The one-line story — what the placard says
+
+> **"Single-estate cacao from Brazil. Every cup traces back to the farmer who grew it — scan to see the tree."**
+
+No prices. No "buy now." No crypto/blockchain jargon. Just taste, place, farmer's name, and an invitation to scan. The QR code carries the full provenance story for anyone curious enough to follow.
+
+---
+
+## 3. What we do NOT do
+
+- **No booth, no branded backdrop, no pitch deck.** The placard by the snack table is the whole footprint.
+- **No dedicated pourer / person staffing the table.** The flasks are self-serve. Gary is in the room as an attendee, not a vendor.
+- **No full-list newsletter blast** (pre or post) — wrong register for this audience.
+- **No promotional discount codes / "limited time."** Breaks the curatorial register.
+- **No cold outreach to attendee list.** It's not ours to scrape.
+- **No payment QR / checkout demo.** The QR on the placard is provenance + opt-in, not a store.
+
+> **Operating principle:** *the snack table is already a grab-and-go zone. Cacao fits there naturally — don't over-stage it.*
+
+---
+
+## 4. On-the-day execution
+
+### 4.1 Placement — snack table, self-serve
+
+| Summit moment | Cacao role |
+|---|---|
+| 11:00 AM – 12:00 PM (morning panels) | Alternative to coffee; sets a different tone |
+| 12:30 PM – 1:30 PM (Gourmet Lunch) | Alongside lunch; ambient discovery |
+| 2:00 PM – 4:00 PM (afternoon panels) | Focus beverage; non-alcoholic counterpoint before happy hour |
+| 5:00 PM onwards (High Tea & Happy Hour) | The sober, mind-enhancing option as alcohol flows |
+
+### 4.2 Format — two flasks, self-serve
+
+- **Two thermal flasks** — Oscar's Farm ceremonial cacao (Bahia) + Paulo's cacao tea (Pará) — pre-brewed and kept hot.
+- **3 oz cups stacked beside the flasks.**
+- **Small placard** (standalone or leaning against the flasks) with farm names, taste notes, provenance QR, and opt-in QR.
+- **Self-serve only** — attendees pour their own. No one stands at the table.
+- **Realistic yield:** two flasks ≈ a few dozen 3 oz servings. At 500+ people, most won't get a pour — and that's fine. The flask being empty by midday tells its own story.
+
+### 4.3 Gary's role — attendee, not vendor
+
+- Gary + friend attend with free passes.
+- **No shift at the table** — he's not staffing it, not hovering, not "manning" anything.
+- If someone mentions the cacao, he can talk story. Otherwise, he networks.
+- The placard carries the message; the QR carries the follow-up.
+
+---
+
+## 5. Placard & QR strategy
+
+### 5.1 The placard — what goes on it
+
+A single card (5x7 or similar), placed by the flasks:
+
+> ### Taste it. Then trace it.
+> **Oscar's Farm** ceremonial cacao (Bahia) — deep, buttery, smooth
+> **Paulo's Farm** cacao tea (Pará) — lighter, gently fruity, low-stimulant
+>
+> Every cup traces back to a single farmer in Brazil.
+> **Scan to follow the bean from farm to cup** ↓
+>
+> `[ provenance QR ]` · `[ keep in touch QR ]`
+>
+> *Regenerating rainforest, one cacao at a time.* · agroverse.shop
+
+### 5.2 QR codes
+
+| QR | Destination | Purpose |
+|---|---|---|
+| **Provenance / traceability** | Lineage assets — the serialized bag's tree-planting proof | "See the tree this cacao came from" |
+| **Opt-in / newsletter** | agl4/agl8 landing pages (consent + subscribe) | Permission capture; `utm_source=event&utm_medium=qr&utm_campaign=sftf-2026` |
+
+- **Tracking:** event-unique code `SFTF_2026` + UTM parameters for scan attribution.
+- **Provenance QR** reuses the existing batch generation pipeline (`AGROVERSE_QR_CODE_BATCH_GENERATION.md`).
+
+---
+
+## 6. Stage shoutout *(confirm with Soniya)*
+
+Soniya offered: *"we could do a shoutout on stage."* If she confirms, the tone should be:
+
+> *"Quick note — if you grab a snack during the break, you'll find two flasks of single-estate cacao from the Brazilian Amazon by the snack table. Every cup traces back to the farmer who grew it. Scan the placard to see the tree. Enjoy."*
+
+No mention of buying, no brand name-drop unless Soniya prefers it. ~30 seconds. Fits naturally during the **Sponsors Acknowledgement** block (3:00–3:15 PM) or right before a break.
+
+---
+
+## 7. Post-event loop
+
+- **Verify opt-in signups** landed in the Main Ledger `Agroverse News Letter Subscribers` tab.
+- **No newsletter to the full list.** If Gary exchanged contact info with specific people, follow up 1:1.
+- **Hit List:** any retail-interest conversations → `Source: SF Tech Fest 2026`.
+- **DApp Remark:** log the activation (date, servings, farms, notable conversations).
+- **Optional truesight.me essay** if the day produced an observation worth writing about (e.g., "500 AI engineers tasted cacao from a blockchain-verified supply chain. Here's what they asked.").
+
+---
+
+## 8. Materials & logistics
+
+| Item | Source | Notes |
+|---|---|---|
+| Flask 1 — Oscar's Farm ceremonial cacao (Bahia), pre-brewed + hot | Inventory / Kirsten prep | The rich ceremonial drink |
+| Flask 2 — Paulo's cacao tea (Pará), pre-brewed + hot | Inventory / Kirsten prep | Lighter cacao-fruit infusion |
+| Compostable cups (3 oz) | Stock / quick order | Stacked by the flasks |
+| Placard (5x7) with farm details + QR codes | Print | The "silent ambassador" |
+| QR codes (provenance + opt-in) | `AGROVERSE_QR_CODE_BATCH_GENERATION.md` pipeline | Minted after dry run |
+| Napkins | Stock | Basic courtesy |
+
+**Not needed:** kettle (flasks arrive hot), backdrop, banner, booth, cards (the placard covers it).
+
+---
+
+## 9. Cost
+
+| Item | Estimate |
+|---|---|
+| Cacao for two flasks (from inventory) | Low — cost basis only |
+| Cups + napkins | ~$10–$20 |
+| Placard printing | Near zero |
+| Gary + friend passes | Free (Soniya offered) |
+| Gary's time | 1 day (attending anyway) |
+
+No new tooling. No paid sponsorship.
+
+---
+
+## 10. Measurement
+
+| Signal | How |
+|---|---|
+| QR scans (unique + total) | `SFTF_2026` redirect counter + UTM |
+| Newsletter opt-ins | `Agroverse News Letter Subscribers` row delta |
+| Retail interest | Hit List rows tagged `SF Tech Fest 2026` |
+| Qualitative | DApp Remark: what people said, what they asked |
+
+**Explicitly not a metric:** bags sold. Selling is not the job.
+
+---
+
+## 11. Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Flasks run out in first hour | Medium | Good — scarcity signals demand. Cacao isn't meant to serve 500 people. |
+| Table is far from foot traffic | Low | Confirm snack table location with Soniya beforehand |
+| Placard gets moved / lost | Low | Bring a backup; tape the placard to the flasks if needed |
+| QR → signup pipeline breaks | Medium | **Pre-event dry run** — scan a test QR, verify signup lands before the event |
+| No one scans the QR | Low–Med | Place codes prominently on placard; the provenance hook is inherently curiosity-driving for a tech crowd |
+| Date / venue wrong in our materials | Medium | **Confirm exact event date with Soniya before printing anything** |
+
+---
+
+## 12. Open questions / asks for Soniya
+
+1. **Confirm snack table location** — where is it relative to the main hall? Can we place the flasks there?
+2. **Confirm self-serve is fine** — no dedicated pourer, attendees help themselves.
+3. **Shoutout on stage** — still on? If so, when would it fit best? (Suggested: Sponsors Acknowledgement block.)
+4. **Gary + friend passes** — confirm logistics for getting them in.
+
+---
+
+*Proposal authored 2026-05-26 by Claude (Anthropic). Grounded in `CMO_SETH_GODIN.md`, `EDITORIAL_TONE.md`, `AGROVERSE_NEWSLETTER_WORKFLOW.md`, `PURPOSE_AND_MISSION.md`, and `AGROVERSE_QR_CODE_BATCH_GENERATION.md`. Implementation steps in `implementation_roadmap.md` (same folder).*


### PR DESCRIPTION
Adds a machine-readable event registry under `events/`, mirroring the lineage-assets `qrs/<id>.json` + `qrs_index.json` pattern.

- **`events/<slug>/event.json`** — per-event source of truth (3 events: SF Tech Fest Jun 12, Onsen Global Forum Jun 23, Dual Tech Summit Jun 26)
- **`events/index.json`** — generated, date-sorted aggregate (read this first)
- **`events/build_index.py`** — regenerates the index from the per-event files
- **`events/README.md`** — short pointer
- Also commits the SF Tech Fest + Onsen source docs (checklist/proposal/roadmap) that were authored but never committed

Convention documented in `agentic_ai_context/EVENTS.md` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)