### PR TITLE
advisory snapshot: stop sourcing OpenClaw (retired)

### DIFF
--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -104,7 +104,6 @@ ADVISORY_KEYWORDS = (
 # PROJECT_INDEX “pipelines” → local clone dirname under Applications/ (must exist to compare git).
 PIPELINE_TO_REPO: dict[str, str] = {
     "go_to_market": "market_research",
-    "openclaw": "agentic_ai_context",
     "TrueChain": "TrueChain",
     "oracle": "iching_oracle",
 }
@@ -1898,7 +1897,6 @@ def _canonical_context_urls() -> list[str]:
     return [
         f"{_RAW_CTX_BASE}/WORKSPACE_CONTEXT.md",
         f"{_RAW_CTX_BASE}/PROJECT_INDEX.md",
-        f"{_RAW_CTX_BASE}/OPENCLAW_WHATSAPP.md",
         f"{_RAW_CTX_BASE}/GOVERNANCE_SOURCES.md",
         f"{_RAW_CTX_BASE}/LEDGER_CONVERSION_AND_REPACKAGING.md",
         f"{_RAW_CTX_BASE}/CONTEXT_UPDATES.md",


### PR DESCRIPTION
OpenClaw is retired, but the daily advisory snapshot (consumed by the oracle at oracle.truesight.me, refreshed every 6h) still pulled it in. Removes the two references in `generate_advisory_snapshot.py`:
- drop `OPENCLAW_WHATSAPP.md` from `_canonical_context_urls()`
- drop the `"openclaw"` entry from `PIPELINE_TO_REPO`

The published `ADVISORY_SNAPSHOT.md` self-heals on the next 6h refresh. `OPENCLAW_WHATSAPP.md` stays in agentic_ai_context as retained legacy history. The main whitepaper was checked and is already clean of OpenClaw.

Tested: `python -m py_compile` OK; no OpenClaw refs remain in the generator.