### PR TITLE
Advisory snapshot: embed attention-surfaces catalog

### DIFF
--- a/scripts/generate_advisory_snapshot.py
+++ b/scripts/generate_advisory_snapshot.py
@@ -1777,6 +1777,19 @@ def _build_markdown(
         "Refreshed by tokenomics `pipeline_metrics_snapshot` GAS.",
     ))
 
+    # Attention surfaces — the stable catalog of WHERE attention can go.
+    # At daily oracle readings the advisor maps the draw's quality onto 1–3
+    # of these surfaces (quality × staleness × mission-weight), checking each
+    # surface's named signal before recommending. Canonical:
+    # agentic_ai_context/ATTENTION_SURFACES.md (+ attention_surfaces.json).
+    parts.append(_read_operator_block(
+        ctx_root / "ATTENTION_SURFACES.md",
+        "## Attention surfaces (catalog for draw-time direction)",
+        "Stable catalog of the ecosystem's ten attention surfaces (signals, levers, staleness "
+        "hints, trigram affinities). The oracle advisor maps each daily draw onto 1–3 of these, "
+        "evidence-first.",
+    ))
+
     # Operations health — supply pipeline + cash float. Placed before
     # activity/log evidence so the oracle reads concrete stock/freight/cash
     # state ahead of narrative context. Source of truth for the structured


### PR DESCRIPTION
## Goal
Surface the new attention-surfaces catalog (agentic_ai_context/ATTENTION_SURFACES.md — ten ecosystem surfaces + trigram resonance layer) inside ADVISORY_SNAPSHOT.md so the oracle advisor at oracle.truesight.me and Sophia both see it with zero new plumbing.

## Changes
- `generate_advisory_snapshot.py`: one `_read_operator_block` call after the operator-metrics block, embedding `ctx_root/ATTENTION_SURFACES.md` under '## Attention surfaces (catalog for draw-time direction)'. Missing-file case degrades gracefully (the operator-block pattern emits a visible edit prompt).

## Testing
`ast.parse` clean. Section renders on next 6-hourly advisory-snapshot-refresh run (catalog already merged in agentic_ai_context PR #288).

## Rollout / follow-ups
truesight_autopilot PR adds the matching prompt protocol for Sophia.