### PR TITLE
SF Tech Fest: downshift to pass-only attendance (serving slot missed)

Gary missed the reply window with Soniya, so the snack-table serving
format is no longer available. He still has a free pass to attend.

Changes:
- event.json: status→attending_only, format→pass-only attendance,
  products→[], qr_codes→[], next_milestone→reconnaissance
- implementation_roadmap.md: stripped all serving phases (0-4),
  kept Phase 5 (post-event recon) with updated scope
- proposal.md: added status note at top, preserved as historical doc

### DIFF
--- a/events/sftechfestjune26/event.json
+++ b/events/sftechfestjune26/event.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "slug": "sftechfestjune26",
   "name": "SF Tech Fest 2026",
-  "status": "planning",
-  "status_note": "Date/venue confirmed; Phase 0 host confirmations (snack table, self-serve, shoutout, passes) pending with Soniya.",
+  "status": "attending_only",
+  "status_note": "Gary missed the reply window with Soniya; snack-table serving slot is no longer available. He still has a free pass to attend as a guest. Reconnaissance mission — walk the floor, note conversations, gather signal.",
   "date": "2026-06-12",
   "end_date": "2026-06-12",
   "start_time": "11:00",
@@ -12,20 +12,17 @@
   "venue": "ICC, 525 Los Coches St, Milpitas, CA 95035",
   "city": "Milpitas, CA",
   "host": { "name": "Soniya", "org": "SF Tech Fest" },
-  "format": "Two flasks — Oscar's ceremonial cacao + Paulo's cacao tea — 3 oz cups, self-serve at the snack table.",
-  "products": ["Oscar's ceremonial cacao (Bahia)", "Paulo's cacao tea (Pará)"],
-  "qr_codes": [
-    { "id": "SFTF_CC_2026", "landing": "agl4", "product": "Oscar's ceremonial cacao", "status": "pending" },
-    { "id": "SFTF_CT_2026", "landing": "agl8", "product": "Paulo's cacao tea", "status": "pending" }
-  ],
+  "format": "Pass-only attendance. No serving. Gary attends as a guest with a free pass, walks the floor, and gathers signal.",
+  "products": [],
+  "qr_codes": [],
   "owner": "Gary",
-  "next_milestone": { "phase": 0, "due": "2026-06-05", "what": "Confirm snack table / self-serve / stage shoutout / passes with Soniya" },
-  "reminders": { "apple_reminder": true, "apple_calendar": "Work", "check_in_date": "2026-05-27" },
+  "next_milestone": { "phase": 5, "due": "2026-06-13", "what": "Post-event: note any conversations or observations from the floor" },
+  "reminders": { "apple_reminder": false, "apple_calendar": null, "check_in_date": null },
   "docs": {
-    "checklist": "EXECUTION_CHECKLIST.md",
+    "checklist": null,
     "proposal": "proposal.md",
     "roadmap": "implementation_roadmap.md",
-    "field_assets": "field_assets.md"
+    "field_assets": null
   },
   "links": { "luma": "https://luma.com/sftechfest26", "website": "https://sftechfest.com/" }
 }

--- a/events/sftechfestjune26/implementation_roadmap.md
+++ b/events/sftechfestjune26/implementation_roadmap.md
@@ -1,142 +1,47 @@
-# SF Tech Fest 2026 — Implementation roadmap
+# SF Tech Fest 2026 — Implementation roadmap (UPDATED)
 
-**Companion to:** `proposal.md` (plan-of-record)
+**Status:** Attending only — serving slot no longer available.
 **Event:** TECH FEST 2026 — Silicon Valley · India Community Center (ICC), Milpitas, CA
 **Date:** June 12, 2026 (Friday) · 11:00 AM – 5:00 PM PT
-**Format (confirmed):** two flasks — **Oscar's ceremonial cacao + Paulo's cacao tea** — + 3 oz cups + placard, self-serve at the snack table. No booth, no dedicated pourer, no selling.
-**Lead:** Claude (infra + narrative + QR pipeline) · **On the ground:** Gary · **Follow-up:** Grok
+**Format (revised):** Pass-only attendance. Gary attends as a guest with a free pass. No flasks, no placard, no serving.
+**Purpose:** Reconnaissance mission — walk the floor, observe the audience, note conversations, gather signal for future events.
 
 ---
 
-## Critical path (the chain the event rises and falls on)
+## Context
 
-```
-Confirm date / venue / snack-table placement with Soniya
-        ↓
-Build placard copy + generate QR codes (provenance + opt-in)
-        ↓
-DRY RUN: scan a test QR, confirm signup lands + send_newsletter.py can address it   ← do NOT skip
-        ↓
-Print placard + assemble kit (flasks, cups, napkins)
-        ↓
-Event day: place flasks at snack table, placard visible → self-serve
-        ↓
-Post-event: verify signups → Hit List → DApp Remark
-```
+Gary reached out to Soniya offering two flasks of cacao at the snack table. He missed the reply window, so the serving format is no longer available. Soniya can still provide a free pass for Gary to attend as a guest.
 
-**Gate rule:** nothing gets printed until the dry run in Phase 2 passes.
+This is not a loss — it's a downshift. The Dual Tech Summit (June 26, SF) is the larger surface with a confirmed table. SF Tech Fest becomes a low-pressure recon opportunity.
 
 ---
 
-## Phase 0 — Confirm remaining logistics with Soniya (now → Jun 5, T-1wk)  · Owner: Gary
+## What changed
 
-**Already confirmed:** two flasks + 3 oz cups + placard by the snack table. Gary + friend get free passes. **Date confirmed:** June 12, 2026 (Fri), 11:00 AM – 5:00 PM PT, ICC Milpitas.
-
-| # | Task | Output | Blocks |
-|---|---|---|---|
-| 0.1 | ~~Confirm date~~ → **June 12, 2026 confirmed** (from Luma schema + sftechfest.com) | Done | — |
-| 0.2 | Confirm **snack table location** — where is it relative to the main hall? Can we place the flasks there? | Setup plan | Placard placement |
-| 0.3 | Confirm **self-serve** is fine (no dedicated pourer) | Format lock | — |
-| 0.4 | Confirm **stage shoutout** — still on? Suggested timing? | Yes/no + when | Placard urgency (less needed if announced) |
-| 0.5 | Confirm **Gary + friend passes** — logistics | Entry plan | — |
-
-**Exit criteria:** snack table location, self-serve approval, and pass logistics locked. → unblocks Phase 1–2.
+| Before | After |
+|--------|-------|
+| Two flasks + placard at snack table, self-serve | No serving — pass-only attendance |
+| QR codes, placard, dry run, kit assembly | None of these needed |
+| Gary networks + checks on flasks | Gary walks the floor, observes, takes notes |
+| Post-event: verify signups, Hit List leads | Post-event: log observations as DApp Remark |
 
 ---
 
-## Phase 1 — Build QR codes + placard (now → Jun 5, T-1wk)  · Owner: Claude
+## Phase 5 — Post-event recon (Jun 13–14)  · Owner: Gary
 
 | # | Task | Output |
 |---|---|---|
-| 1.1 | Generate QR batch `SFTF_CC_2026` (Oscar's ceremonial) + `SFTF_CT_2026` (Paulo's tea) via existing pipeline; publish to `lineage-assets` repo | QR PNGs + `qrs_index.json` entries |
-| 1.2 | Produce provenance QR targets (agl4/agl8 landing pages with consent + subscribe) — reuse existing pages, no new build | Working QR → signup pipeline |
-| 1.3 | Draft placard copy: farm names, taste notes, provenance QR, opt-in QR, agroverse.shop footer | Placard text (→ `field_assets.md`) |
-| 1.4 | Design placard layout (5x7, print-ready, two QRs + copy) | Placard PDF/PNG |
-
-**Register guardrails:** placard copy stays curatorial — no prices, no urgency, no blockchain jargon. Taste notes from `AGROVERSE_PRICE_LIST_AND_ASSETS.md`.
-
----
-
-## Phase 2 — DRY RUN (Jun 5–7)  · Owner: Claude  ← gate
-
-| # | Task | Output |
-|---|---|---|
-| 2.1 | **Dry run:** print one test QR placard, scan both codes, confirm signup lands in `Agroverse News Letter Subscribers` tab | Pass/fail |
-| 2.2 | Confirm `send_newsletter.py` can address the new test subscriber | Pass/fail |
-| 2.3 | Verify provenance QR resolves to the correct lineage-assets page (no dead link / CORS) | Pass/fail |
-| 2.4 | Fix any issues | Green pipeline |
-
-**⛔ Gate:** Phase 3 printing proceeds **only when 2.1–2.3 pass.**
-
----
-
-## Phase 3 — Print + assemble kit (Jun 8–11)  · Owner: Gary
-
-| # | Task | Output |
-|---|---|---|
-| 3.1 | Print the placard (5x7) — 2 copies (backup) | Physical placard |
-| 3.2 | Pull cacao for two flasks; log `[INVENTORY MOVEMENT]` | Stock + ledger entry |
-| 3.3 | Assemble kit: 2 flasks, cups, napkins, placard x2 | Event kit |
-| 3.4 | Day-of: pre-brew both flasks (Kirsten or Gary) | Flasks ready to go |
-
-**No kettle needed** — flasks arrive pre-brewed and hot.
-
----
-
-## Phase 4 — Event day (Jun 12)  · Owner: Gary
-
-- **Arrive early.** Find Soniya, confirm the snack table location.
-- **Place two flasks + cups + napkins + placard** at the snack table. Self-serve. Visible. Unfussy.
-- **The placard is the whole presence.** No backdrop, no banner, no standing at the table.
-- **Gary networks** — free passes, full attendee.
-- **If Soniya does the stage shoutout:** great. If not, the placard handles it.
-- **Note conversations:** anyone who specifically mentions the cacao → mental note (name, what they asked, next step).
-- **Check midday:** is a flask empty? Reposition the placard if it got moved.
-- **3-5 photos** of the setup (for DApp Remark + internal record).
-
----
-
-## Phase 5 — Immediate post-event (Jun 13–14)  · Owner: Claude
-
-| # | Task | Output |
-|---|---|---|
-| 5.1 | Verify opt-in signups landed in subscribers tab | Confirmed list |
-| 5.2 | Add warm leads to Hit List (`Source: SF Tech Fest 2026`, Notes) | Pipeline input |
-| 5.3 | Verify `suggest_manager_followup_drafts.py` picks up any new leads | Queued drafts |
-| 5.4 | Log activation as a **DApp Remark** (date, servings, farms, notable conversations, photos) | Training data |
-
----
-
-## Phase 6 — Follow-up (Jun 15–26)
-
-| # | Task | Owner | Output |
-|---|---|---|---|
-| 6.1 | Manager Follow-up drafts for event leads | Grok (existing pipeline) → Gary sends | Warm-up touches |
-| 6.2 | Personal 1:1 follow-up with any contacts Gary made | Gary | Relationship |
-| 6.3 | **No full-list newsletter** — skip unless there's a specific story worth telling (Gary's call) | — | — |
-| 6.4 | Optional truesight.me essay if the day produced an observation | Claude (draft) → Gary (review/publish) | Essay |
+| 5.1 | Note any conversations or observations from the floor — who was there, what topics dominated, any potential leads or partner signals | Raw notes |
+| 5.2 | Log a **DApp Remark** with key observations (date, audience notes, any notable conversations) | Training data |
+| 5.3 | If any warm leads emerged, add to Hit List (`Source: SF Tech Fest 2026`) | Pipeline input |
 
 ---
 
 ## Milestone checklist (one-glance)
 
-- [ ] **M0** — Date, snack table, self-serve, passes confirmed with Soniya *(Gary)*
-- [ ] **M1** — QR codes minted + placard copy ready *(Claude)*
-- [ ] **M2** — ✅ **Dry run passes** ← gate
-- [ ] **M3** — Placard printed, kit assembled, flasks pre-brewed *(Gary)*
-- [ ] **M4** — Event executed: flasks at snack table, self-serve, Gary networks *(Gary)*
-- [ ] **M5** — Signups verified, leads in Hit List, DApp Remark logged *(Claude/Gary)*
-- [ ] **M6** — Follow-ups sent, essay (if warranted) *(Grok/Claude)*
+- [ ] **M5** — Attend, observe, note conversations *(Gary)*
+- [ ] **M6** — DApp Remark logged, any leads in Hit List *(Gary)*
 
 ---
 
-## Decision points for Gary
-
-1. **Flasks** — Oscar's ceremonial + Paulo's tea (same pairing as Dual Tech Summit)? *Recommended: yes — proven combination, different taste registers.*
-2. **Stage shoutout** — push for it or let it go? *Recommended: ask Soniya gently, but don't press. The placard works either way.*
-3. **Newsletter** — skip full-list entirely? *Recommended: yes. This audience doesn't match the wellness list. 1:1 follow-ups only.*
-4. **Post-event essay** — worth writing? *Recommended: decide after the event based on what actually happened.*
-
----
-
-*Roadmap authored 2026-05-26 by Claude (Anthropic). Date confirmed June 12, 2026 from Luma schema + sftechfest.com.*
+*Roadmap updated 2026-06-04. Original serving plan authored 2026-05-26 by Claude (Anthropic).*

--- a/events/sftechfestjune26/proposal.md
+++ b/events/sftechfestjune26/proposal.md
@@ -1,6 +1,10 @@
 # SF Tech Fest 2026 — Agroverse cacao activation proposal
 
-**Status:** DRAFT v0.1 — plan-of-record
+**⚠️ STATUS UPDATE (2026-06-04):** This proposal is now **historical**. Gary missed the reply window with Soniya, so the snack-table serving format is no longer available. He still has a free pass to attend as a guest. See `implementation_roadmap.md` for the revised plan (reconnaissance mission only). The original proposal is preserved below for reference.
+
+---
+
+**Status:** DRAFT v0.1 — plan-of-record (historical)
 **Date:** 2026-05-26
 **Author:** Claude (Anthropic) — lead
 
@@ -26,7 +30,7 @@ Gary reached out to Soniya (May 2026) after seeing the invitation, offering two 
 
 > **Soniya:** *"That would be very helpful."*
 
-**Format confirmed:** two flasks + 3 oz cups + a placard, placed at the snack table. Self-serve. Gary gets free passes for himself + a friend. Shoutout on stage is on the table (confirm with Soniya).
+**Format confirmed (original):** two flasks + 3 oz cups + a placard, placed at the snack table. Self-serve. Gary gets free passes for himself + a friend. Shoutout on stage is on the table (confirm with Soniya).
 
 ---
 


### PR DESCRIPTION
Opened by Sophia (truesight_autopilot).

SF Tech Fest: downshift to pass-only attendance (serving slot missed)

Gary missed the reply window with Soniya, so the snack-table serving
format is no longer available. He still has a free pass to attend.

Changes:
- event.json: status→attending_only, format→pass-only attendance,
  products→[], qr_codes→[], next_milestone→reconnaissance
- implementation_roadmap.md: stripped all serving phases (0-4),
  kept Phase 5 (post-event recon) with updated scope
- proposal.md: added status note at top, preserved as historical doc