### PR TITLE
Warm-up auto-send: clean-tier drafts send themselves (capped, kill-switched)

### DIFF
--- a/.github/workflows/warmup_autosend.yml
+++ b/.github/workflows/warmup_autosend.yml
@@ -1,0 +1,96 @@
+# Auto-send the linter-clean tier of AI/Warm-up Gmail drafts.
+#
+# Graduation of the human send-click for machine-checked first touches —
+# see agentic_ai_context/WARMUP_AUTOSEND_PLAN.md (assessment, guardrails,
+# rollback) and HIT_LIST_STATE_MACHINE.md § Operator review loop.
+#
+# Guardrails:
+#   - Scheduled runs are armed ONLY when repo variable WARMUP_AUTOSEND_ENABLED
+#     == 'true' (Settings → Secrets and variables → Actions → Variables).
+#     Unset/false = the workflow no-ops; drafts wait for human review as before.
+#   - Drip cadence: weekdays ~9am PT, default cap 12 sends per run
+#     (send_clean_warmup_drafts.py --max-sends).
+#   - Any red/yellow lint flag, or Hosts Circles=Yes, keeps a draft in the
+#     human review queue (preview_warmup_drafts.py).
+#   - Rollback: set WARMUP_AUTOSEND_ENABLED=false. No deploy needed.
+#
+# After sending, the same run invokes sync_email_agent_followup.py so the
+# Gmail label swap (AI/Warm-up → AI/Sent Warm-up) and the Email Agent Follow Up
+# log row land immediately instead of waiting for the hourly sync.
+#
+# Secrets: GOOGLE_CREDENTIALS_JSON, GMAIL_TOKEN_JSON
+
+name: Warm-up auto-send (clean tier)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — list the would-send cohort, no Gmail sends'
+        type: boolean
+        default: false
+      max_sends:
+        description: 'Cap sends this run'
+        type: string
+        default: '12'
+  schedule:
+    - cron: '5 17 * * 1-5'   # weekdays 17:05 UTC ≈ 9:05am PT
+
+concurrency:
+  group: warmup-autosend
+  cancel-in-progress: false
+
+jobs:
+  autosend:
+    name: Send clean warm-up drafts
+    runs-on: ubuntu-latest
+    # Scheduled runs require the arm switch; manual dispatch reflects explicit
+    # operator intent and runs regardless (still dry-run capable via input).
+    if: github.event_name == 'workflow_dispatch' || vars.WARMUP_AUTOSEND_ENABLED == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create Google credentials file
+        env:
+          GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
+        run: |
+          echo "$GOOGLE_CREDENTIALS_JSON" > google_credentials.json
+
+      - name: Send clean warm-up drafts
+        env:
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+          INPUT_MAX_SENDS: ${{ github.event.inputs.max_sends }}
+        run: |
+          MAX="${INPUT_MAX_SENDS:-12}"
+          if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
+            python scripts/send_clean_warmup_drafts.py --max-sends "$MAX"
+          else
+            python scripts/send_clean_warmup_drafts.py --execute --max-sends "$MAX"
+          fi
+
+      - name: Reconcile labels + Follow Up log (immediate sync)
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
+        run: |
+          python scripts/sync_email_agent_followup.py

--- a/scripts/preview_warmup_drafts.py
+++ b/scripts/preview_warmup_drafts.py
@@ -52,7 +52,9 @@ PENDING_STATUS = "pending_review"
 HOSTS_CIRCLES_COL = "Hosts Circles"
 
 GENERIC_INBOX_RE = re.compile(
-    r"^(info|sales|hello|contact|admin|support|orders|hi|team|enquiry|enquiries|inquiry|inquiries)@",
+    r"^(info|sales|hello|contact|admin|support|orders|hi|team|enquiry|enquiries|inquiry|inquiries"
+    r"|compliance|billing|accounts|accounting|legal|privacy|webmaster|postmaster"
+    r"|noreply|no-reply|donotreply|office|reception|frontdesk|filler)@",
     re.IGNORECASE,
 )
 GENERIC_SALUTATION_RE = re.compile(
@@ -60,6 +62,31 @@ GENERIC_SALUTATION_RE = re.compile(
 )
 PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}|\[[A-Z_]{3,}\]")
 NON_LATIN_RE = re.compile(r"[Ѐ-ӿ一-鿿぀-ヿ؀-ۿ]")
+
+# Consumer mailbox providers — a shop legitimately using one of these tells us
+# nothing about ownership, so the email_domain_mismatch rule only fires for
+# *custom* recipient domains that differ from the Hit List Website domain.
+FREEMAIL_DOMAINS = {
+    "gmail.com", "yahoo.com", "ymail.com", "hotmail.com", "outlook.com",
+    "live.com", "msn.com", "aol.com", "icloud.com", "me.com", "mac.com",
+    "proton.me", "protonmail.com", "pm.me", "mail.com", "gmx.com", "gmx.net",
+    "comcast.net", "att.net", "verizon.net", "sbcglobal.net", "qq.com",
+    "zoho.com", "fastmail.com", "hey.com",
+}
+
+
+def _website_host(url: str) -> str:
+    """Bare registrable host from a Hit List Website cell ('' on miss).
+    'https://www.seagrapeapothecary.com/about' -> 'seagrapeapothecary.com'."""
+    u = (url or "").strip()
+    if not u:
+        return ""
+    u = re.sub(r"^[a-z][a-z0-9+.-]*://", "", u, flags=re.IGNORECASE)
+    host = u.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0].strip().lower()
+    host = host.split("@")[-1].split(":")[0]  # drop userinfo / port
+    if host.startswith("www."):
+        host = host[4:]
+    return host
 
 SEV_RED = "red"
 SEV_YELLOW = "yellow"
@@ -97,6 +124,7 @@ def _load_hit_list_index(ws) -> tuple[dict, dict, int | None]:
     city_i = hdr.get("City")
     state_i = hdr.get("State")
     status_i = hdr.get("Status")
+    website_i = hdr.get("Website")
     aw_i = hdr.get(HOSTS_CIRCLES_COL)
 
     by_email: dict[str, dict] = {}
@@ -112,6 +140,7 @@ def _load_hit_list_index(ws) -> tuple[dict, dict, int | None]:
             "notes": smf.cell(row, notes_i) if notes_i is not None else "",
             "city_state": ", ".join(x for x in [city, state] if x),
             "status": smf.cell(row, status_i) if status_i is not None else "",
+            "website": smf.cell(row, website_i) if website_i is not None else "",
         }
         if em and em not in by_email:
             by_email[em] = payload
@@ -207,6 +236,21 @@ def _lint(draft: dict, body: str, subject: str, hit: dict | None, dapp_count: in
         out.append((SEV_RED, "body_too_short", f"Body is only {len(body)} chars — generation likely truncated"))
     if not body.strip():
         out.append((SEV_RED, "body_empty", "Body is empty (Gmail draft missing or fetch failed)"))
+    if em and hit is not None:
+        em_dom = em.rsplit("@", 1)[-1].lower()
+        site_host = _website_host(hit.get("website", ""))
+        if (
+            site_host
+            and em_dom not in FREEMAIL_DOMAINS
+            and em_dom != site_host
+            and not em_dom.endswith("." + site_host)
+            and not site_host.endswith("." + em_dom)
+        ):
+            out.append((
+                SEV_RED,
+                "email_domain_mismatch",
+                f"Recipient domain {em_dom} ≠ website domain {site_host} — may be an agency / third-party inbox",
+            ))
 
     if hit is not None:
         if not hit.get("city_state"):

--- a/scripts/send_clean_warmup_drafts.py
+++ b/scripts/send_clean_warmup_drafts.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Auto-send the **linter-clean** tier of AI/Warm-up Gmail drafts.
+
+Graduation of the operator review loop documented in
+``agentic_ai_context/HIT_LIST_STATE_MACHINE.md`` (§ Operator review loop) and
+``agentic_ai_context/WARMUP_AUTOSEND_PLAN.md``: warm-up drafts with **zero red
+and zero yellow lint flags** no longer wait for a human send-click — they are
+sent directly via the Gmail API, capped per run, oldest first. Everything with
+any flag at all stays in the human review queue exactly as before
+(``preview_warmup_drafts.py`` + Gmail ``AI/Warm-up`` label).
+
+Evidence gate for this graduation (see WARMUP_AUTOSEND_PLAN.md §1): ~6%
+genuine reply rate across 232 audited threads, zero copy complaints, while the
+pending_review backlog sat a median 24 days on the human click.
+
+Safety posture
+--------------
+- Same lint pass as ``preview_warmup_drafts.py`` (including the
+  ``email_domain_mismatch`` red rule). Clean = no red AND no yellow.
+- **Hosts Circles=Yes prospects are excluded by default** — high-leverage rows
+  keep human eyes (``--include-hosts-circles`` to override).
+- ``--dry-run`` is the **default**; pass ``--execute`` to actually send.
+- ``--max-sends`` caps each run (default 12) — drip cadence protects sender
+  reputation vs the historical 90+ one-day bursts.
+- After each send the ``Email Agent Drafts`` row flips
+  ``pending_review → sent`` immediately (plus ``gmail_message_id`` /
+  ``thread_id`` and an audit note); the hourly
+  ``email-agent-sync-followup.yml`` run completes the Gmail label swap
+  (``AI/Warm-up`` → ``AI/Sent Warm-up``) and the ``Email Agent Follow Up``
+  log row via its existing reconcile paths.
+
+Usage::
+
+    cd market_research
+    python3 scripts/send_clean_warmup_drafts.py                 # dry-run listing
+    python3 scripts/send_clean_warmup_drafts.py --execute
+    python3 scripts/send_clean_warmup_drafts.py --execute --max-sends 5
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import gspread
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import preview_warmup_drafts as pw  # noqa: E402  (lint rules + loaders)
+import suggest_manager_followup_drafts as smf  # noqa: E402  (creds + sheet helpers)
+
+DRAFTS_WS = "Email Agent Drafts"
+AUTOSEND_NOTE = "auto-sent by send_clean_warmup_drafts"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _classify(draft: dict, service, by_email: dict, by_store: dict, dapp_counts: dict) -> dict:
+    """Fetch the Gmail draft, lint it, and return a decision payload."""
+    subject, body, _to_hdr, message_id = pw._fetch_draft(service, draft["draft_id"])
+    hit = by_email.get(draft["to_email"]) or by_store.get(draft["store_key"])
+    dapp_count = dapp_counts.get((draft["shop_name"] or "").lower(), 0)
+    flags = pw._lint(draft, body, subject, hit, dapp_count)
+    reds = [f for f in flags if f[0] == pw.SEV_RED]
+    yellows = [f for f in flags if f[0] == pw.SEV_YELLOW]
+    hosts_circles = bool(hit and hit.get("hosts_circles"))
+    return {
+        **draft,
+        "subject": subject,
+        "body_len": len(body),
+        "message_id": message_id,
+        "flags": flags,
+        "reds": reds,
+        "yellows": yellows,
+        "hosts_circles": hosts_circles,
+    }
+
+
+def _flip_rows_sent(ws, decisions: list[dict]) -> int:
+    """Batch-flip Email Agent Drafts rows for sent drafts: status, ids, note.
+    Mirrors the cell-batch pattern of sync_email_agent_followup.py
+    ``reconcile_drafts_status_to_sent``."""
+    values = ws.get_all_values()
+    hdr = smf.header_map(values[0])
+    i_status = hdr.get("status")
+    i_msg = hdr.get("gmail_message_id")
+    i_thread = hdr.get("thread_id")
+    i_notes = hdr.get("notes")
+    if i_status is None:
+        sys.stderr.write("Email Agent Drafts missing 'status' column\n")
+        return 0
+    cells: list[gspread.Cell] = []
+    for d in decisions:
+        r = d["sheet_row"]
+        cells.append(gspread.Cell(r, i_status + 1, "sent"))
+        if i_msg is not None and d.get("sent_message_id"):
+            cells.append(gspread.Cell(r, i_msg + 1, d["sent_message_id"]))
+        if i_thread is not None and d.get("sent_thread_id"):
+            cells.append(gspread.Cell(r, i_thread + 1, d["sent_thread_id"]))
+        if i_notes is not None:
+            prior = smf.cell(values[r - 1], i_notes) if r - 1 < len(values) else ""
+            note = f"{AUTOSEND_NOTE} {d['sent_at']}"
+            cells.append(gspread.Cell(r, i_notes + 1, f"{prior} | {note}".strip(" |")))
+    if cells:
+        ws.update_cells(cells, value_input_option="RAW")
+    return len(decisions)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--execute", action="store_true",
+                    help="Actually send. Default is a dry-run listing.")
+    ap.add_argument("--max-sends", type=int, default=12,
+                    help="Cap sends per run (default 12 — drip cadence).")
+    ap.add_argument("--include-hosts-circles", action="store_true",
+                    help="Also auto-send Hosts Circles=Yes prospects "
+                         "(default: excluded — they keep human review).")
+    args = ap.parse_args(argv)
+
+    sa = smf.get_sheets_client()
+    sh = sa.open_by_key(smf.SPREADSHEET_ID)
+    hit_ws = sh.worksheet(smf.HIT_LIST_WS)
+    drafts_ws = sh.worksheet(DRAFTS_WS)
+    remarks_ws = smf.open_dapp_remarks_worksheet(sh)
+
+    service = build("gmail", "v1", credentials=smf.get_gmail_creds(), cache_discovery=False)
+
+    by_email, by_store, _aw = pw._load_hit_list_index(hit_ws)
+    dapp_counts = pw._load_dapp_remarks_counts(remarks_ws) if remarks_ws else {}
+    pending = pw._load_pending_warmup_drafts(drafts_ws)
+    pending.sort(key=lambda d: d.get("created_at") or "")  # oldest first
+
+    clean: list[dict] = []
+    skipped: list[dict] = []
+    for draft in pending:
+        d = _classify(draft, service, by_email, by_store, dapp_counts)
+        if d["reds"] or d["yellows"]:
+            d["skip_reason"] = "; ".join(c for _s, c, _m in d["reds"] + d["yellows"])
+            skipped.append(d)
+        elif d["hosts_circles"] and not args.include_hosts_circles:
+            d["skip_reason"] = "hosts_circles (human review by default)"
+            skipped.append(d)
+        elif not d["body_len"]:
+            d["skip_reason"] = "gmail draft missing"
+            skipped.append(d)
+        else:
+            clean.append(d)
+
+    to_send = clean[: max(args.max_sends, 0)]
+    overflow = clean[len(to_send):]
+
+    print(f"pending_review AI/Warm-up drafts: {len(pending)}")
+    print(f"  clean tier: {len(clean)}  (sending {len(to_send)}, "
+          f"{len(overflow)} deferred to next run by --max-sends)")
+    print(f"  kept for human review: {len(skipped)}")
+    for d in skipped:
+        print(f"    REVIEW  {d['shop_name'][:40]:40} <{d['to_email']}>  [{d['skip_reason']}]")
+    for d in to_send:
+        print(f"    {'SEND' if args.execute else 'WOULD SEND':10} "
+              f"{d['shop_name'][:40]:40} <{d['to_email']}>  created {d['created_at']}")
+
+    if not args.execute:
+        print("\ndry-run (default) — pass --execute to send.")
+        return 0
+
+    sent: list[dict] = []
+    for d in to_send:
+        try:
+            resp = service.users().drafts().send(
+                userId="me", body={"id": d["draft_id"]}
+            ).execute()
+        except HttpError as e:
+            if smf.is_missing_draft_http_error(e):
+                sys.stderr.write(f"draft vanished, skipping: {d['shop_name']} <{d['to_email']}>\n")
+                continue
+            raise
+        d["sent_message_id"] = str(resp.get("id") or "")
+        d["sent_thread_id"] = str(resp.get("threadId") or "")
+        d["sent_at"] = _now_iso()
+        sent.append(d)
+        print(f"sent: {d['shop_name']} <{d['to_email']}> message_id={d['sent_message_id']}")
+
+    flipped = _flip_rows_sent(drafts_ws, sent)
+    print(f"\nsent {len(sent)} drafts; flipped {flipped} Email Agent Drafts rows to status=sent.")
+    print("label swap + Email Agent Follow Up logging completes on the next "
+          "email-agent-sync-followup.yml run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Goal
Graduate the linter-clean tier of AI/Warm-up drafts from human click-to-send to automated drip sending, per [WARMUP_AUTOSEND_PLAN.md](https://github.com/TrueSightDAO/agentic_ai_context/blob/main/WARMUP_AUTOSEND_PLAN.md) (PR1). Evidence gate from HIT_LIST_STATE_MACHINE.md met: ~6% genuine reply rate, zero copy complaints, while 98 drafts sat median 24 days on the human send-click.

## Changes
- **scripts/send_clean_warmup_drafts.py** (new): selects `pending_review` + `AI/Warm-up` drafts, lints with the shared rules, sends only zero-red/zero-yellow drafts via Gmail `drafts().send()`, oldest first, `--max-sends` cap (default 12). `--dry-run` is the default; `--execute` required to send. Hosts Circles=Yes excluded by default. Flips Email Agent Drafts rows to `sent` (+message/thread ids + audit note) in one batch update.
- **scripts/preview_warmup_drafts.py**: new red rule `email_domain_mismatch` (custom recipient domain ≠ Hit List Website domain); `generic_inbox` extended (compliance/billing/office/reception/filler/etc); Hit List index carries Website.
- **.github/workflows/warmup_autosend.yml** (new): weekdays 17:05 UTC ≈ 9am PT; scheduled runs armed only when repo variable `WARMUP_AUTOSEND_ENABLED == 'true'`; `workflow_dispatch` with `dry_run`/`max_sends` inputs; runs `sync_email_agent_followup.py` post-send for immediate label swap + Follow Up logging.

## Testing
Live dry-run against production sheet + Gmail (74 pending drafts): 18 clean / 12 capped would-send / 56 held for review. The new rules caught real misfires that would have auto-sent: `compliance@4life.com` (wrong company), `filler@godaddy.com` (placeholder), `info@stonesthrowgifts.com` for Song Birds Centre (domain mismatch). `py_compile` clean on both scripts.

## Rollout
1. Merge. 2. Create repo variable `WARMUP_AUTOSEND_ENABLED=true` to arm the schedule (ships disarmed). 3. Optionally observe first run via `workflow_dispatch` with `dry_run=true`. Rollback = set the variable to `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)