### PR TITLE
Proposal: West Coast distributor list assembly for ceremonial cacao & chocolate

### DIFF
--- a/briefs/2026-06-06_west_coast_distributor_list_assembly_proposal.md
+++ b/briefs/2026-06-06_west_coast_distributor_list_assembly_proposal.md
@@ -1,0 +1,456 @@
+# West Coast Distributor List Assembly — Implementation Proposal
+
+**For:** Gary Teh, Agroverse / TrueSight DAO
+**Date:** June 6, 2026
+**Status:** Proposal — not yet in execution
+**Inspired by:** Lucas Rude's approach (find info on the web, then call)
+
+---
+
+## 1. Executive Summary
+
+Agroverse currently distributes ceremonial cacao (~37+ retail partners) and the newly launched 81% dark chocolate bar (first run sold out) primarily through **direct-to-store consignment** — Gary visits or emails individual apothecaries, metaphysical shops, and wellness venues one by one. This model has proven the product works at retail but is **operator-hour-bound**.
+
+A **distributor layer** would let one relationship unlock dozens of shelf placements. This proposal outlines how to systematically assemble a qualified distributor list across the US West Coast (CA, OR, WA) for **two product lines**:
+
+| Product | Format | Retail price | Distributor fit |
+|---------|--------|-------------|----------------|
+| Ceremonial cacao | 200g bag | $25 | Natural foods, wellness, metaphysical |
+| Premium 81% dark chocolate | 50g bar | $10 | Specialty chocolate, natural grocery, gourmet |
+
+---
+
+## 2. Why a distributor layer now
+
+### 2a. Current bottleneck
+
+- ~37 retail partners, mostly direct consignment
+- Each partner requires individual onboarding, restock management, and check-in
+- Gary's personal driving + email outreach is the primary acquisition channel
+- The Email360 warm-up pipeline is producing drafts, but conversion to Partnered still requires operator attention per lead
+
+### 2b. Signal that the time is right
+
+- **The 81% bar sold out** its first production run (40+ bars) — this is the SKU distributors understand (bar format, $10 price point, premium positioning)
+- **The Way Home Shop** (Portland) onboarded entirely remotely over email — zero in-person visit — proving the product sells itself when it reaches the right buyer
+- **Lumin Earth Apothecary** (Morro Bay) stocks our cacao alongside Kakao Laboratory and Pacha Mama — multiple-region cacao is a feature, not a bug, for distributors who already carry cacao
+- **Expo West 2026** contacts are sitting in the pipeline — many of those conversations were with distributors and natural chain buyers
+
+### 2c. What a distributor does for us
+
+- **Shelf access** — one relationship = placement in dozens/hundreds of stores
+- **Warehousing & logistics** — they hold inventory, we ship pallets instead of individual bags
+- **Order consolidation** — they handle the individual store orders, we handle one distributor PO
+- **Category credibility** — being carried by a known distributor signals legitimacy to retailers
+
+---
+
+## 3. Phase 1: Research & List Assembly (Weeks 1–3)
+
+### 3.1 Four-track research approach
+
+#### Track A: Natural Foods Distributors (highest priority for chocolate bar)
+
+These are the distributors that supply natural grocery co-ops, health food stores, and specialty markets — the exact stores identified as "On Hold" in the Hit List (SLO Food Co-op, Lassens, Sunshine Health Foods, etc.) because they need a ~$10 premium chocolate bar SKU.
+
+**Target list:**
+
+| Distributor | HQ | Coverage | Known for |
+|------------|-----|----------|-----------|
+| **UNFI** | Providence, RI (national) | West Coast warehouses in CA, OR, WA | Largest natural foods distributor; carries Ora Cacao |
+| **KeHE** | Naperville, IL (national) | West Coast distribution centers | Natural/specialty; strong in independent grocers |
+| **Nature's Best** | Los Alamitos, CA | CA, AZ, NV, HI | West Coast specialty; wellness-focused |
+| **Tree of Life** | St. Louis, MO (national) | West Coast presence | Natural/organic; carries premium chocolate |
+| **DPI (Distributor Processing Inc.)** | Fresno, CA | Western US | Specialty food; strong in independent natural stores |
+| **Blooms & Berries** | Various | Regional | Smaller specialty distributors per region |
+
+**Research method for Track A:**
+
+1. **Web search** each distributor's vendor submission page — most have a "Become a Vendor" or "New Product Submission" form
+2. **LinkedIn** — search for "Category Manager" or "Buyer" at each distributor; note names
+3. **Expo West contacts** — review the contacts collected at Expo West March 2026; many were from these distributors
+4. **Industry directories** — use web search for "natural foods distributor list West Coast 2026" and "specialty food distributor California"
+5. **Competitor analysis** — check which distributors carry Ora Cacao, Four Visions, Ma Cacao (our competitors from the SEO research); those distributors already understand the category
+
+#### Track B: Specialty Chocolate Distributors
+
+These distributors focus on premium chocolate and confectionery — the natural home for the 81% bar.
+
+**Target list:**
+
+| Distributor | HQ | Coverage | Notes |
+|------------|-----|----------|-------|
+| **Chocolate Alchemy** | Eugene, OR | National (online + wholesale) | Bean-to-bar supply; carries craft chocolate brands |
+| **Chocolate Trading Co.** | Various | National | Premium chocolate distribution |
+| **The Chocolate Bar** | Various | Regional | Specialty chocolate retail + wholesale |
+| **Gourmet Food Distributors** | Various | West Coast | Premium/gourmet food; chocolate category |
+| **Regional candy/gourmet distributors** | Per state | Local | Many states have regional confectionery distributors |
+
+**Research method for Track B:**
+
+1. Search "premium chocolate distributor West Coast" and "craft chocolate wholesale distributor"
+2. Look at who carries brands like Dick Taylor, Dandelion Chocolate, Raaka, Taza — those are our natural shelf neighbors
+3. Check Faire marketplace for chocolate brands' distributor networks (we're already on Faire)
+4. Industry shows: Sweets & Snacks Expo (Chicago), Expo West (already attended)
+
+#### Track C: Wellness / Apothecary / Metaphysical Distributors
+
+These are the distributors that supply the exact store types we already partner with — apothecaries, metaphysical shops, wellness centers.
+
+**Target list:**
+
+| Distributor | HQ | Coverage | Notes |
+|------------|-----|----------|-------|
+| **Lotus Light** | Silverton, OR | National | Metaphysical/wellness wholesale; carries ceremonial items, herbs, incense |
+| **Pacific Botanicals** | Grants Pass, OR | National | Organic herbs; wellness channel |
+| **Starwest Botanicals** | Rancho Cordova, CA | National | Bulk herbs, spices, teas; wellness channel |
+| **Mountain Rose Herbs** | Eugene, OR | National | Organic herbs, spices, teas; wellness channel |
+| **Regional metaphysical wholesalers** | Per region | Local | Many metaphysical shops buy from regional wholesalers |
+
+**Research method for Track C:**
+
+1. Ask existing Partnered stores (Go Ask Alice, Lumin Earth, Queen Hippie Gypsy) who their distributors are — this is the highest-signal source
+2. Search "metaphysical store wholesale distributor" and "apothecary wholesale supplier"
+3. Check the Hit List for stores that mentioned their existing suppliers in DApp Remarks
+4. Instagram — look at which wholesale accounts Partnered stores follow
+
+#### Track D: Regional Brokers & Food Service
+
+These are independent sales reps or brokerages that represent brands to multiple distributors and chains.
+
+**Target list:**
+
+| Broker | Coverage | Specialty |
+|--------|----------|-----------|
+| **Acosta Group** | National | CPG; natural/specialty |
+| **Crossmark** | National | CPG; specialty food |
+| **Advantage Solutions** | National | CPG; natural/organic |
+| **Regional natural food brokers** | Per region | Smaller, more focused |
+
+**Research method for Track D:**
+
+1. Expo West contacts — Acosta Group had a session there; check who we met
+2. Search "natural food broker California" and "specialty food sales rep West Coast"
+3. LinkedIn — search for "broker" + "natural foods" + "West Coast"
+
+### 3.2 Data sources to use
+
+| Source | What it gives | How to access |
+|--------|---------------|---------------|
+| **Google Maps / Places API** | Store names, addresses, categories | Already integrated in `discover_apothecaries_la_hit_list.py` |
+| **Web search** | Distributor names, vendor pages, contact info | `web_search` tool |
+| **LinkedIn** | Buyer names, titles, company pages | Manual search or LinkedIn Sales Navigator if available |
+| **Expo West contacts** | Warm leads from March 2026 | Review collected business cards / notes |
+| **Existing Partnered stores** | Their distributor relationships | Ask via Partner Check-in loop |
+| **Faire marketplace** | Distributor/retailer network | Already integrated; check Faire order data |
+| **Competitor websites** | Which distributors carry them | Crawl competitor "Where to Buy" pages |
+| **Industry directories** | Curated lists of distributors | Web search for "SPINS distributor list" or "natural products distributor directory" |
+
+### 3.3 Deliverable: West Coast Distributor Master List
+
+A Google Sheet (or CSV in `go_to_market/market_research/physical_stores/data/`) with columns:
+
+| Column | Description |
+|--------|-------------|
+| Distributor Name | Legal name |
+| Category | Natural Foods / Specialty Chocolate / Wellness / Broker |
+| HQ City | City |
+| HQ State | State |
+| Coverage | West Coast region(s) served |
+| Website | URL |
+| Vendor Page URL | Direct link to "Become a Vendor" or submission form |
+| Buyer Name(s) | Names of category managers / buyers (if found) |
+| Buyer Email(s) | Contact emails (if found) |
+| Buyer Phone | Phone (if found) |
+| Carries Cacao? | Yes/No/Unknown — do they already carry ceremonial cacao? |
+| Carries Premium Chocolate? | Yes/No/Unknown — do they carry craft chocolate bars? |
+| Competitor Brands | Which competitor brands they carry (Ora, Four Visions, etc.) |
+| Product Fit | Ceremonial / Chocolate Bar / Both |
+| Warm Lead? | Yes/No — do we have a prior contact or referral? |
+| Notes | Free text |
+| Status | Research / Contacted / Meeting Scheduled / Partnered / Rejected |
+
+---
+
+## 4. Phase 2: Qualification & Enrichment (Weeks 2–4, overlapping with Phase 1)
+
+### 4.1 Vetting criteria
+
+Not every distributor is a good fit. Score each on:
+
+| Criterion | Weight | How to assess |
+|-----------|--------|---------------|
+| **Category fit** | High | Do they already carry cacao, chocolate, or wellness products? |
+| **West Coast coverage** | High | Do they serve CA/OR/WA retailers? |
+| **Store type match** | High | Do they supply the store types we already succeed in (apothecaries, natural grocers, metaphysical shops)? |
+| **Minimum order** | Medium | Is their MOQ achievable for our production scale? |
+| **Slotting fees** | Medium | Do they require upfront fees to list? (Some do; budget accordingly) |
+| **Warm connection** | Medium | Do we have a prior contact, Expo West meeting, or referral? |
+| **Competitor overlap** | Low | Carrying competitors is fine — multiple-region cacao is a feature |
+
+### 4.2 Contact enrichment workflow
+
+For each qualified distributor, enrich with contact info:
+
+1. **Check existing contacts** — Expo West, prior emails, Partner Check-in notes
+2. **Website crawl** — vendor page, "Meet the Team," press releases
+3. **LinkedIn** — search for "Category Manager" or "Buyer" at the company
+4. **Gmail search** — check `garyjob@agroverse.shop` for any prior correspondence
+5. **Warm intro** — ask existing partners if they know anyone at the distributor
+
+This can reuse the existing `hit_list_enrich_contact.py` pattern — the enrichment logic (Place Details + website crawl + Grok email extraction) is the same, just applied to distributor companies instead of retail stores.
+
+### 4.3 Prioritization matrix
+
+Score each distributor on a simple 3×3 grid:
+
+| | High category fit | Medium category fit | Low category fit |
+|---|---|---|---|
+| **Warm contact** | **Tier 1** — contact this week | **Tier 2** — contact this month | **Tier 3** — keep on radar |
+| **No contact, good fit** | **Tier 2** — research + reach out | **Tier 3** — research first | **Tier 4** — skip |
+| **No contact, uncertain fit** | **Tier 3** — research deeper | **Tier 4** — skip for now | **Tier 4** — skip |
+
+---
+
+## 5. Phase 3: Outreach Sequencing (Weeks 3–8)
+
+### 5.1 Two outreach paths
+
+#### Path A: Warm outreach (Tier 1)
+
+For distributors where we have a prior contact (Expo West, referral, existing email thread):
+
+1. **Personal email** from Gary referencing the prior conversation
+2. Attach: one-pager (PDF), wholesale price list, packaging photos
+3. Offer: samples shipment (ceremonial cacao + chocolate bar)
+4. Follow-up: 7 days if no reply
+
+#### Path B: Cold outreach (Tier 2–3)
+
+For distributors where we have no prior contact:
+
+1. **Find the right person** — category manager, buyer, or new vendor intake
+2. **Cold email** using the Email360 warm-up pipeline (reuse `suggest_warmup_prospect_drafts.py` with a new distributor-specific template)
+3. **Follow by phone** — Lucas Rude's method: find the number, call. This is the key insight from his approach.
+4. **Follow-up email** at day 7 and day 14
+5. **If no response after 3 touches** — move to "On Hold" and re-approach in 3 months
+
+### 5.2 Pitch differentiation per product line
+
+| Product | Pitch angle | Key selling points |
+|---------|-------------|-------------------|
+| **Ceremonial cacao** (200g bag) | "The fastest-growing ceremonial wellness category, with verifiable provenance" | QR traceability, tree-planting per bag, single-estate vintages, $25 retail, 64% margin |
+| **81% dark chocolate bar** (50g) | "Premium craft chocolate with an impact story that sells itself" | Sold out first run, $10 retail, regenerative Amazon story, QR traceability, 40% margin |
+| **Both** | "Complete cacao portfolio — ceremony + everyday indulgence" | Cross-sell opportunity, single source for both SKUs, farm-direct supply chain |
+
+### 5.3 Materials to prepare before outreach
+
+| Material | Status | Notes |
+|----------|--------|-------|
+| Wholesale price list (PDF) | ✅ Exists | Used in warm-up emails |
+| Packaging photos | ✅ Exists | Front/back of ceremonial bag |
+| Chocolate bar packaging photos | 🟩 In progress | First run sold out; need photos of final packaging |
+| Distributor one-pager | ⬜ Needs creation | Different from retailer one-pager — focus on margins, velocity, category growth |
+| Distributor FAQ | ⬜ Needs creation | MOQ, lead times, shipping, returns, slotting fees |
+| Lab reports (FDA, allergen) | ✅ Exists | Used for retailer concerns |
+| Sample kit | ✅ Exists | Ceremonial cacao + cacao tea; add chocolate bar when available |
+
+---
+
+## 6. Phase 4: Integration into Existing Pipeline
+
+### 6.1 Hit List state machine extension
+
+The existing Hit List state machine (`HIT_LIST_STATE_MACHINE.md`) is designed for **retail stores**. Distributors are a different entity type. Options:
+
+**Option A: New "Distributor List" tab** (recommended)
+
+Add a new tab to the Hit List spreadsheet called "Distributor List" with its own state machine:
+
+| State | Meaning |
+|-------|---------|
+| Research | Identified, not yet qualified |
+| Qualified | Fit confirmed, contact info being gathered |
+| Contacted | First outreach sent |
+| Meeting Scheduled | Call or meeting on calendar |
+| Samples Sent | Sample kit shipped |
+| Negotiating | Terms being discussed |
+| Partnered | Agreement signed, first PO received |
+| On Hold | Parked for later re-approach |
+| Rejected | Not a fit |
+
+**Option B: Extend the existing Hit List**
+
+Add a "Distributor" shop type and use the existing state machine. Simpler but mixes two different entity types in one view.
+
+**Recommendation:** Option A — separate tab, same spreadsheet. Distributors have different lifecycle stages and metrics than retail stores.
+
+### 6.2 Email360 warm-up pipeline reuse
+
+The existing warm-up email pipeline (`suggest_warmup_prospect_drafts.py`, `preview_warmup_drafts.py`, Gmail labels `AI/Warm-up` / `AI/Follow-up`) can be reused for distributor outreach with:
+
+- A new **distributor-specific email template** (different from the retail warm-up template)
+- A new **Gmail label** (e.g., `AI/Distributor Warm-up` and `AI/Distributor Follow-up`)
+- The same cadence logic (7-day minimum between sends)
+- The same operator review loop (draft → preview → send from Gmail)
+
+### 6.3 Partner Check-in loop integration
+
+Once a distributor is Partnered, they enter the Partner Check-in loop:
+
+- Quarterly business review cadence
+- Restock alerts (via existing `RESTOCK_RECOMMENDER_ON_THE_FLY.md` logic)
+- New product introduction (when new vintages or SKUs launch)
+- Performance reporting (sell-through rates, velocity by store)
+
+---
+
+## 7. Tooling & Automation Recommendations
+
+### 7.1 Scripts to build
+
+| Script | Purpose | Priority |
+|--------|---------|----------|
+| `discover_distributors.py` | Web search + Places API to find distributors by category and region | High |
+| `enrich_distributor_contacts.py` | Website crawl + Grok email extraction for distributor companies (reuse `hit_list_enrich_contact.py` pattern) | High |
+| `suggest_distributor_warmup_drafts.py` | Grok-drafted warm-up emails for distributors (fork of `suggest_warmup_prospect_drafts.py`) | Medium |
+| `distributor_outreach_tracker.py` | Log outreach attempts, replies, meetings (could be a new tab in the Hit List sheet) | Medium |
+| `distributor_qualification_scorer.py` | Auto-score distributors by vetting criteria | Low |
+
+### 7.2 Existing infrastructure to leverage
+
+| Tool | How to use |
+|------|------------|
+| `web_search` | Find distributor names, vendor pages, contact info |
+| `web_extract` | Read distributor website vendor pages in full |
+| `gmail_search` / `gmail_read_message` | Check for prior correspondence with distributors |
+| `hit_list_enrich_contact.py` | Reuse the enrichment pattern (Place Details + website crawl + Grok email pick) |
+| `suggest_warmup_prospect_drafts.py` | Fork for distributor-specific templates |
+| `preview_warmup_drafts.py` | Reuse for distributor draft triage |
+| Partner Check-in DApp | Track distributor relationships post-onboarding |
+| Faire integration | Already on Faire; check if any Faire orders came from distributor accounts |
+
+### 7.3 Data sources to automate
+
+| Source | Automation approach |
+|--------|-------------------|
+| Google Places API | Search for "natural food distributor" near West Coast cities |
+| Web crawl | Visit each distributor's vendor page, extract submission form URL and requirements |
+| LinkedIn (manual) | Human-driven; too fragile to automate reliably |
+| Competitor "Where to Buy" pages | Crawl competitor sites for distributor lists |
+| Industry directories (SPINS, New Hope Network) | May require subscription; check access |
+
+---
+
+## 8. Success Metrics & Milestones
+
+### 8.1 Milestones
+
+| Milestone | Target date | Definition of done |
+|-----------|-------------|-------------------|
+| M1: Distributor Master List v1 | Week 3 | 20+ qualified distributors identified with contact info |
+| M2: First outreach batch | Week 4 | 5 Tier-1 distributors contacted (warm or cold) |
+| M3: First meeting | Week 6 | At least 1 meeting scheduled with a distributor buyer |
+| M4: First sample shipment | Week 8 | Sample kits sent to interested distributors |
+| M5: First distributor partner | Week 12 | At least 1 distributor agreement signed |
+| M6: First distributor PO | Week 16 | First purchase order received from a distributor |
+
+### 8.2 Success metrics
+
+| Metric | Target (3 months) | Target (6 months) |
+|--------|-------------------|-------------------|
+| Distributors on list | 30+ | 50+ |
+| Tier-1 contacts made | 10 | 25 |
+| Meetings held | 5 | 15 |
+| Distributor partners | 1–2 | 3–5 |
+| Stores reached via distributors | 10–20 | 50–100 |
+| Revenue via distributor channel | $2k–$5k/mo | $10k–$25k/mo |
+
+### 8.3 Leading indicators (track weekly)
+
+- Number of new distributors added to list
+- Number of contact info fields enriched
+- Number of outreach attempts sent
+- Reply rate to outreach (target: >20% for warm, >10% for cold)
+- Meetings booked
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Distributors require slotting fees | Medium | High | Budget $500–$2k per distributor; start with distributors that don't charge |
+| MOQ too high for current production | Medium | Medium | Negotiate phased ramp; start with smaller regional distributors |
+| Distributor already carries competitor cacao | High | Low | Multiple-region cacao is a feature; frame as complementary, not competitive |
+| Distributor doesn't understand ceremonial cacao category | Medium | Medium | Educate with category data (8,100 monthly searches for "ceremonial cacao") |
+| Chocolate bar production limited | High | Medium | First run sold out; align distributor onboarding with next production batch |
+| Distributor requires exclusive territory | Low | High | Do not grant exclusivity; offer preferred pricing instead |
+| Cold outreach ignored (low reply rate) | Medium | Medium | Follow Lucas Rude's method: find the number and call after email |
+
+---
+
+## 10. Immediate Next Steps (Week 1)
+
+1. **Create the Distributor Master List sheet** — new tab in the Hit List spreadsheet or new CSV in `go_to_market/market_research/physical_stores/data/`
+2. **Run Track A research** — web search for natural foods distributors serving CA/OR/WA; populate initial 10–15 entries
+3. **Check Expo West contacts** — review who we met; flag any distributor conversations
+4. **Ask existing partners** — via Partner Check-in loop: "Who are your distributors?"
+5. **Prepare distributor one-pager** — different from retailer one-pager; focus on margins, velocity, category growth
+6. **Prepare chocolate bar sample kit** — coordinate with Kirsten on next production batch for samples
+
+---
+
+## 11. Appendix: Sample Outreach Email (Distributor Cold)
+
+```
+Subject: Ceremonial cacao + premium chocolate — Amazon rainforest provenance
+
+Hi [Buyer Name],
+
+I'm reaching out because Agroverse is looking for distribution partners on the West Coast for two product lines that are seeing strong retail traction:
+
+1. **Ceremonial cacao** (200g bag, $25 retail) — single-estate, vintage-dated, QR-traceable to the farm in Bahia, Brazil. Each bag plants a tree in the Amazon.
+2. **81% dark chocolate bar** (50g, $10 retail) — our first production run sold out. Single-estate, regenerative, same QR provenance story.
+
+We currently have 37+ retail partners (apothecaries, natural grocers, metaphysical shops) across CA, OR, and WA — mostly direct consignment. We're at the point where a distributor partner would let us scale shelf presence without scaling operator hours.
+
+Key numbers:
+- $25 ceremonial cacao retails at 64% margin ($17 cost)
+- $10 chocolate bar retails at 40% margin ($6 cost, mostly the $5 tree-planting set-aside)
+- 8,100 monthly US searches for "ceremonial cacao" (growing category)
+- QR traceability on every unit — customers scan and see their tree
+
+I'd love to send you samples and a wholesale deck. Are you the right person to talk to about new vendor intake, or can you point me to the right contact?
+
+Best,
+Gary Teh
+Agroverse / TrueSight DAO
+415-300-0019
+community@agroverse.shop
+```
+
+---
+
+## 12. Appendix: Distributor Call Script (Lucas Rude Method)
+
+Based on Lucas's approach: find the number, call. No email ping-pong.
+
+**Opening:**
+"Hi [Name], this is Gary from Agroverse. We're a cacao company sourcing from the Brazilian Amazon — ceremonial cacao and premium chocolate bars. I'm calling because I saw you distribute [natural foods / specialty chocolate / wellness products] on the West Coast, and I think our products would be a strong fit for your portfolio."
+
+**If they ask what makes you different:**
+"Every bag and bar has a QR code that traces back to the actual farm and shipment ledger it came from. Each sale plants a tree in the Amazon. It's verifiable provenance — not just a label claim."
+
+**If they ask about existing retail traction:**
+"We're in 37+ stores on the West Coast — apothecaries, natural grocers, metaphysical shops. Our first chocolate bar run sold out. We're looking for a distributor to take us from 37 stores to 100+."
+
+**If they ask about pricing:**
+"Ceremonial cacao: $17 cost, $25 retail. Chocolate bar: $6 cost, $10 retail. Standard distributor margins apply — happy to discuss terms."
+
+**Close:**
+"I'd like to send you samples and a wholesale deck. What's the best address? And would you have 15 minutes next week to discuss further?"
+
+---
+
+*End of proposal. This document is a plan, not an execution order. Review, adjust, and approve before starting Phase 1.*


### PR DESCRIPTION
## Summary

A detailed implementation plan for assembling a distributor list along the US West Coast for two Agroverse product lines:
1. **Ceremonial cacao** (200g bags, $25 retail)
2. **Premium chocolate bars** (50g, $10 retail — 81% dark, first run sold out)

Inspired by Lucas Rude's approach: find distributor info on the web, then call.

## What's in the proposal

- **Phase 1: Research & list assembly** — 4-track approach (natural foods distributors, specialty chocolate distributors, wellness/apothecary distributors, regional brokers)
- **Phase 2: Qualification & enrichment** — vetting criteria, contact enrichment, prioritization matrix
- **Phase 3: Outreach sequencing** — warm vs cold approach, cadence, pitch differentiation per product line
- **Phase 4: Integration into existing pipeline** — how this feeds the Hit List state machine, Email360 warm-up queue, and Partner Check-in loop
- **Tooling & automation recommendations** — scripts to build, data sources to use, existing infrastructure to leverage
- **Success metrics & milestones**

## Why now

- 37+ retail partners on the West Coast, mostly direct-to-store consignment
- The 81% chocolate bar sold out its first run — distributor demand signal exists
- Current model is operator-intensive (Gary driving, visiting, emailing one-by-one)
- A distributor layer would let us scale shelf presence without proportional operator hours