### PR TITLE
Hosts Circles fast lane + recurring reply-rate readout (PR3, stacked on #169)

### DIFF
--- a/.github/workflows/warmup_conversion_readout.yml
+++ b/.github/workflows/warmup_conversion_readout.yml
@@ -1,0 +1,80 @@
+# Monthly reply-rate readout for first-touch warm-up sends, split by segment
+# (Hosts Circles yes/no) and by channel (auto-sent vs human-sent).
+#
+# Why this exists: WARMUP_AUTOSEND_PLAN.md §6 promised a 30-day metrics
+# readout after the 2026-06-05 auto-send graduation. It was never run — a
+# 6-week reply-rate collapse (6% -> 0.3%) sat undetected until an on-demand
+# review caught it. This workflow makes the readout something that happens
+# on its own, not something that depends on a human remembering to run it.
+# See agentic_ai_context/plans/WARMUP_CONVERSION_IMPROVEMENT_PLAN.md PR3.
+#
+# Read-only against Hit List / Email Agent Drafts (Sheets API); only writes
+# the report file back into this repo.
+#
+# Required repository secret: GOOGLE_CREDENTIALS_JSON (same service account
+# as the other Hit List workflows — Sheets read only, no Gmail scope needed).
+
+name: Warm-up conversion readout
+
+on:
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'ISO date cutoff (default 2026-06-05, auto-send launch). Empty for all-time.'
+        required: false
+        default: ''
+  schedule:
+    # First of the month, 08:00 UTC.
+    - cron: "0 8 1 * *"
+
+concurrency:
+  group: warmup-conversion-readout
+  cancel-in-progress: false
+
+jobs:
+  readout:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Write service account JSON
+        env:
+          GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
+        run: printf '%s' "$GOOGLE_CREDENTIALS_JSON" > google_credentials.json
+
+      - name: Generate readout
+        env:
+          SINCE: ${{ github.event.inputs.since }}
+        run: |
+          if [ -n "${SINCE}" ]; then
+            python3 scripts/warmup_conversion_readout.py --since "${SINCE}" \
+              --output reports/warmup_conversion_readout_latest.md
+          else
+            python3 scripts/warmup_conversion_readout.py \
+              --output reports/warmup_conversion_readout_latest.md
+          fi
+
+      - name: Commit and push if changed
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add reports/warmup_conversion_readout_latest.md
+          if git diff --staged --quiet; then
+            echo "No changes to the readout; skipping commit."
+          else
+            git commit -m "chore: refresh warm-up conversion readout [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/reports/warmup_conversion_readout_latest.md
+++ b/reports/warmup_conversion_readout_latest.md
@@ -1,0 +1,29 @@
+# Warm-up conversion readout
+
+Generated 2026-07-20 07:15 UTC | cohort: sent `AI/Warm-up` first-touch, since `2026-06-05`
+
+**Overall:** 274 sent, 3 engaged (1.1%)
+
+## By segment
+
+| Segment | Sent | Engaged | Rate |
+|---|---|---|---|
+| ceremonial_spiritual | 173 | 3 | 1.7% |
+| circles_host | 56 | 0 | 0.0% |
+| retail_merch | 45 | 0 | 0.0% |
+
+## By channel
+
+| Channel | Sent | Engaged | Rate |
+|---|---|---|---|
+| auto | 274 | 3 | 1.1% |
+
+## By segment x channel
+
+| Segment | Channel | Sent | Engaged | Rate |
+|---|---|---|---|---|
+| ceremonial_spiritual | auto | 173 | 3 | 1.7% |
+| circles_host | auto | 56 | 0 | 0.0% |
+| retail_merch | auto | 45 | 0 | 0.0% |
+
+_"Engaged" = Hit List row currently in a reply-derived status (replied / partnered / manager follow-up / rejected / deferred / on-hold), excluding rows parked as confirmed auto-responder-only dead ends. Retroactive against current sheet state, not a point-in-time snapshot -- read directionally, not as an exact per-send outcome._

--- a/scripts/preview_warmup_drafts.py
+++ b/scripts/preview_warmup_drafts.py
@@ -350,6 +350,18 @@ def _render_html(rows: list[dict], generated_at: str) -> str:
     parts.append(f"<div><b style='color:#28a'>{n_aw}</b>Hosts Circles=Yes</div>")
     parts.append("</div>")
 
+    # Hosts Circles=Yes fast lane (WARMUP_CONVERSION_IMPROVEMENT_PLAN.md PR3) —
+    # that segment converts ~1.8x the rest of the list; call out backlog age
+    # explicitly so "same-day attention" is a checkable fact, not an assumption.
+    oldest_hc_days = _oldest_hosts_circles_age_days(rows)
+    if n_aw and oldest_hc_days is not None and oldest_hc_days > 1:
+        parts.append(
+            f"<div style='background:#fde; color:#a00; padding:8px 12px; "
+            f"border-radius:6px; margin-bottom:16px; font-size:13px;'>"
+            f"⚠️ {n_aw} Hosts Circles=Yes draft(s) pending — oldest is "
+            f"{oldest_hc_days:.1f} day(s) old (target: same-day review).</div>"
+        )
+
     if not rows:
         parts.append("<div class='empty'>No pending warm-up drafts.</div>")
         parts.append("</body></html>")
@@ -462,8 +474,40 @@ def main(argv=None) -> int:
     n_yel = sum(1 for r in rows if any(s == SEV_YELLOW for s, *_ in r["flags"]) and not any(s == SEV_RED for s, *_ in r["flags"]))
     n_clean = sum(1 for r in rows if not any(s in (SEV_RED, SEV_YELLOW) for s, *_ in r["flags"]))
     print(f"Flagged: red={n_red} yellow_only={n_yel} clean={n_clean}")
+    # Hosts Circles=Yes fast lane (WARMUP_CONVERSION_IMPROVEMENT_PLAN.md PR3): that
+    # segment converts ~1.8x the rest of the list, so surface its backlog age
+    # explicitly rather than relying on the operator to notice it in the sorted
+    # list — a count alone doesn't say whether same-day attention is being kept up.
+    oldest_hc_days = _oldest_hosts_circles_age_days(rows)
+    n_hc = sum(1 for r in rows if r.get("hosts_circles"))
+    if n_hc:
+        if oldest_hc_days is not None and oldest_hc_days > 1:
+            print(f"⚠️  Hosts Circles=Yes: {n_hc} pending, oldest is {oldest_hc_days:.1f}d old (target: same-day)")
+        else:
+            print(f"Hosts Circles=Yes: {n_hc} pending, oldest {oldest_hc_days:.1f}d old" if oldest_hc_days is not None else f"Hosts Circles=Yes: {n_hc} pending")
     print(f"Wrote {out_path}")
     return 0
+
+
+def _oldest_hosts_circles_age_days(rows: list[dict]) -> float | None:
+    ages = []
+    now = datetime.now(timezone.utc)
+    for r in rows:
+        if not r.get("hosts_circles"):
+            continue
+        dt = _parse_created_at(r.get("created_at", ""))
+        if dt:
+            ages.append((now - dt).total_seconds() / 86400)
+    return max(ages) if ages else None
+
+
+def _parse_created_at(ts: str) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _write_and_open(rows: list[dict], no_browser: bool) -> Path:

--- a/scripts/suggest_warmup_prospect_drafts.py
+++ b/scripts/suggest_warmup_prospect_drafts.py
@@ -81,6 +81,39 @@ DEFAULT_GROK_MODEL = smf.DEFAULT_GROK_MODEL
 DEFAULT_GMAIL_LABEL = "AI/Warm-up"
 PER_MESSAGE_BODY_CAP = smf.PER_MESSAGE_BODY_CAP
 
+# ── first-touch segmentation (WARMUP_CONVERSION_IMPROVEMENT_PLAN.md PR2) ────
+#
+# Before this, every warm-up email was the same boilerplate script (Amazon
+# restoration -> tree-per-bag -> QR code -> 30-sec reel) regardless of whether
+# the recipient was an astrology store, a yoga studio, or a wellness clinic —
+# despite `Shop Type` and `Hosts Circles` already sitting in the Hit List as
+# targetable signal. This selects one of three framings per recipient; every
+# variant still keeps the required mission line, attachments mention, and
+# flexible-consignment-or-bulk language, and still must clear the existing
+# 12-rule linter before it's eligible for auto-send.
+SEGMENT_CIRCLES_HOST = "circles_host"
+SEGMENT_CEREMONIAL_SPIRITUAL = "ceremonial_spiritual"
+SEGMENT_RETAIL_MERCH = "retail_merch"
+
+_CEREMONIAL_SHOP_TYPES = {
+    "metaphysical/spiritual", "spiritual/zen center", "yoga studio",
+}
+
+
+def classify_warmup_segment(shop_type: str, hosts_circles: str) -> str:
+    """Pick a template/framing segment from existing Hit List signal only —
+    no new scraping. `Hosts Circles` overrides Shop Type: a venue that hosts
+    sound baths / breathwork / moon circles converts ~1.8x the rest of the
+    list (11.8% vs 6.6% to Partnered/Manager Follow-up, per the 2026-07-18
+    stats review) and gets its own framing regardless of its retail category.
+    """
+    if (hosts_circles or "").strip().lower().startswith("yes"):
+        return SEGMENT_CIRCLES_HOST
+    st = (shop_type or "").strip().lower()
+    if st in _CEREMONIAL_SHOP_TYPES:
+        return SEGMENT_CEREMONIAL_SPIRITUAL
+    return SEGMENT_RETAIL_MERCH
+
 
 def load_warmup_targets(ws: gspread.Worksheet) -> list[dict]:
     values = ws.get_all_values()
@@ -94,6 +127,8 @@ def load_warmup_targets(ws: gspread.Worksheet) -> list[dict]:
     notes_i = hdr.get("Notes")
     city_i = hdr.get("City")
     state_i = hdr.get("State")
+    shop_type_i = hdr.get("Shop Type")
+    hosts_circles_i = hdr.get("Hosts Circles")
     if status_i is None or email_i is None:
         raise SystemExit("Hit List row 1 must include 'Status' and 'Email'.")
 
@@ -115,9 +150,23 @@ def load_warmup_targets(ws: gspread.Worksheet) -> list[dict]:
                 "to_email": em,
                 "notes": smf.cell(row, notes_i) if notes_i is not None else "",
                 "city_state": locale,
+                "shop_type": smf.cell(row, shop_type_i) if shop_type_i is not None else "",
+                "hosts_circles": smf.cell(row, hosts_circles_i) if hosts_circles_i is not None else "",
             }
         )
     return out
+
+
+def pick_warmup_segment_fields(targets: list[dict], partner_email: str) -> tuple[str, str]:
+    """(shop_type, hosts_circles) for the same primary-store row `smf.pick_primary_store`
+    would pick (lowest hit_list_row) — kept separate since the shared `pick_primary_store`
+    return arity is used by suggest_manager_followup_drafts.py too and doesn't carry these
+    two fields."""
+    matches = [t for t in targets if t["to_email"] == partner_email]
+    if not matches:
+        return "", ""
+    first = min(matches, key=lambda x: x["hit_list_row"])
+    return (first.get("shop_type") or "").strip(), (first.get("hosts_circles") or "").strip()
 
 
 def _email_from_from_header(from_hdr: str) -> str:
@@ -1013,6 +1062,28 @@ def grok_warmup_system_prompt() -> str:
     )
 
 
+_SEGMENT_GROK_FRAMING = {
+    SEGMENT_CIRCLES_HOST: (
+        "segment: circles_host — this venue hosts community circles (sound healing, breathwork, moon "
+        "circles, ecstatic dance, etc. — see hosts_circles_activities below). Lead with cacao as a "
+        "natural fit for the circles they already host, not a generic retail pitch. It's fine to "
+        "mention it could work as part of the ceremony itself (session-sized quantity), alongside the "
+        "standard retail/wholesale option — offer both, don't force a choice."
+    ),
+    SEGMENT_CEREMONIAL_SPIRITUAL: (
+        "segment: ceremonial_spiritual — a metaphysical/spiritual retail storefront (not necessarily "
+        "hosting circles itself). Lead with ceremonial cacao as a natural complement to what they "
+        "already sell to an intentional, ritual-minded customer base — not a generic 'stock this "
+        "snack' pitch."
+    ),
+    SEGMENT_RETAIL_MERCH: (
+        "segment: retail_merch — a general wellness/specialty retail shop. Lead with the "
+        "retail-merchandising angle: shelf variety, margin-friendly consignment or wholesale, "
+        "tree-traceability as a customer-facing story their shop can tell."
+    ),
+}
+
+
 def grok_generate_warmup(
     *,
     api_key: str,
@@ -1025,6 +1096,8 @@ def grok_generate_warmup(
     hit_list_notes: str,
     dapp_remarks_log: str,
     conversation_history: str,
+    segment: str = SEGMENT_RETAIL_MERCH,
+    hosts_circles_activities: str = "",
 ) -> tuple[str, str]:
     crm_notes = (hit_list_notes or "").strip()
     locality = (city_state or "").strip()
@@ -1037,7 +1110,10 @@ def grok_generate_warmup(
         f"- hit_list_row(s): {hit_list_row}\n"
         f"- recipient_email: {to_email}\n"
         f"- hit_list_status: {HIT_STATUS_WARMUP} (first-touch intro; PDF wholesale list + two packaging photos will be attached)\n"
+        f"- {_SEGMENT_GROK_FRAMING.get(segment, _SEGMENT_GROK_FRAMING[SEGMENT_RETAIL_MERCH])}\n"
     )
+    if segment == SEGMENT_CIRCLES_HOST and (hosts_circles_activities or "").strip():
+        user += f"- hosts_circles_activities: {hosts_circles_activities.strip()}\n"
     if crm_notes:
         user += (
             "- internal_hit_list_notes (use for specificity; do not quote as if the merchant wrote this): "
@@ -1131,13 +1207,69 @@ def build_message_raw_with_attachments(
     return {"raw": raw}
 
 
-def warmup_subject_template(shop_name: str) -> str:
+def warmup_subject_template(shop_name: str, segment: str = SEGMENT_RETAIL_MERCH) -> str:
     s = (shop_name or "Intro").strip()
+    if segment == SEGMENT_CIRCLES_HOST:
+        return f"Ceremonial cacao for the circles you host at {s}"
+    if segment == SEGMENT_CEREMONIAL_SPIRITUAL:
+        return f"Ceremonial cacao for {s} — sourced with intention (PDF attached)"
     return f"Ceremonial cacao for {s} — each bag plants a tree (PDF attached)"
 
 
-def warmup_body_template(shop_name: str) -> str:
-    shop = shop_name or "your shop"
+_WARMUP_SHARED_CLOSE = (
+    "We're **flexible on structure** — **either** **consignment-friendly** retail **or** "
+    "**wholesale / bulk** works on our side; I've attached our **wholesale price list PDF** so you "
+    "can skim SKUs and tiers, plus **two photos of the packaging** (front and back) so you can "
+    "picture how it sits on shelf.\n\n"
+    "For partner-shop shelf photos and the current U.S. stockist list, see "
+    "https://agroverse.shop/wholesale — that's the visual companion to the PDF.\n\n"
+    "No need to meet in person on my side; happy to answer by email or on a quick call if that's "
+    "easier. If you tell me which path you'd rather explore first (consignment vs bulk), I can "
+    "point you to the lightest next step.\n\n"
+    "Thanks,\n"
+    "Gary\n"
+    "Agroverse | ceremonial cacao for retail\n"
+    "garyjob@agroverse.shop\n"
+)
+
+
+def _warmup_body_circles_host(shop: str) -> str:
+    return (
+        f"Hi —\n\n"
+        f"I'm Gary with Agroverse. I came across {shop} and the circles you host — the kind of space "
+        f"where ceremonial cacao usually already belongs. We work with regenerative farms across the "
+        f"Brazilian Amazon — Oscar's Farm in Bahia (deep European-chocolate profile, buttery and smooth) "
+        f"and Paulo's Farm in the Pará Amazon (smoky, earthy, unfolding into delicate floral notes) — and "
+        f"every bag sold plants a new tree, directly traceable via the unique QR code on that bag.\n\n"
+        f"30-second proof of the restoration in motion: https://www.instagram.com/p/DJqW8TRtJK3/ — watch "
+        f"on your phone, see the actual tree planting and the satellite imagery the QR code unlocks.\n\n"
+        f"A few hosts have started offering it as part of their circle itself, not just on a shelf — "
+        f"sound healing, breathwork, moon circles, ecstatic dance — cacao as part of setting the "
+        f"container before people arrive. Happy to send samples sized for that if it's useful, alongside "
+        f"the retail option below.\n\n"
+        f"{_WARMUP_SHARED_CLOSE}"
+    )
+
+
+def _warmup_body_ceremonial_spiritual(shop: str) -> str:
+    return (
+        f"Hi —\n\n"
+        f"I'm Gary with Agroverse. I'm reaching out to {shop} because ceremonial cacao — sourced with "
+        f"the same intention your customers already bring to their practice — feels like a natural fit "
+        f"for what you carry. We work with regenerative farms across the Brazilian Amazon — Oscar's Farm "
+        f"in Bahia (deep European-chocolate profile, buttery and smooth) and Paulo's Farm in the Pará "
+        f"Amazon (smoky, earthy, unfolding into delicate floral notes) — and every bag sold plants a new "
+        f"tree, directly traceable via the unique QR code on that bag.\n\n"
+        f"30-second proof of the restoration in motion: https://www.instagram.com/p/DJqW8TRtJK3/ — watch "
+        f"on your phone, see the actual tree planting and the satellite imagery the QR code unlocks for "
+        f"anyone curious about where their cacao comes from.\n\n"
+        f"I think it's a natural complement to what you already offer — not a generic add-on, but "
+        f"something your customers who already value intentional, traceable sourcing would recognize.\n\n"
+        f"{_WARMUP_SHARED_CLOSE}"
+    )
+
+
+def _warmup_body_retail_merch(shop: str) -> str:
     return (
         f"Hi —\n\n"
         f"I'm Gary with Agroverse. We work with regenerative cacao farms across the Brazilian Amazon — "
@@ -1146,22 +1278,24 @@ def warmup_body_template(shop_name: str) -> str:
         f"bag sold plants a new tree, directly traceable via the unique QR code on each bag.\n\n"
         f"30-second proof of the restoration in motion: https://www.instagram.com/p/DJqW8TRtJK3/ — watch on "
         f"your phone, see the actual tree planting and the satellite imagery the QR code unlocks for customers.\n\n"
-        f"We're **flexible on structure** — **either** **consignment-friendly** retail **or** **wholesale / bulk** "
-        f"works on our side; I've attached our **wholesale price list PDF** so you can skim SKUs and tiers, "
-        f"plus **two photos of the packaging** (front and back) so you can picture how it sits on shelf.\n\n"
         f"I'm reaching out to {shop} because we believe offering different taste profiles "
         f"creates a richer experience for your customers — each farm's cacao is distinct, and variety "
         f"is what keeps a shelf interesting.\n\n"
-        f"For partner-shop shelf photos and the current U.S. stockist list, see "
-        f"https://agroverse.shop/wholesale — that's the visual companion to the PDF.\n\n"
-        f"No need to meet in person on my side; happy to answer by email or on a quick call if that's easier. "
-        f"If you tell me which path you'd rather explore first (consignment vs bulk), I can point you to the "
-        f"lightest next step.\n\n"
-        f"Thanks,\n"
-        f"Gary\n"
-        f"Agroverse | ceremonial cacao for retail\n"
-        f"garyjob@agroverse.shop\n"
+        f"{_WARMUP_SHARED_CLOSE}"
     )
+
+
+_WARMUP_BODY_BY_SEGMENT = {
+    SEGMENT_CIRCLES_HOST: _warmup_body_circles_host,
+    SEGMENT_CEREMONIAL_SPIRITUAL: _warmup_body_ceremonial_spiritual,
+    SEGMENT_RETAIL_MERCH: _warmup_body_retail_merch,
+}
+
+
+def warmup_body_template(shop_name: str, segment: str = SEGMENT_RETAIL_MERCH) -> str:
+    shop = shop_name or "your shop"
+    fn = _WARMUP_BODY_BY_SEGMENT.get(segment, _warmup_body_retail_merch)
+    return fn(shop)
 
 
 def main() -> None:
@@ -1389,6 +1523,8 @@ def main() -> None:
         if args.max_drafts > 0 and n_made >= args.max_drafts:
             break
         sk, shop, rows_str, hit_notes, city_st = smf.pick_primary_store(targets, to_addr)
+        shop_type, hosts_circles = pick_warmup_segment_fields(targets, to_addr)
+        segment = classify_warmup_segment(shop_type, hosts_circles)
         if remarks_ws is not None:
             dapp_ctx = smf.format_dapp_remarks_for_grok(remarks_ws, shop, sk)
         else:
@@ -1430,16 +1566,18 @@ def main() -> None:
                     hit_list_notes=hit_notes,
                     dapp_remarks_log=dapp_ctx,
                     conversation_history=hist,
+                    segment=segment,
+                    hosts_circles_activities=hosts_circles,
                 )
                 source = "grok"
             except Exception as e:
                 sys.stderr.write(f"Grok failed for {to_addr}: {e}\n")
-                subj = warmup_subject_template(shop)
-                body = warmup_body_template(shop)
+                subj = warmup_subject_template(shop, segment)
+                body = warmup_body_template(shop, segment)
                 source = "template_fallback"
         else:
-            subj = warmup_subject_template(shop)
-            body = warmup_body_template(shop)
+            subj = warmup_subject_template(shop, segment)
+            body = warmup_body_template(shop, segment)
 
         sug_id = str(uuid.uuid4())
         tracking_base = (os.environ.get("EMAIL_AGENT_TRACKING_BASE_URL") or "https://edgar.truesight.me").strip()
@@ -1473,7 +1611,7 @@ def main() -> None:
             sys.exit(1)
 
         if args.dry_run:
-            print(f"\n--- dry-run draft → {to_addr} ({shop}) ---")
+            print(f"\n--- dry-run draft → {to_addr} ({shop}) [segment={segment}] ---")
             if args.use_grok:
                 print("(Note: --dry-run skips Grok; preview is template.)")
             print(f"Subject: {subj}")
@@ -1503,7 +1641,7 @@ def main() -> None:
             [args.pdf_path.name] + [p.name for p in image_paths]
         )
         notes = (
-            f"kind=warmup_intro; attachments={attachment_names}; source={source}; "
+            f"kind=warmup_intro; attachments={attachment_names}; source={source}; segment={segment}; "
             f"cadence min_days={args.min_days_since_sent}; last_logged_send={prev_s}; "
             f"grok_model={args.grok_model if args.use_grok else 'n/a'}. Edit before Send."
         )

--- a/scripts/warmup_conversion_readout.py
+++ b/scripts/warmup_conversion_readout.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Reply-rate readout for first-touch warm-up sends, split by **segment**
+(`Hosts Circles` yes/no — the 2026-07-18 stats review found this predicts
+conversion ~1.8x, see `agentic_ai_context/plans/WARMUP_CONVERSION_IMPROVEMENT_PLAN.md`)
+and by **channel** (auto-sent via `send_clean_warmup_drafts.py` vs. human-sent
+directly in Gmail).
+
+Why this exists: `WARMUP_AUTOSEND_PLAN.md` §6 promised a 30-day metrics
+readout after the auto-send graduation shipped 2026-06-05. It was never run —
+a 6-week-old reply-rate collapse (6% -> 0.3%) sat undetected until an
+on-demand stats review caught it. This script is the readout, made runnable
+on demand and (via the paired GitHub Actions workflow) on a schedule that
+can't be silently skipped again.
+
+Read-only: only reads `Hit List` and `Email Agent Drafts` (Sheets API,
+service account). No Gmail calls, no writes.
+
+**Engaged** (a warm-up cohort member counts as having produced signal) means
+the Hit List row's *current* Status is one of `AI: Prospect replied`,
+`Partnered`, `Manager Follow-up`, `Rejected`, `Deferred / Revisit later`, `On
+Hold` -- **except** rows parked by the auto-reply-only logic in
+`suggest_warmup_prospect_drafts.py` (Notes contains "parked: auto-responder
+only"), which are confirmed dead mailboxes, not engagement. This is a
+retroactive, best-effort classification against *current* sheet state, not a
+point-in-time snapshot -- a row's status can have moved for reasons unrelated
+to this specific send (e.g. re-enriched after a bounce). Treat the read as
+directional, not exact.
+
+Usage:
+  cd market_research
+  python3 scripts/warmup_conversion_readout.py
+  python3 scripts/warmup_conversion_readout.py --since 2026-06-05
+  python3 scripts/warmup_conversion_readout.py --output reports/warmup_conversion_readout_latest.md
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import suggest_manager_followup_drafts as smf  # noqa: E402
+from suggest_warmup_prospect_drafts import classify_warmup_segment  # noqa: E402
+
+WARMUP_LABEL = "AI/Warm-up"
+SENT_STATUS = "sent"
+AUTOSEND_MARKER = "auto-sent by send_clean_warmup_drafts"
+AUTO_PARK_MARKER = "parked: auto-responder only"
+
+# Auto-send launch date (WARMUP_AUTOSEND_PLAN.md) -- default cutoff so the
+# pre-automation, hand-curated era doesn't dilute the read on the automated
+# channel's own performance. Override with --since for an all-time view.
+DEFAULT_SINCE = "2026-06-05"
+
+ENGAGED_STATUSES = {
+    "AI: Prospect replied",
+    "Partnered",
+    "Manager Follow-up",
+    "Rejected",
+    "Deferred / Revisit later",
+    "On Hold",
+}
+
+
+def _parse_dt(ts: str) -> datetime | None:
+    if not ts:
+        return None
+    ts = ts.strip()
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(ts, fmt)
+            return dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _load_hit_list_by_row(ws) -> dict[int, dict]:
+    values = ws.get_all_values()
+    if not values:
+        return {}
+    hdr = smf.header_map(values[0])
+    status_i = hdr.get("Status")
+    shop_type_i = hdr.get("Shop Type")
+    hosts_circles_i = hdr.get("Hosts Circles")
+    notes_i = hdr.get("Notes")
+    out: dict[int, dict] = {}
+    for r, row in enumerate(values[1:], start=2):
+        out[r] = {
+            "status": smf.cell(row, status_i) if status_i is not None else "",
+            "shop_type": smf.cell(row, shop_type_i) if shop_type_i is not None else "",
+            "hosts_circles": smf.cell(row, hosts_circles_i) if hosts_circles_i is not None else "",
+            "notes": smf.cell(row, notes_i) if notes_i is not None else "",
+        }
+    return out
+
+
+def _load_sent_warmup_drafts(ws) -> list[dict]:
+    values = ws.get_all_values()
+    if not values:
+        return []
+    hdr = smf.header_map(values[0])
+    need = ["status", "gmail_label", "created_at_utc", "notes", "hit_list_row", "shop_name"]
+    for k in need:
+        if k not in hdr:
+            sys.stderr.write(f"Email Agent Drafts missing column: {k}\n")
+            sys.exit(1)
+    out: list[dict] = []
+    for row in values[1:]:
+        if smf.cell(row, hdr["status"]) != SENT_STATUS:
+            continue
+        if smf.cell(row, hdr["gmail_label"]) != WARMUP_LABEL:
+            continue
+        hit_row_raw = smf.cell(row, hdr["hit_list_row"])
+        first_row = hit_row_raw.split(",")[0].strip() if hit_row_raw else ""
+        out.append({
+            "created_at_utc": smf.cell(row, hdr["created_at_utc"]),
+            "notes": smf.cell(row, hdr["notes"]),
+            "hit_list_row": int(first_row) if first_row.isdigit() else None,
+            "shop_name": smf.cell(row, hdr["shop_name"]),
+        })
+    return out
+
+
+def _is_engaged(hit: dict | None) -> bool:
+    if hit is None:
+        return False
+    status = hit.get("status", "")
+    if status not in ENGAGED_STATUSES:
+        return False
+    if AUTO_PARK_MARKER in (hit.get("notes") or ""):
+        return False
+    return True
+
+
+def _channel(notes: str) -> str:
+    return "auto" if AUTOSEND_MARKER in (notes or "") else "human"
+
+
+def build_readout(since: str) -> tuple[str, dict]:
+    sa = smf.get_sheets_client()
+    sh = sa.open_by_key(smf.SPREADSHEET_ID)
+    hit_ws = sh.worksheet("Hit List")
+    drafts_ws = sh.worksheet("Email Agent Drafts")
+
+    hit_by_row = _load_hit_list_by_row(hit_ws)
+    sent = _load_sent_warmup_drafts(drafts_ws)
+
+    since_dt = _parse_dt(since) if since else None
+    rows = []
+    for d in sent:
+        dt = _parse_dt(d["created_at_utc"])
+        if since_dt and dt and dt < since_dt:
+            continue
+        hit = hit_by_row.get(d["hit_list_row"]) if d["hit_list_row"] else None
+        segment = classify_warmup_segment(
+            (hit or {}).get("shop_type", ""), (hit or {}).get("hosts_circles", "")
+        )
+        rows.append({
+            "shop_name": d["shop_name"],
+            "segment": segment,
+            "channel": _channel(d["notes"]),
+            "engaged": _is_engaged(hit),
+        })
+
+    def _rate_block(subset: list[dict]) -> dict:
+        n = len(subset)
+        engaged = sum(1 for r in subset if r["engaged"])
+        return {"n": n, "engaged": engaged, "rate": (engaged / n * 100) if n else 0.0}
+
+    by_segment = {
+        seg: _rate_block([r for r in rows if r["segment"] == seg])
+        for seg in sorted({r["segment"] for r in rows})
+    }
+    by_channel = {
+        ch: _rate_block([r for r in rows if r["channel"] == ch])
+        for ch in sorted({r["channel"] for r in rows})
+    }
+    by_segment_channel = {
+        (seg, ch): _rate_block([r for r in rows if r["segment"] == seg and r["channel"] == ch])
+        for seg in sorted({r["segment"] for r in rows})
+        for ch in sorted({r["channel"] for r in rows})
+    }
+    overall = _rate_block(rows)
+
+    lines = []
+    lines.append("# Warm-up conversion readout")
+    lines.append("")
+    lines.append(
+        f"Generated {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} | "
+        f"cohort: sent `AI/Warm-up` first-touch, since `{since or 'all-time'}`"
+    )
+    lines.append("")
+    lines.append(
+        f"**Overall:** {overall['n']} sent, {overall['engaged']} engaged "
+        f"({overall['rate']:.1f}%)"
+    )
+    lines.append("")
+    lines.append("## By segment")
+    lines.append("")
+    lines.append("| Segment | Sent | Engaged | Rate |")
+    lines.append("|---|---|---|---|")
+    for seg, b in sorted(by_segment.items(), key=lambda kv: -kv[1]["rate"]):
+        lines.append(f"| {seg} | {b['n']} | {b['engaged']} | {b['rate']:.1f}% |")
+    lines.append("")
+    lines.append("## By channel")
+    lines.append("")
+    lines.append("| Channel | Sent | Engaged | Rate |")
+    lines.append("|---|---|---|---|")
+    for ch, b in sorted(by_channel.items(), key=lambda kv: -kv[1]["rate"]):
+        lines.append(f"| {ch} | {b['n']} | {b['engaged']} | {b['rate']:.1f}% |")
+    lines.append("")
+    lines.append("## By segment x channel")
+    lines.append("")
+    lines.append("| Segment | Channel | Sent | Engaged | Rate |")
+    lines.append("|---|---|---|---|---|")
+    for (seg, ch), b in sorted(by_segment_channel.items(), key=lambda kv: -kv[1]["rate"]):
+        if b["n"] == 0:
+            continue
+        lines.append(f"| {seg} | {ch} | {b['n']} | {b['engaged']} | {b['rate']:.1f}% |")
+    lines.append("")
+    lines.append(
+        "_\"Engaged\" = Hit List row currently in a reply-derived status "
+        "(replied / partnered / manager follow-up / rejected / deferred / on-hold), "
+        "excluding rows parked as confirmed auto-responder-only dead ends. "
+        "Retroactive against current sheet state, not a point-in-time snapshot -- "
+        "read directionally, not as an exact per-send outcome._"
+    )
+
+    return "\n".join(lines), {
+        "overall": overall, "by_segment": by_segment, "by_channel": by_channel,
+        "by_segment_channel": by_segment_channel,
+    }
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--since", default=DEFAULT_SINCE, help=f"ISO date cutoff (default {DEFAULT_SINCE}, auto-send launch). Empty string for all-time.")
+    p.add_argument("--output", type=Path, default=None, help="Also write the markdown report to this path.")
+    args = p.parse_args(argv)
+
+    report, _stats = build_readout(args.since)
+    print(report)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(report + "\n", encoding="utf-8")
+        print(f"\nWrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Stacked on #169 (PR2) -- this PR's diff will include PR2's changes until #169 merges; review the incremental diff (3 new/changed files: `warmup_conversion_readout.py`, `warmup_conversion_readout.yml`, `preview_warmup_drafts.py` fast-lane banner, plus the seed report).

`WARMUP_AUTOSEND_PLAN.md` §6 promised a 30-day metrics readout after the 2026-06-05 auto-send graduation. It was never run -- a 6-week reply-rate collapse (6% -> 0.3%) sat undetected until an on-demand stats review + full-333-thread Gmail audit caught it (see `agentic_ai_context/plans/WARMUP_CONVERSION_IMPROVEMENT_PLAN.md`). This PR closes that gap two ways:

1. **`scripts/warmup_conversion_readout.py`** -- reply-rate readout split by segment (`Hosts Circles` yes/no, via PR2's `classify_warmup_segment`) and by channel (auto-sent vs human-sent, using the `send_clean_warmup_drafts.py` note marker that already existed). Read-only against Sheets, no Gmail calls, no writes to the ledger. Live run against real data (seeded at `reports/warmup_conversion_readout_latest.md`):
   - 274 warm-ups sent since launch, **all 274 auto-sent, 0 human-sent** in that window
   - **1.1% overall engaged** (3/274) -- confirms the collapse found manually
   - By segment: ceremonial_spiritual 1.7%, circles_host 0.0%, retail_merch 0.0%
2. **`.github/workflows/warmup_conversion_readout.yml`** -- monthly cron (1st, 08:00 UTC) + `workflow_dispatch`, commits the refreshed report back to the repo automatically. This is the actual fix for "the readout was promised but never run" -- it no longer depends on anyone remembering.
3. **`preview_warmup_drafts.py` Hosts Circles fast lane** -- that segment converts ~1.8x the rest of the list but the existing tooling only surfaced it via sort order (already decent). Added an explicit backlog-age callout (CLI line + HTML banner) so "same-day review" is a checkable fact. Live run: 8 pending, oldest already 2.7 days -- immediately surfaces a real miss against the target.

## Test plan
- [x] `python3 -m py_compile scripts/warmup_conversion_readout.py scripts/preview_warmup_drafts.py`
- [x] `python3 scripts/warmup_conversion_readout.py` run live against production Sheets (read-only) -- output above, seeded to `reports/`
- [x] `python3 scripts/preview_warmup_drafts.py --no-browser --no-fetch` run live -- correctly flags an 8-draft / 2.7-day-old Hosts Circles backlog
- [ ] First scheduled workflow run reviewed for a clean commit

Generated with Claude Code