### PR TITLE
Reply-only involvement: every pre-reply state is machine-handled

### DIFF
--- a/scripts/hit_list_enrich_contact.py
+++ b/scripts/hit_list_enrich_contact.py
@@ -110,9 +110,12 @@ SESSION.headers.update(
 PLACE_ID_IN_NOTES = re.compile(
     r"(?i)place[_\s-]*id\s*:\s*([A-Za-z0-9_-]{12,})",
 )
-# Dead inboxes recorded by handle_warmup_bounces.py — never re-pick these.
+# Addresses we must never re-pick: bounced_email= written by
+# handle_warmup_bounces.py (delivery failures), bad_email= written by
+# send_clean_warmup_drafts.py (positive wrongness evidence, e.g. a marketing
+# agency's inbox flagged by email_domain_mismatch).
 BOUNCED_EMAIL_IN_NOTES = re.compile(
-    r"(?i)bounced_email=([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})",
+    r"(?i)(?:bounced|bad)_email=([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})",
 )
 DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
 

--- a/scripts/preview_warmup_drafts.py
+++ b/scripts/preview_warmup_drafts.py
@@ -224,13 +224,14 @@ def _lint(draft: dict, body: str, subject: str, hit: dict | None, dapp_count: in
         out.append((SEV_RED, "fallback_shop_name", "Body uses fallback 'your shop' (shop name was missing at gen time)"))
     em = draft.get("to_email", "")
     if em and GENERIC_INBOX_RE.match(em):
-        # Policy change 2026-06-05 (data-backed): a generic prefix on the
-        # shop's OWN domain is its primary contact channel, not a dead drop —
-        # The Way Home Shop converted to Partnered via info@thewayhomeshop.com,
-        # and Seagrape / Esalen / Good Vibrations replies all came from
-        # own-domain generic inboxes. Own-domain generic → blue (informational,
-        # auto-sendable). Generic on a freemail or unverifiable domain stays
-        # red (third-party domains are caught by email_domain_mismatch below).
+        # Policy 2026-06-05, tightened same day per operator's reply-only
+        # principle: generic_inbox is NEVER red. Own-domain generic inboxes
+        # converted a partner (The Way Home Shop via info@) and produced
+        # multiple genuine replies; unverifiable ones are simply the shop's
+        # only listed address — sending to it is what a human would do, and
+        # the bounce handler is the safety net for dead inboxes. The only
+        # address-blocking signal is positive wrongness evidence, which
+        # email_domain_mismatch (red, below) carries on its own.
         em_dom = em.rsplit("@", 1)[-1].lower()
         site_host = _website_host(hit.get("website", "")) if hit else ""
         own_domain = bool(
@@ -243,7 +244,9 @@ def _lint(draft: dict, body: str, subject: str, hit: dict | None, dapp_count: in
             out.append((SEV_BLUE, "generic_inbox_own_domain",
                         f"Generic prefix on the shop's own domain ({em}) — primary contact channel"))
         else:
-            out.append((SEV_RED, "generic_inbox", f"Generic inbox ({em.split('@')[0]}@) — likely not read by decision maker"))
+            out.append((SEV_BLUE, "generic_inbox",
+                        f"Generic inbox ({em.split('@')[0]}@) — domain unverified; "
+                        "wrongness evidence is email_domain_mismatch's job"))
     first_3_lines = "\n".join(body.splitlines()[:3])
     if GENERIC_SALUTATION_RE.search(first_3_lines):
         out.append((SEV_RED, "no_first_name", "Salutation is generic ('Hi there' / 'Hello team') — no first-name parse"))

--- a/scripts/send_clean_warmup_drafts.py
+++ b/scripts/send_clean_warmup_drafts.py
@@ -119,6 +119,146 @@ def _flip_rows_sent(ws, decisions: list[dict]) -> int:
     return len(decisions)
 
 
+REGEN_NOTE = "auto-discarded for regen by send_clean_warmup_drafts"
+REROUTABLE_STATUSES = {
+    "AI: Warm up prospect", "AI: Email found", "AI: Prospect replied",
+    "Manager Follow-up", "Followed Up",
+}
+
+
+def _prior_regen_recipients(drafts_ws) -> set[str]:
+    """to_emails that already burned their one automatic regen attempt."""
+    values = drafts_ws.get_all_values()
+    if len(values) < 2:
+        return set()
+    hdr = smf.header_map(values[0])
+    i_to, i_notes = hdr.get("to_email"), hdr.get("notes")
+    out: set[str] = set()
+    for row in values[1:]:
+        if REGEN_NOTE in smf.cell(row, i_notes):
+            em = smf.normalize_email(smf.cell(row, i_to))
+            if em:
+                out.add(em)
+    return out
+
+
+def _discard_for_regen(service, drafts_ws, regen: list[dict]) -> None:
+    """Delete flagged drafts so the suggester regenerates them next run.
+    One automatic attempt per recipient — _prior_regen_recipients gates the
+    second offense into the human review residue."""
+    if not regen:
+        return
+    from hit_list_dapp_remarks_sheet import gspread_retry
+    values = drafts_ws.get_all_values()
+    hdr = smf.header_map(values[0])
+    i_status, i_notes = hdr["status"], hdr.get("notes")
+    stamp = _now_iso()
+    cells: list[gspread.Cell] = []
+    for d in regen:
+        try:
+            service.users().drafts().delete(userId="me", id=d["draft_id"]).execute()
+        except HttpError as e:
+            if not smf.is_missing_draft_http_error(e):
+                sys.stderr.write(f"  WARNING: draft delete failed: {e}\n")
+                continue
+        r = d["sheet_row"]
+        cells.append(gspread.Cell(r, i_status + 1, "discarded"))
+        if i_notes is not None:
+            prior = smf.cell(values[r - 1], i_notes) if r - 1 < len(values) else ""
+            note = f"{REGEN_NOTE} {stamp} ({d['skip_reason']})"
+            cells.append(gspread.Cell(r, i_notes + 1, f"{prior} | {note}".strip(" |")))
+        print(f"discarded for regen: {d['shop_name']} <{d['to_email']}>")
+    if cells:
+        gspread_retry(lambda: drafts_ws.update_cells(cells, value_input_option="RAW"))
+
+
+def _remediate_wrong_addresses(service, hit_ws, drafts_ws, remarks_ws, wrong: list[dict]) -> None:
+    """Positive wrongness evidence (email_domain_mismatch): same treatment as
+    a bounce — bad_email Notes marker, Email cleared, staged draft discarded,
+    row re-queued to contact discovery. Mirrors handle_warmup_bounces.py."""
+    if not wrong:
+        return
+    import uuid
+    from datetime import datetime, timezone
+
+    from hit_list_dapp_remarks_sheet import append_dapp_remark_and_apply, gspread_retry
+    hit_values = gspread_retry(lambda: hit_ws.get_all_values())
+    hit_headers = hit_values[0]
+    hdr = {h: i for i, h in enumerate(hit_headers)}
+    by_email: dict[str, dict] = {}
+    for ri, row in enumerate(hit_values[1:], start=2):
+        em = smf.normalize_email(row[hdr["Email"]] if len(row) > hdr["Email"] else "")
+        if em and em not in by_email:
+            by_email[em] = {
+                "row": ri,
+                "shop": row[hdr["Shop Name"]] if len(row) > hdr["Shop Name"] else "",
+                "status": row[hdr["Status"]] if len(row) > hdr["Status"] else "",
+            }
+    dvalues = drafts_ws.get_all_values()
+    dhdr = smf.header_map(dvalues[0])
+    cells: list[gspread.Cell] = []
+    for d in wrong:
+        dead = d["to_email"]
+        hit = by_email.get(dead)
+        try:
+            service.users().drafts().delete(userId="me", id=d["draft_id"]).execute()
+        except HttpError as e:
+            if not smf.is_missing_draft_http_error(e):
+                sys.stderr.write(f"  WARNING: draft delete failed: {e}\n")
+        r = d["sheet_row"]
+        cells.append(gspread.Cell(r, dhdr["status"] + 1, "discarded"))
+        if dhdr.get("notes") is not None:
+            prior = smf.cell(dvalues[r - 1], dhdr["notes"]) if r - 1 < len(dvalues) else ""
+            note = f"discarded {_now_iso()}: wrong address ({d['skip_reason']})"
+            cells.append(gspread.Cell(r, dhdr["notes"] + 1, f"{prior} | {note}".strip(" |")))
+        if not hit or hit["status"] not in REROUTABLE_STATUSES:
+            print(f"wrong address (draft discarded; row untouched — "
+                  f"status {(hit or {}).get('status', 'no row')!r}): {d['shop_name']} <{dead}>")
+            continue
+        now_iso = datetime.now(timezone.utc).isoformat()
+        notes_now = gspread_retry(
+            lambda: hit_ws.cell(hit["row"], hdr["Notes"] + 1).value) or ""
+        if f"bad_email={dead}" not in notes_now:
+            gspread_retry(lambda: hit_ws.update_cell(
+                hit["row"], hdr["Notes"] + 1,
+                f"{notes_now.strip()}; bad_email={dead}".strip("; ")))
+        gspread_retry(lambda: hit_ws.update_cell(hit["row"], hdr["Email"] + 1, ""))
+        append_dapp_remark_and_apply(
+            hit_ws, remarks_ws, hit["row"], hit["shop"], "AI: Enrich with contact",
+            (f"[wrong-address {now_iso}] outcome=re_enrich; bad_email={dead}. "
+             f"Lint evidence: {d['skip_reason']}. Email cleared, draft discarded, "
+             "row re-queued for contact discovery."),
+            "send_clean_warmup_drafts", now_iso, f"wrongaddr-{uuid.uuid4()}",
+            hit_headers=hit_headers,
+        )
+        print(f"re-enriched: {d['shop_name']} <{dead}> (email cleared, bad_email marker)")
+    if cells:
+        gspread_retry(lambda: drafts_ws.update_cells(cells, value_input_option="RAW"))
+
+
+def _reconcile_missing_rows(drafts_ws, missing: list[dict]) -> None:
+    """Rows whose Gmail draft vanished (deleted out-of-band) are sheet
+    artifacts, not review items — flip them to discarded so the suggester
+    can regenerate on its next pass."""
+    if not missing:
+        return
+    from hit_list_dapp_remarks_sheet import gspread_retry
+    values = drafts_ws.get_all_values()
+    hdr = smf.header_map(values[0])
+    i_status, i_notes = hdr["status"], hdr.get("notes")
+    cells: list[gspread.Cell] = []
+    for d in missing:
+        r = d["sheet_row"]
+        cells.append(gspread.Cell(r, i_status + 1, "discarded"))
+        if i_notes is not None:
+            prior = smf.cell(values[r - 1], i_notes) if r - 1 < len(values) else ""
+            note = f"auto-reconciled {_now_iso()}: gmail draft missing"
+            cells.append(gspread.Cell(r, i_notes + 1, f"{prior} | {note}".strip(" |")))
+        print(f"stale row reconciled: {d['shop_name']} <{d['to_email']}>")
+    if cells:
+        gspread_retry(lambda: drafts_ws.update_cells(cells, value_input_option="RAW"))
+
+
 def _reconcile_review_label(service, skipped: list[dict]) -> None:
     """Keep the AI/Needs Review Gmail label in sync with the flagged cohort:
     add it to every skipped draft, strip it from anything that is no longer
@@ -159,9 +299,10 @@ def main(argv=None) -> int:
                     help="Actually send. Default is a dry-run listing.")
     ap.add_argument("--max-sends", type=int, default=12,
                     help="Cap sends per run (default 12 — drip cadence).")
-    ap.add_argument("--include-hosts-circles", action="store_true",
-                    help="Also auto-send Hosts Circles=Yes prospects "
-                         "(default: excluded — they keep human review).")
+    ap.add_argument("--exclude-hosts-circles", action="store_true",
+                    help="Hold Hosts Circles=Yes prospects for human review "
+                         "(default: they auto-send too — operator decision "
+                         "2026-06-05: human involvement starts at the reply).")
     args = ap.parse_args(argv)
 
     sa = smf.get_sheets_client()
@@ -177,19 +318,35 @@ def main(argv=None) -> int:
     pending = pw._load_pending_warmup_drafts(drafts_ws)
     pending.sort(key=lambda d: d.get("created_at") or "")  # oldest first
 
+    # Recipients whose draft was already auto-discarded once for regeneration:
+    # a second flagged draft for the same address means regen isn't converging
+    # — that residue is the only thing left for human eyes.
+    regen_seen = _prior_regen_recipients(drafts_ws)
+
     clean: list[dict] = []
-    skipped: list[dict] = []
+    wrong_addr: list[dict] = []   # positive wrongness evidence → re-enrich
+    regen: list[dict] = []        # body-quality reds → discard + regenerate
+    missing: list[dict] = []      # stale rows whose Gmail draft vanished
+    review: list[dict] = []       # repeat offenders only — the true residue
     for draft in pending:
         d = _classify(draft, service, by_email, by_store, dapp_counts)
-        if d["reds"] or d["yellows"]:
-            d["skip_reason"] = "; ".join(c for _s, c, _m in d["reds"] + d["yellows"])
-            skipped.append(d)
-        elif d["hosts_circles"] and not args.include_hosts_circles:
-            d["skip_reason"] = "hosts_circles (human review by default)"
-            skipped.append(d)
-        elif not d["body_len"]:
+        red_codes = {c for _s, c, _m in d["reds"]}
+        if not d["body_len"]:
             d["skip_reason"] = "gmail draft missing"
-            skipped.append(d)
+            missing.append(d)
+        elif "email_domain_mismatch" in red_codes:
+            d["skip_reason"] = "; ".join(sorted(red_codes))
+            wrong_addr.append(d)
+        elif red_codes or d["yellows"]:
+            d["skip_reason"] = "; ".join(c for _s, c, _m in d["reds"] + d["yellows"])
+            if d["to_email"] in regen_seen:
+                d["skip_reason"] += " (regen already attempted — human eyes)"
+                review.append(d)
+            else:
+                regen.append(d)
+        elif d["hosts_circles"] and args.exclude_hosts_circles:
+            d["skip_reason"] = "hosts_circles (excluded by flag)"
+            review.append(d)
         else:
             clean.append(d)
 
@@ -199,18 +356,29 @@ def main(argv=None) -> int:
     print(f"pending_review AI/Warm-up drafts: {len(pending)}")
     print(f"  clean tier: {len(clean)}  (sending {len(to_send)}, "
           f"{len(overflow)} deferred to next run by --max-sends)")
-    print(f"  kept for human review: {len(skipped)}")
-    for d in skipped:
-        print(f"    REVIEW  {d['shop_name'][:40]:40} <{d['to_email']}>  [{d['skip_reason']}]")
+    print(f"  wrong address → re-enrich: {len(wrong_addr)}; "
+          f"discard for regen: {len(regen)}; stale rows: {len(missing)}; "
+          f"human review: {len(review)}")
+    for d in wrong_addr:
+        print(f"    {'RE-ENRICH' if args.execute else 'WOULD RE-ENRICH':16} "
+              f"{d['shop_name'][:40]:40} <{d['to_email']}>  [{d['skip_reason']}]")
+    for d in regen:
+        print(f"    {'REGEN' if args.execute else 'WOULD REGEN':16} "
+              f"{d['shop_name'][:40]:40} <{d['to_email']}>  [{d['skip_reason']}]")
+    for d in review:
+        print(f"    {'REVIEW':16} {d['shop_name'][:40]:40} <{d['to_email']}>  [{d['skip_reason']}]")
     for d in to_send:
-        print(f"    {'SEND' if args.execute else 'WOULD SEND':10} "
+        print(f"    {'SEND' if args.execute else 'WOULD SEND':16} "
               f"{d['shop_name'][:40]:40} <{d['to_email']}>  created {d['created_at']}")
 
     if not args.execute:
         print("\ndry-run (default) — pass --execute to send.")
         return 0
 
-    _reconcile_review_label(service, skipped)
+    _remediate_wrong_addresses(service, hit_ws, drafts_ws, remarks_ws, wrong_addr)
+    _discard_for_regen(service, drafts_ws, regen)
+    _reconcile_missing_rows(drafts_ws, missing)
+    _reconcile_review_label(service, review)
 
     sent: list[dict] = []
     for d in to_send:


### PR DESCRIPTION
## Goal
Operator reviewed the 16-draft queue and found nothing needing human judgment: *"I should only need to get involved when people actually respond."* This PR makes that the architecture: the AI/Needs Review label now only ever holds drafts that defeated one automatic regeneration attempt — in steady state, zero.

## Changes
- **Hosts Circles auto-send by default** (`--exclude-hosts-circles` opt-out)
- **`generic_inbox` never red** — own-domain converted a partner; unverifiable generic = the shop's only listed address, and bounce handling is the safety net. `email_domain_mismatch` remains the sole address-blocking signal.
- **Wrong addresses self-heal like bounces**: draft discarded, `bad_email=` Notes marker, Email cleared, row re-queued to enrichment (status-gated); enrich exclusion regex covers `(bounced|bad)_email=`
- **Body-quality reds auto-discard for regeneration** — one attempt per recipient, repeat offenders are the only human residue
- **Stale rows (draft deleted out-of-band) auto-reconcile**

## Testing
Live dry-run: 47 pending → 46 clean / 1 wrong-address (a .org inbox mismatching the shop's website) / 0 regen / 0 review. `py_compile` clean ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)