### PR TITLE
Lint policy: own-domain generic inboxes are auto-sendable

### DIFF
--- a/scripts/preview_warmup_drafts.py
+++ b/scripts/preview_warmup_drafts.py
@@ -224,7 +224,26 @@ def _lint(draft: dict, body: str, subject: str, hit: dict | None, dapp_count: in
         out.append((SEV_RED, "fallback_shop_name", "Body uses fallback 'your shop' (shop name was missing at gen time)"))
     em = draft.get("to_email", "")
     if em and GENERIC_INBOX_RE.match(em):
-        out.append((SEV_RED, "generic_inbox", f"Generic inbox ({em.split('@')[0]}@) — likely not read by decision maker"))
+        # Policy change 2026-06-05 (data-backed): a generic prefix on the
+        # shop's OWN domain is its primary contact channel, not a dead drop —
+        # The Way Home Shop converted to Partnered via info@thewayhomeshop.com,
+        # and Seagrape / Esalen / Good Vibrations replies all came from
+        # own-domain generic inboxes. Own-domain generic → blue (informational,
+        # auto-sendable). Generic on a freemail or unverifiable domain stays
+        # red (third-party domains are caught by email_domain_mismatch below).
+        em_dom = em.rsplit("@", 1)[-1].lower()
+        site_host = _website_host(hit.get("website", "")) if hit else ""
+        own_domain = bool(
+            site_host
+            and (em_dom == site_host
+                 or em_dom.endswith("." + site_host)
+                 or site_host.endswith("." + em_dom))
+        )
+        if own_domain:
+            out.append((SEV_BLUE, "generic_inbox_own_domain",
+                        f"Generic prefix on the shop's own domain ({em}) — primary contact channel"))
+        else:
+            out.append((SEV_RED, "generic_inbox", f"Generic inbox ({em.split('@')[0]}@) — likely not read by decision maker"))
     first_3_lines = "\n".join(body.splitlines()[:3])
     if GENERIC_SALUTATION_RE.search(first_3_lines):
         out.append((SEV_RED, "no_first_name", "Salutation is generic ('Hi there' / 'Hello team') — no first-name parse"))


### PR DESCRIPTION
## Goal
The `generic_inbox` red flag is empirically too strict: the only email-only Partnered conversion (The Way Home Shop) came through `info@thewayhomeshop.com`, and the Seagrape / Esalen / Good Vibrations replies all arrived from own-domain generic inboxes. A generic prefix on the shop's **own** domain is its primary contact channel.

## Change
`generic_inbox` stays **red** only when the domain is freemail or can't be matched to the Hit List Website; when the recipient domain matches the shop's website it becomes **blue** `generic_inbox_own_domain` (informational → auto-send eligible). Third-party domains are still blocked by `email_domain_mismatch`.

## Testing
Live dry-run on the 53 pending drafts: clean tier 18 → 21; zero drafts now held for generic_inbox alone; remaining review queue = 20 × `fallback_shop_name` (being regenerated), 11 × Hosts Circles (intentionally human), 1 × genuine domain mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)